### PR TITLE
Better cache for unconfirmed_transaction() (master)

### DIFF
--- a/lib/blocks.py
+++ b/lib/blocks.py
@@ -684,6 +684,7 @@ def list_tx(db, proxy, block_hash, block_index, block_time, tx_hash, tx_index):
     if block_hash == None:
         block_hash = config.MEMPOOL_BLOCK_HASH
         block_index = config.MEMPOOL_BLOCK_INDEX
+        backend.extract_addresses(tx_hash) # prepare cache for backend.unconfirmed_transactions().
 
     if source and (data or destination == config.UNSPENDABLE):
         logger.debug('Saving transaction: {}'.format(tx_hash))


### PR DESCRIPTION
Remove query by batch and prepare cache for each transaction during the mempool initialization in blocks.py. The cache is really effective after the mempool is initialised in blocks.follow()
