### PR TITLE
counterpartyd api cannot create transaction

### DIFF
--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -386,7 +386,7 @@ def sort_unspent_txouts(unspent, allow_unconfirmed_inputs):
 def private_key_to_public_key (private_key_wif):
     # allowable_wif_prefixes = [
     try:
-        secret_exponent, compressed = wif_to_tuple_of_secret_exponent_compressed(private_key_wif, is_test=config.TESTNET)
+        secret_exponent, compressed = wif_to_tuple_of_secret_exponent_compressed(private_key_wif)
     except EncodingError:
         raise exceptions.AltcoinSupportError('pycoin: unsupported WIF prefix')
     public_pair = public_pair_for_secret_exponent(generator_secp256k1, secret_exponent)


### PR DESCRIPTION
wif_to_tuple_of_secret_exponent_compressed doesn't have is_test keyword argument, so sending assets with counterpartyd fails.

This fixes it
