### PR TITLE
fix decode vin script by bitcoind decoderawtransaction

### DIFF
--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -206,7 +206,7 @@ def serialise (inputs, destination_output=None, data_output=None, change_output=
         s += binascii.unhexlify(bytes(txin['txid'], 'utf-8'))[::-1]         # TxOutHash
         s += txin['vout'].to_bytes(4, byteorder='little')   # TxOutIndex
 
-        script = str.encode(txin['scriptPubKey'])
+        script = binascii.unhexlify(txin['scriptPubKey'])
         s += var_int(int(len(script)))                      # Script length
         s += script                                         # Script
         s += b'\xff' * 4                                    # Sequence


### PR DESCRIPTION
bitcoind (and also pycoin) fails to parse transaction input script generated by countrepartyd. So we can not extract pubkey without workaround.
