### PR TITLE
Quiet AddrIndexRs Errors

### DIFF
--- a/counterparty-lib/counterpartylib/lib/backend/addrindexrs.py
+++ b/counterparty-lib/counterpartylib/lib/backend/addrindexrs.py
@@ -319,12 +319,12 @@ def getrawtransaction_batch(txhash_list, verbose=False, skip_missing=False, _ret
                     else None
                 )
         except KeyError as e:  # shows up most likely due to finickyness with addrindex not always returning results that we need...
-            logger.error("Key error in addrindexrs still exists!!!!!")
+            logger.debug("Key error in addrindexrs still exists!!!!!")
             _hash = hashlib.md5(
                 json.dumps(list(txhash_list)).encode(), usedforsecurity=False
             ).hexdigest()
             _list = list(txhash_list.difference(noncached_txhashes))
-            _logger.warning(
+            _logger.debug(
                 f"tx missing in rawtx cache: {e} -- txhash_list size: {len(txhash_list)}, hash: {_hash} / raw_transactions_cache size: {len(raw_transactions_cache)} / # rpc_batch calls: {len(payload)} / txhash in noncached_txhashes: {tx_hash in noncached_txhashes} / txhash in txhash_list: {tx_hash in txhash_list} -- list {_list}"
             )
             if _retry < GETRAWTRANSACTION_MAX_RETRIES:  # try again

--- a/counterparty-lib/counterpartylib/lib/backend/addrindexrs.py
+++ b/counterparty-lib/counterpartylib/lib/backend/addrindexrs.py
@@ -417,7 +417,7 @@ class SocketManager:
                     logger.debug(f"`{self.host}:{self.port}` -- JSONDecodeError -- continuing")
                     continue
             except socket.timeout as e:
-                logger.exception(f"`{self.host}:{self.port}` -- Timeout receiving message: {e}")
+                logger.debug(f"`{self.host}:{self.port}` -- Timeout receiving message: {e}")
                 self.connected = False
                 raise e
             except Exception as e:


### PR DESCRIPTION
Getting a ton of this:
```
13|counterparty  | counterpartylib.lib.exceptions.BalanceError: Insufficient BTC at address 1Q8f3efUeUCxhwtU1yJGiXuwbMFxGz9sjd. (Need approximately 7.68e-05 BTC.)
13|counterparty  | [2024-04-14 10:57:13][ERROR] `localhost:8432` -- Timeout receiving message: timed out
13|counterparty  | Traceback (most recent call last):
13|counterparty  |   File "/home/adam/counterparty-core/counterparty-lib/counterpartylib/lib/backend/addrindexrs.py", line 405, in recv
13|counterparty  |     chunk = self.socket.recv(buffer_size)
13|counterparty  | TimeoutError: timed out
13|counterparty  | [2024-04-14 10:57:13][ERROR] AddrIndexRsClient.thread -- exception timed out
13|counterparty  | Traceback (most recent call last):
13|counterparty  |   File "/home/adam/counterparty-core/counterparty-lib/counterpartylib/lib/backend/addrindexrs.py", line 538, in _run
13|counterparty  |     res = self.socket_manager.recv()
13|counterparty  |   File "/home/adam/counterparty-core/counterparty-lib/counterpartylib/lib/backend/addrindexrs.py", line 422, in recv
13|counterparty  |     raise e
13|counterparty  |   File "/home/adam/counterparty-core/counterparty-lib/counterpartylib/lib/backend/addrindexrs.py", line 405, in recv
13|counterparty  |     chunk = self.socket.recv(buffer_size)
13|counterparty  | TimeoutError: timed out
13|counterparty  | [2024-04-14 10:57:27][ERROR] `localhost:8432` -- Timeout receiving message: timed out
13|counterparty  | Traceback (most recent call last):
13|counterparty  |   File "/home/adam/counterparty-core/counterparty-lib/counterpartylib/lib/backend/addrindexrs.py", line 405, in recv
13|counterparty  |     chunk = self.socket.recv(buffer_size)
13|counterparty  | TimeoutError: timed out
13|counterparty  | [2024-04-14 10:57:27][ERROR] AddrIndexRsClient.thread -- exception timed out
13|counterparty  | Traceback (most recent call last):
13|counterparty  |   File "/home/adam/counterparty-core/counterparty-lib/counterpartylib/lib/backend/addrindexrs.py", line 538, in _run
13|counterparty  |     res = self.socket_manager.recv()
13|counterparty  |   File "/home/adam/counterparty-core/counterparty-lib/counterpartylib/lib/backend/addrindexrs.py", line 422, in recv
13|counterparty  |     raise e
13|counterparty  |   File "/home/adam/counterparty-core/counterparty-lib/counterpartylib/lib/backend/addrindexrs.py", line 405, in recv
13|counterparty  |     chunk = self.socket.recv(buffer_size)
13|counterparty  | TimeoutError: timed out
13|counterparty  | [2024-04-14 10:57:52][INFO] Block: 839168 (225.37, hashes: L:06110 / TX:85520 / M:9e3f9)
```

and this:

```
13|counterparty  | [2024-04-14 11:01:59][ERROR] Key error in addrindexrs still exists!!!!!
13|counterparty  | [2024-04-14 11:01:59][WARNING] tx missing in rawtx cache: '692c6693aa4ee3787ece043700bcfc539877c310cf7e5c57751612738a455be5' -- txhash_list size: 20000, hash: 5d1411dbcf412ff2ce26f613025489e0 / raw_transactions_cache size: 20000 / # rpc_batch calls: 20000 / txhash in noncached_txhashes: True / txhash in txhash_list: True -- list []
13|counterparty  | [2024-04-14 11:01:59][ERROR] Key error in addrindexrs still exists!!!!!
13|counterparty  | [2024-04-14 11:01:59][WARNING] tx missing in rawtx cache: '46470c3739614f1614125815c96fe8301d1f6abad181337a81c289c2c24cab2b' -- txhash_list size: 20000, hash: 5d1411dbcf412ff2ce26f613025489e0 / raw_transactions_cache size: 20000 / # rpc_batch calls: 20000 / txhash in noncached_txhashes: True / txhash in txhash_list: True -- list []
```