### PR TITLE
fix "AttributeError: 'NoneType' object has no attribute 'json'"

### DIFF
--- a/lib/api.py
+++ b/lib/api.py
@@ -456,7 +456,7 @@ class APIServer(threading.Thread):
             @cherrypy.expose
             def index(self):
                 try:
-                    data = cherrypy.request.body.read().decode('utf-8')
+                    data = json.loads(cherrypy.request.body.read().decode('utf-8'))
                 except ValueError:
                     raise cherrypy.HTTPError(400, 'Invalid JSON document')
 


### PR DESCRIPTION
Hi, XCP team,

Currently I'm working on the integration of XCP on my exchange, but get a 500 on any API call:

```
  File "/home/coinbaz/counterpartyd_build/env/lib/python3.4/site-packages/cherrypy/_cprequest.py", line 656, in respond
    response.body = self.handler()
  File "/home/coinbaz/counterpartyd_build/env/lib/python3.4/site-packages/cherrypy/lib/encoding.py", line 188, in __call__
    self.body = self.oldhandler(*args, **kwargs)
  File "/home/coinbaz/counterpartyd_build/env/lib/python3.4/site-packages/cherrypy/_cpdispatch.py", line 34, in __call__
    return self.callable(*self.args, **self.kwargs)
  File "/home/coinbaz/counterpartyd_build/dist/counterpartyd/lib/api.py", line 489, in index
    return response.json.encode()
AttributeError: 'NoneType' object has no attribute 'json'
```

after investigation, I noticed that the `data` parameter in L485 `response = jsonrpc.JSONRPCResponseManager.handle(data, dispatcher)` is a string, as a result of L459: `data = cherrypy.request.body.read().decode('utf-8')`.

I'm not familiar with cherrypy, can it decode the `application/json` request to json by default? However, after adding a `json.loads()`, the `500 Internal Error` disappeared for me.

Regards.
