### PR TITLE
fix btcpay validation

### DIFF
--- a/lib/btcpay.py
+++ b/lib/btcpay.py
@@ -39,14 +39,14 @@ def validate (db, source, order_match_id):
     # Figure out to which address the BTC are being paid.
     # Check that source address is correct.
     if order_match['backward_asset'] == config.BTC:
-        if source != order_match['tx1_address'] and not (block_index >= 313900 or config.testnet):  # Protocol change.
+        if source != order_match['tx1_address'] and not (order_match['block_index'] >= 313900 or config.TESTNET):  # Protocol change.
             problems.append('incorrect source address')
         destination = order_match['tx0_address']
         btc_quantity = order_match['backward_quantity']
         escrowed_asset  = order_match['forward_asset']
         escrowed_quantity = order_match['forward_quantity']
     elif order_match['forward_asset'] == config.BTC:
-        if source != order_match['tx0_address'] and not (block_index >= 313900 or config.testnet):  # Protocol change.
+        if source != order_match['tx0_address'] and not (order_match['block_index'] >= 313900 or config.TESTNET):  # Protocol change.
             problems.append('incorrect source address')
         destination = order_match['tx1_address']
         btc_quantity = order_match['forward_quantity']


### PR DESCRIPTION
order_match['block_index'] instead util.last_block(db)['block_index'] to avoid valid composition and invalid parsing ?
