### PR TITLE
[v10.1.1] Raise exception if no default value

### DIFF
--- a/counterparty-lib/counterpartylib/lib/exceptions.py
+++ b/counterparty-lib/counterpartylib/lib/exceptions.py
@@ -79,4 +79,8 @@ class InvalidVersion(Exception):
     pass
 
 
+class ComposeTransactionError(Exception):
+    pass
+
+
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/counterparty-lib/counterpartylib/lib/messages/issuance.py
+++ b/counterparty-lib/counterpartylib/lib/messages/issuance.py
@@ -345,7 +345,17 @@ def validate(
     )
 
 
-def compose(db, source, transfer_destination, asset, quantity, divisible, lock, reset, description):
+def compose(
+    db,
+    source,
+    asset,
+    quantity,
+    transfer_destination=None,
+    divisible=None,
+    lock=None,
+    reset=None,
+    description=None,
+):
     # Callability is deprecated, so for re‐issuances set relevant parameters
     # to old values; for first issuances, make uncallable.
     issuances = ledger.get_issuances(db, asset=asset, status="valid", first=True)

--- a/counterparty-lib/counterpartylib/test/fixtures/scenarios.py
+++ b/counterparty-lib/counterpartylib/test/fixtures/scenarios.py
@@ -34,25 +34,25 @@ UNITTEST_FIXTURE = [
     ["burn", (ADDR[0], DP["burn_quantity"]), {"encoding": "multisig"}],  # 310000
     [
         "issuance",
-        (ADDR[0], None, "DIVISIBLE", DP["quantity"] * 1000, True, None, None, "Divisible asset"),
+        (ADDR[0], "DIVISIBLE", DP["quantity"] * 1000, None, True, None, None, "Divisible asset"),
         {"encoding": "multisig"},
     ],
     [
         "issuance",
-        (ADDR[0], None, "NODIVISIBLE", 1000, False, None, None, "No divisible asset"),
+        (ADDR[0], "NODIVISIBLE", 1000, None, False, None, None, "No divisible asset"),
         {"encoding": "multisig"},
     ],
     [
         "issuance",
-        (ADDR[0], None, "CALLABLE", 1000, True, None, None, "Callable asset"),
+        (ADDR[0], "CALLABLE", 1000, None, True, None, None, "Callable asset"),
         {"encoding": "multisig"},
     ],
     [
         "issuance",
-        (ADDR[0], None, "LOCKED", 1000, True, None, None, "Locked asset"),
+        (ADDR[0], "LOCKED", 1000, None, True, None, None, "Locked asset"),
         {"encoding": "multisig"},
     ],
-    ["issuance", (ADDR[0], None, "LOCKED", 0, True, None, None, "LOCK"), {"encoding": "multisig"}],
+    ["issuance", (ADDR[0], "LOCKED", 0, None, True, None, None, "LOCK"), {"encoding": "multisig"}],
     [
         "order",
         (ADDR[0], "XCP", DP["quantity"], "DIVISIBLE", DP["quantity"], 2000, 0),
@@ -94,7 +94,7 @@ UNITTEST_FIXTURE = [
     ["send", (ADDR[0], MULTISIGADDR[0], "NODIVISIBLE", 10), {"encoding": "multisig"}, None],
     [
         "issuance",
-        (ADDR[0], None, "MAXI", 2**63 - 1, True, None, None, "Maximum quantity"),
+        (ADDR[0], "MAXI", 2**63 - 1, None, True, None, None, "Maximum quantity"),
         {"encoding": "multisig"},
     ],
     [
@@ -120,7 +120,7 @@ UNITTEST_FIXTURE = [
     ["burn", (P2SH_ADDR[0], int(DP["burn_quantity"] / 2)), {"encoding": "opreturn"}],
     [
         "issuance",
-        (P2SH_ADDR[0], None, "PAYTOSCRIPT", 1000, False, None, None, "PSH issued asset"),
+        (P2SH_ADDR[0], "PAYTOSCRIPT", 1000, None, False, None, None, "PSH issued asset"),
         {"encoding": "multisig", "dust_return_pubkey": False},
     ],
     ["send", (ADDR[0], P2SH_ADDR[0], "DIVISIBLE", DP["quantity"]), {"encoding": "multisig"}, None],
@@ -137,17 +137,17 @@ UNITTEST_FIXTURE = [
     # locked with an issuance after lock
     [
         "issuance",
-        (ADDR[6], None, "LOCKEDPREV", 1000, True, None, None, "Locked asset"),
+        (ADDR[6], "LOCKEDPREV", 1000, None, True, None, None, "Locked asset"),
         {"encoding": "multisig"},
     ],
     [
         "issuance",
-        (ADDR[6], None, "LOCKEDPREV", 0, True, None, None, "LOCK"),
+        (ADDR[6], "LOCKEDPREV", 0, None, True, None, None, "LOCK"),
         {"encoding": "multisig"},
     ],
     [
         "issuance",
-        (ADDR[6], None, "LOCKEDPREV", 0, True, None, None, "changed"),
+        (ADDR[6], "LOCKEDPREV", 0, None, True, None, None, "changed"),
         {"encoding": "multisig"},
     ],
     ["burn", (P2WPKH_ADDR[0], DP["burn_quantity"]), {"encoding": "opreturn"}],
@@ -209,23 +209,23 @@ UNITTEST_FIXTURE = [
     ["burn", (ADDR[2], DP["burn_quantity"]), {"encoding": "multisig"}],
     [
         "issuance",
-        (ADDR[2], None, "DIVIDEND", 100, True, "Test dividend", None, None),
+        (ADDR[2], "DIVIDEND", 100, None, True, "Test dividend", None, None),
         {"encoding": "multisig"},
     ],
     ["send", (ADDR[2], ADDR[3], "DIVIDEND", 10), {"encoding": "multisig"}, None],
     ["send", (ADDR[2], ADDR[3], "XCP", 92945878046), {"encoding": "multisig"}, None],
     [
         "issuance",
-        (ADDR[0], None, "PARENT", DP["quantity"] * 1, True, None, None, "Parent asset"),
+        (ADDR[0], "PARENT", DP["quantity"] * 1, None, True, None, None, "Parent asset"),
         {"encoding": "opreturn"},
     ],
     [
         "issuance",
         (
             ADDR[0],
-            None,
             "PARENT.already.issued",
             DP["quantity"] * 1,
+            None,
             True,
             None,
             None,
@@ -267,12 +267,12 @@ def generate_standard_scenario(address1, address2, order_matches):
         ["btcpay", (address1, order_matches[0]), {"encoding": "multisig"}],
         [
             "issuance",
-            (address1, None, "BBBB", DP["quantity"] * 10, True, None, None, ""),
+            (address1, "BBBB", DP["quantity"] * 10, None, True, None, None, ""),
             {"encoding": "multisig"},
         ],
         [
             "issuance",
-            (address1, None, "BBBC", round(DP["quantity"] / 1000), False, None, None, "foobar"),
+            (address1, "BBBC", round(DP["quantity"] / 1000), None, False, None, None, "foobar"),
             {"encoding": "multisig"},
         ],
         [

--- a/counterparty-lib/counterpartylib/test/fixtures/vectors.py
+++ b/counterparty-lib/counterpartylib/test/fixtures/vectors.py
@@ -3874,19 +3874,19 @@ UNITTEST_VECTOR = {
         # compose (db, source, transfer_destination, asset, quantity, divisible, lock, reset=None, description=None)
         "compose": [
             {
-                "in": (ADDR[0], None, "ASSET", 1000, True, False, None, ""),
+                "in": (ADDR[0], "ASSET", 1000, None, True, False, None, ""),
                 "error": (exceptions.AssetNameError, "non‐numeric asset name starts with ‘A’"),
             },
             {
-                "in": (ADDR[0], None, "BSSET1", 1000, True, False, None, ""),
+                "in": (ADDR[0], "BSSET1", 1000, None, True, False, None, ""),
                 "error": (exceptions.AssetNameError, "invalid character:"),
             },
             {
-                "in": (ADDR[0], None, "SET", 1000, True, False, None, ""),
+                "in": (ADDR[0], "SET", 1000, None, True, False, None, ""),
                 "error": (exceptions.AssetNameError, "too short"),
             },
             {
-                "in": (ADDR[0], None, "BSSET", 1000, True, False, None, ""),
+                "in": (ADDR[0], "BSSET", 1000, None, True, False, None, ""),
                 "out": (
                     "mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc",
                     [],
@@ -3894,7 +3894,7 @@ UNITTEST_VECTOR = {
                 ),
             },
             {
-                "in": (ADDR[0], None, "BASSET", 1000, True, False, None, ""),
+                "in": (ADDR[0], "BASSET", 1000, None, True, False, None, ""),
                 "out": (
                     "mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc",
                     [],
@@ -3902,7 +3902,7 @@ UNITTEST_VECTOR = {
                 ),
             },
             {
-                "in": (P2SH_ADDR[0], None, "BSSET", 1000, True, False, None, ""),
+                "in": (P2SH_ADDR[0], "BSSET", 1000, None, True, False, None, ""),
                 "out": (
                     P2SH_ADDR[0],
                     [],
@@ -3912,9 +3912,9 @@ UNITTEST_VECTOR = {
             {
                 "in": (
                     ADDR[0],
-                    None,
                     "BSSET",
                     1000,
+                    None,
                     True,
                     False,
                     None,
@@ -3927,7 +3927,7 @@ UNITTEST_VECTOR = {
                 ),
             },
             {
-                "in": (ADDR[0], ADDR[1], "DIVISIBLE", 0, True, False, None, ""),
+                "in": (ADDR[0], "DIVISIBLE", 0, ADDR[1], True, False, None, ""),
                 "out": (
                     "mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc",
                     [("mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns", None)],
@@ -3935,7 +3935,7 @@ UNITTEST_VECTOR = {
                 ),
             },
             {
-                "in": (MULTISIGADDR[0], None, "BSSET", 1000, True, False, None, ""),
+                "in": (MULTISIGADDR[0], "BSSET", 1000, None, True, False, None, ""),
                 "out": (
                     "1_mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc_mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns_2",
                     [],
@@ -3943,7 +3943,7 @@ UNITTEST_VECTOR = {
                 ),
             },
             {
-                "in": (ADDR[0], MULTISIGADDR[0], "DIVISIBLE", 0, True, False, None, ""),
+                "in": (ADDR[0], "DIVISIBLE", 0, MULTISIGADDR[0], True, False, None, ""),
                 "out": (
                     "mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc",
                     [
@@ -3956,7 +3956,7 @@ UNITTEST_VECTOR = {
                 ),
             },
             {
-                "in": (ADDR[0], None, "MAXIMUM", 2**63 - 1, True, False, None, "Maximum quantity"),
+                "in": (ADDR[0], "MAXIMUM", 2**63 - 1, None, True, False, None, "Maximum quantity"),
                 "out": (
                     "mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc",
                     [],
@@ -3964,7 +3964,7 @@ UNITTEST_VECTOR = {
                 ),
             },
             {
-                "in": (ADDR[0], None, f"A{2 ** 64 - 1}", 1000, None, False, None, None),
+                "in": (ADDR[0], f"A{2 ** 64 - 1}", 1000, None, None, False, None, None),
                 "out": (
                     "mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc",
                     [],
@@ -3972,16 +3972,16 @@ UNITTEST_VECTOR = {
                 ),
             },
             {
-                "in": (ADDR[0], None, f"A{2 ** 64}", 1000, True, False, None, ""),
+                "in": (ADDR[0], f"A{2 ** 64}", 1000, None, True, False, None, ""),
                 "error": (exceptions.AssetNameError, "numeric asset name not in range"),
             },
             {
-                "in": (ADDR[0], None, f"A{26 ** 12}", 1000, True, False, None, ""),
+                "in": (ADDR[0], f"A{26 ** 12}", 1000, None, True, False, None, ""),
                 "error": (exceptions.AssetNameError, "numeric asset name not in range"),
             },
             {
                 "comment": "basic child asset",
-                "in": (ADDR[0], None, "PARENT.child1", 100000000, True, False, None, ""),
+                "in": (ADDR[0], "PARENT.child1", 100000000, None, True, False, None, ""),
                 "out": (
                     "mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc",
                     [],
@@ -3994,7 +3994,7 @@ UNITTEST_VECTOR = {
             },
             {
                 "comment": "basic child asset with description",
-                "in": (ADDR[0], None, "PARENT.child1", 100000000, True, False, None, "hello world"),
+                "in": (ADDR[0], "PARENT.child1", 100000000, None, True, False, None, "hello world"),
                 "out": (
                     "mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc",
                     [],
@@ -4014,7 +4014,7 @@ UNITTEST_VECTOR = {
                 #     └────────────────── Type ID (4 bytes) - type 21/subasset
             },
             {
-                "in": (ADDR[0], None, "PARENT.a.b.c", 1000, True, False, None, ""),
+                "in": (ADDR[0], "PARENT.a.b.c", 1000, None, True, False, None, ""),
                 "out": (
                     "mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc",
                     [],
@@ -4026,7 +4026,7 @@ UNITTEST_VECTOR = {
                 # 00000015|01530821671b1001|00000000000003e8|01|0a|014a74856171ca3c559f
             },
             {
-                "in": (ADDR[0], None, "PARENT.a-zA-Z0-9.-_@!", 1000, True, False, None, ""),
+                "in": (ADDR[0], "PARENT.a-zA-Z0-9.-_@!", 1000, None, True, False, None, ""),
                 "out": (
                     "mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc",
                     [],
@@ -4038,7 +4038,7 @@ UNITTEST_VECTOR = {
             },
             {
                 "comment": "make sure compose catches asset name syntax errors",
-                "in": (ADDR[0], None, "BADASSETx.child1", 1000, True, False, None, ""),
+                "in": (ADDR[0], "BADASSETx.child1", 1000, None, True, False, None, ""),
                 "error": (
                     exceptions.AssetNameError,
                     "parent asset name contains invalid character:",
@@ -4046,12 +4046,12 @@ UNITTEST_VECTOR = {
             },
             {
                 "comment": "make sure compose catches validation errors",
-                "in": (ADDR[1], None, "PARENT.child1", 1000, True, False, None, ""),
+                "in": (ADDR[1], "PARENT.child1", 1000, None, True, False, None, ""),
                 "error": (exceptions.ComposeError, ["parent asset owned by another address"]),
             },
             {
                 "comment": "referencing parent asset by name composes a reissuance",
-                "in": (ADDR[0], None, "PARENT.already.issued", 1000, True, False, None, ""),
+                "in": (ADDR[0], "PARENT.already.issued", 1000, None, True, False, None, ""),
                 "out": (
                     "mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc",
                     [],
@@ -4061,7 +4061,7 @@ UNITTEST_VECTOR = {
             {
                 "comment": "basic child asset with compact message type id",
                 "mock_protocol_changes": {"short_tx_type_id": True},
-                "in": (ADDR[0], None, "PARENT.child1", 100000000, True, False, None, ""),
+                "in": (ADDR[0], "PARENT.child1", 100000000, None, True, False, None, ""),
                 "out": (
                     "mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc",
                     [],
@@ -4074,9 +4074,9 @@ UNITTEST_VECTOR = {
             {
                 "in": (
                     ADDR[0],
-                    None,
                     f"A{26 ** 12 + 101}",
                     200000000,
+                    None,
                     True,
                     None,
                     None,
@@ -4091,9 +4091,9 @@ UNITTEST_VECTOR = {
             {
                 "in": (
                     ADDR[0],
-                    ADDR[1],
                     "DIVISIBLEB",
                     0,
+                    ADDR[1],
                     True,
                     False,
                     None,
@@ -4106,7 +4106,7 @@ UNITTEST_VECTOR = {
                 ),
             },
             {
-                "in": (ADDR[0], None, "DIVISIBLEC", 0, True, True, None, "third divisible asset"),
+                "in": (ADDR[0], "DIVISIBLEC", 0, None, True, True, None, "third divisible asset"),
                 "out": (
                     "mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc",
                     [],

--- a/release-notes/release-notes-v10.1.1.md
+++ b/release-notes/release-notes-v10.1.1.md
@@ -1,0 +1,18 @@
+# Release Notes - Counterparty Core v10.1.1 (2024-04-??)
+
+# ChangeLog
+
+## Bugfixes
+* No longer automatically uses `None` for missing arguments during an RPC call to `create_*`. Instead we use the default value defined in the signature of the corresponding `*.compose()` function. If no default value is defined the parameter is mandatory.
+
+## Codebase
+
+
+## Command-Line Interface
+
+
+# Credits
+* Ouziel Slama
+* Adam Krellenstein
+* Warren Puffett
+* Matt Marcello


### PR DESCRIPTION
Currently, when calling one of the `create_*` functions with the API, if one of the arguments of the `*.compose()` function is missing it is systematically replaced by `None`.
With this PR we automatically fill missing arguments only if they have a default value in the corresponding `*.compose()` function. Otherwise the API returns a clear error message with the missing parameter names.
(Merged after the release of `v10.1.0`)
(Fix https://github.com/CounterpartyXCP/counterparty-core/issues/1025)