### PR TITLE
Move import statement to top of bitcoin.py

### DIFF
--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -3,6 +3,7 @@ Craft, sign and broadcast Bitcoin transactions.
 Interface with Bitcoind.
 """
 
+import os
 import sys
 import binascii
 import json
@@ -219,7 +220,6 @@ def get_inputs (source, total_btc_out, test=False):
     if not test:
         listunspent = rpc('listunspent', [])
     else:
-        import os
         CURR_DIR = os.path.dirname(os.path.realpath(os.path.join(os.getcwd(), os.path.expanduser(__file__))))
         with open(CURR_DIR + '/../test/listunspent.test.json', 'r') as listunspent_test_file:   # HACK
             listunspent = json.load(listunspent_test_file)


### PR DESCRIPTION
The os module is a default in cpython, so it can be safely moved to the top with the other imports. I don't know what to do about the pycoin imports yet; since pycoin is a dependency, it should probably be imported before it has the chance to explode for not existing on the system.
