### PR TITLE
Fix egde case

### DIFF
--- a/counterparty-core/requirements.txt
+++ b/counterparty-core/requirements.txt
@@ -5,4 +5,4 @@ colorlog==6.8.0
 python-dateutil==2.8.2
 requests==2.31.0
 termcolor==2.4.0
-counterparty-lib==10.0.0
+counterparty-lib==10.0.1

--- a/counterparty-lib/counterpartylib/lib/config.py
+++ b/counterparty-lib/counterpartylib/lib/config.py
@@ -7,7 +7,7 @@ UNIT = 100000000  # The same across assets.
 
 
 # Semantic Version
-__version__ = "10.0.1" # for hatch
+__version__ = "10.0.1"  # for hatch
 VERSION_STRING = __version__
 version = VERSION_STRING.split("-")[0].split(".")
 VERSION_MAJOR = int(version[0])

--- a/counterparty-lib/counterpartylib/lib/messages/order.py
+++ b/counterparty-lib/counterpartylib/lib/messages/order.py
@@ -916,6 +916,10 @@ def expire(db, block_index):
 
     # Expire orders and give refunds for the quantity give_remaining (if non-zero; if not BTC).
     orders = ledger.get_orders_to_expire(db, block_index)
+    # Edge case: filled orders, and therefore not expired in the previous block,
+    # re-ropened by order_match expiration in the previous block.
+    # TODO: protocol change: expire order matches then orders.
+    orders += ledger.get_orders_to_expire(db, block_index - 1)
     for order in orders:
         cancel_order(db, order, "expired", block_index, 0)  # tx_index=0 for block action
 

--- a/counterparty-rs/Cargo.lock
+++ b/counterparty-rs/Cargo.lock
@@ -198,7 +198,7 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "counterparty-rs"
-version = "10.0.0"
+version = "10.0.1"
 dependencies = [
  "bip32",
  "bitcoin",


### PR DESCRIPTION
In the `order.expire()` function we first expire the `orders` and then the `order_matches`.
It can therefore happen that an order with the status `filled`, and therefore not expired, is re-opened because of an expired `order_match`.

In v9 we used `WHERE expire_index < :block_index` and therefore the order was expired at the next block (this is why the order `e928918dd9a0605dc737eca5034cc444080d20f4ff7a7090b11f10d2a8e637e6` is expired at block 835513 instead of being expired at block 835512).

In v10, for optimization reasons and because in theory a `<` should not be necessary, we use `WHERE expire_index = :block_index - 1`. And therefore the order is not expired in the next block.

To reproduce this edge case while optimizing performance we now also check `WHERE expire_index = :block_index - 2`.
The correct fix should be to first expire `order_matches` and then expire `orders` but this is a protocol change. I will open an issue for this.