### PR TITLE
basic sentry integration

### DIFF
--- a/counterparty-lib/counterpartylib/lib/api.py
+++ b/counterparty-lib/counterpartylib/lib/api.py
@@ -68,6 +68,23 @@ from counterpartylib.lib.messages.versions import enhanced_send  # noqa: E402
 
 logger = logging.getLogger(config.LOGGER_NAME)
 
+if os.environ.get("SENTRY_DSN"):
+    import sentry_sdk
+
+    environment = os.environ.get("SENTRY_ENVIRONMENT", "development")
+
+    release = os.environ.get("SENTRY_RELEASE", config.__version__)
+
+    logger.info("Sentry DSN found, initializing Sentry")
+
+    sentry_sdk.init(
+        dsn=os.environ["SENTRY_DSN"],
+        environment=environment,
+        release=release,
+        traces_sample_rate=1.0,
+    )
+
+
 API_TABLES = [
     "assets",
     "balances",

--- a/counterparty-lib/requirements.txt
+++ b/counterparty-lib/requirements.txt
@@ -25,3 +25,5 @@ arc4==0.4.0
 halo==0.0.31
 termcolor==2.4.0
 counterparty-rs==10.1.0-rc.1
+sentry-sdk==1.45.0
+


### PR DESCRIPTION
you need to set the following env vars:

- `SENTRY_DSN` ( application identifier ) 
- `SENTRY_ENVIRONMENT` ( defaults to `development`) 
- `SENTRY_RELEASE` ( defaults to `config.__version__` ) 

The Sentry client will not be initialized if `SENTRY_DSN` is not defined on os.environ. 

