### PR TITLE
new scriptpubkey_to_address()

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -17,6 +17,7 @@ import hashlib
 import sha3
 from functools import lru_cache
 import getpass
+import bitcoin as bitcoinlib
 
 from . import (config, exceptions)
 
@@ -1082,8 +1083,10 @@ def asset_names_v2_enabled(block_index):
 FIRST_MULTISIG_BLOCK_TESTNET = 303000
 def multisig_enabled(block_index):
     return protocol_change(block_index, 333000, FIRST_MULTISIG_BLOCK_TESTNET)
+
 ### Unconfirmed Transactions ###
 
+# TODO: use scriptpubkey_to_address()
 @lru_cache(maxsize=4096)
 def extract_addresses(tx):
     tx = json.loads(tx) # for lru_cache
@@ -1103,12 +1106,68 @@ def extract_addresses(tx):
 
 def unconfirmed_transactions(address):
     transactions = []
-
     for tx_hash in MEMPOOL:
         tx = get_cached_raw_transaction(tx_hash)
         if address in extract_addresses(json.dumps(tx)):
             transactions.append(tx)
-
     return transactions
+
+
+### Script ####
+
+def hash160(x):
+    x = hashlib.sha256(x).digest()
+    m = hashlib.new('ripemd160')
+    m.update(x)
+    return m.digest()
+
+def pubkey_to_pubkeyhash(pubkey):
+    pubkeyhash = hash160(pubkey)
+    pubkey = base58_check_encode(binascii.hexlify(pubkeyhash).decode('utf-8'), config.ADDRESSVERSION)
+    return pubkey
+
+def get_asm(scriptpubkey):
+    try:
+        asm = []
+        for op in scriptpubkey:
+            if type(op) == bitcoinlib.core.script.CScriptOp:
+                asm.append(str(op))
+            else:
+                asm.append(op)
+    except bitcoinlib.core.script.CScriptTruncatedPushDataError:
+        raise exceptions.DecodeError('invalid pushdata due to truncation')
+    if not asm:
+        raise exceptions.DecodeError('empty output')
+    return asm
+
+def get_checksig(asm):
+    if len(asm) == 5 and asm[0] == 'OP_DUP' and asm[1] == 'OP_HASH160' and asm[3] == 'OP_EQUALVERIFY' and asm[4] == 'OP_CHECKSIG':
+        pubkeyhash = asm[2]
+        if type(pubkeyhash) == bytes:
+            return pubkeyhash
+    raise exceptions.DecodeError('invalid OP_CHECKSIG')
+
+def get_checkmultisig(asm):
+    # N‐of‐2
+    if len(asm) == 5 and asm[3] == 2 and asm[4] == 'OP_CHECKMULTISIG':
+        pubkeys, signatures_required = asm[1:3], asm[0]
+        if all([type(pubkey) == bytes for pubkey in pubkeys]):
+            return pubkeys, signatures_required
+    # N‐of‐3
+    if len(asm) == 6 and asm[4] == 3 and asm[5] == 'OP_CHECKMULTISIG':
+        pubkeys, signatures_required = asm[1:4], asm[0]
+        if all([type(pubkey) == bytes for pubkey in pubkeys]):
+            return pubkeys, signatures_required
+    raise exceptions.DecodeError('invalid OP_CHECKMULTISIG')
+
+def scriptpubkey_to_address(scriptpubkey):
+    asm = get_asm(scriptpubkey)
+    if asm[-1] == 'OP_CHECKSIG':
+        return base58_check_encode(binascii.hexlify(get_checksig(asm)).decode('utf-8'), config.ADDRESSVERSION)
+    elif asm[-1] == 'OP_CHECKMULTISIG':
+        pubkeys, signatures_required = get_checkmultisig(asm)
+        pubkeyhashes = [pubkey_to_pubkeyhash(pubkey) for pubkey in pubkeys]
+        return construct_array(signatures_required, pubkeyhashes, len(pubkeyhashes))
+    return None
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
@adamkrellenstein, to avoid circular import I had to move `pubkey_to_pubkeyhash()`, `get_asm()`, `get_checksig()` and `get_checkmultisig()`   in  `util.py`. Do you think we should move all this functions in `bitcoin.py` or move `pubkeyhash_to_pubkey()` in `bitcoin.py` ?
