### PR TITLE
Make CLI issuance work

### DIFF
--- a/counterpartyd.py
+++ b/counterpartyd.py
@@ -474,10 +474,10 @@ if __name__ == '__main__':
         else:
             call_date, call_price = 0, 0
 
-        cli('create_issuance', [args.source, args.transfer_destination,
-                               args.asset, quantity, args.divisible,
+        cli('create_issuance', [args.source,
+                               args.asset, quantity, args.divisible, args.description,
                                args.callable_, call_date,
-                               call_price, args.description],
+                               call_price, args.transfer_destination],
            args.unsigned)
 
     elif args.action == 'broadcast':


### PR DESCRIPTION
Reorder the parameters for CLI issuance to match the order of the
parameters for the create_issuance API endpoint.
