### PR TITLE
Update index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ The Counterparty protocol specification may be found `here <https://github.com/C
 To get ``counterpartyd`` installed and set up on your computer, you have two options:
 
 - Set it up manually, using the instructions `here <https://github.com/CounterpartyXCP/counterpartyd/blob/master/README.md>`__
-- For Windows and Ubuntu Linux users, you can use the `automated build system <http://counterpartyd-build.rtfd.org>`__
+- For Windows and Ubuntu Linux users, you can use the `automated build system <http://counterparty.io/docs/build-system/build-from-source/>`__
 
 
 Table of Contents


### PR DESCRIPTION
Fixed the broken link on 'automated build system' - now it points to the counterparty.io website 'Build from source'. This files is synced with http://counterparty.io/docs/counterpartyd/, the link should probably point to  https://github.com/CounterpartyXCP/counterpartyd_build/blob/master/docs/BuildingFromSource.rst but not sure how to sync that with the site, so I just pointed it directly to the site.
