### PR TITLE
Fix random consensus error around block 823000

### DIFF
--- a/counterparty-lib/counterpartylib/lib/backend/addrindexrs.py
+++ b/counterparty-lib/counterpartylib/lib/backend/addrindexrs.py
@@ -597,7 +597,7 @@ class AddrindexrsSocket:
             try:
                 data = self.sock.recv(READ_BUF_SIZE)
             except (TimeoutError, ConnectionResetError) as e:
-                raise AddrindexrsSocketError("Timeout or connection reset. Please retry.")
+                raise AddrindexrsSocketError("Timeout or connection reset. Please retry.") from e
             if data:
                 response = json.loads(data.decode('utf-8')) # assume valid JSON
                 if "id" not in response:


### PR DESCRIPTION
The problem was a hidden timeout error. A first call to `get_oldest_tx()` returned `{}` because of a timeout and the next call to `get_oldest_tx()` returned the result of the previous call which had finally arrived.
So I have:
- increased the timeout from 5 to 20 seconds.
- made the `get_oldest_tx()` function much stricter. We only return `{}` if the error returned by `addrindexrs` is 'no txs for address'
If `addrindexrs` returns nothing after 20s we throw an error.