### PR TITLE
Fix `get_dispenser_info` RPC call

### DIFF
--- a/counterparty-lib/counterpartylib/lib/api.py
+++ b/counterparty-lib/counterpartylib/lib/api.py
@@ -1185,16 +1185,14 @@ class APIServer(threading.Thread):
 
         @dispatcher.add_method
         def get_dispenser_info(tx_hash=None, tx_index=None):
-            cursor = self.db.cursor()  # noqa: F841
-
             if tx_hash is None and tx_index is None:
                 raise APIError("You must provided a tx hash or a tx index")
 
             dispensers = []
             if tx_hash is not None:
-                dispensers = get_dispenser_info(self.db, tx_hash=tx_hash)
+                dispensers = ledger.get_dispenser_info(self.db, tx_hash=tx_hash)
             else:
-                dispensers = get_dispenser_info(self.db, tx_index=tx_index)
+                dispensers = ledger.get_dispenser_info(self.db, tx_index=tx_index)
 
             if len(dispensers) == 1:
                 dispenser = dispensers[0]


### PR DESCRIPTION
Before:
```
$ curl -X POST http://localhost:4000/api/ --user rpc:rpc -H 'Content-Type: application/json; charset=UTF-8' -H 'Accept: application/json, text/javascript' --data-binary '{ 
    "method" : "get_dispenser_info",
    "params" : {
        "tx_hash": "02d9fcc1793804465e1a9e051c1ba568c95f8be5d3a379cce5e5b1375c7bbff0"
    },
    "jsonrpc" : "2.0",
    "id" : 0
    }' | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   504  100   313  100   191   7308   4459 --:--:-- --:--:-- --:--:-- 12000
{
    "error": {
        "code": -32000,
        "message": "Server error",
        "data": {
            "type": "TypeError",
            "args": [
                "APIServer.run.<locals>.get_dispenser_info() got multiple values for argument 'tx_hash'"
            ],
            "message": "APIServer.run.<locals>.get_dispenser_info() got multiple values for argument 'tx_hash'"
        }
    },
    "id": 0,
    "jsonrpc": "2.0"
}
```

After:
```
$ curl -X POST http://localhost:4000/api/ --user rpc:rpc -H 'Content-Type: application/json; charset=UTF-8' -H 'Accept: application/json, text/javascript' --data-binary '{ 
    "method" : "get_dispenser_info",
    "params" : {
        "tx_hash": "02d9fcc1793804465e1a9e051c1ba568c95f8be5d3a379cce5e5b1375c7bbff0"
    },
    "jsonrpc" : "2.0",
    "id" : 0
    }' | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   679  100   488  100   191  17648   6907 --:--:-- --:--:-- --:--:-- 25148
{
    "result": {
        "tx_index": 1915003,
        "tx_hash": "02d9fcc1793804465e1a9e051c1ba568c95f8be5d3a379cce5e5b1375c7bbff0",
        "block_index": 724720,
        "source": "1JjALGQhbVGx2ig6cRFu56SM7KT4xkX39q",
        "asset": "YAKUSA",
        "give_quantity": 1,
        "escrow_quantity": 2,
        "mainchainrate": 159906,
        "fiat_price": "",
        "fiat_unit": "",
        "oracle_price": "",
        "satoshi_price": "",
        "status": 10,
        "give_remaining": 0,
        "oracle_address": null,
        "oracle_price_last_updated": "",
        "asset_longname": null
    },
    "id": 0,
    "jsonrpc": "2.0"
}
```
