### PR TITLE
Correctly close database on shutdown

### DIFF
--- a/counterparty-lib/counterpartylib/lib/api.py
+++ b/counterparty-lib/counterpartylib/lib/api.py
@@ -757,6 +757,8 @@ class APIServer(threading.Thread):
     def __init__(self, db=None):
         self.db = db
         self.is_ready = False
+        self.server = None
+        self.ctx = None
         threading.Thread.__init__(self)
 
     def stop(self):

--- a/counterparty-lib/counterpartylib/lib/backend/__init__.py
+++ b/counterparty-lib/counterpartylib/lib/backend/__init__.py
@@ -47,6 +47,7 @@ def backend(initialize=True):
 
 
 def stop():
+    logger.info("Stopping backend...")
     backend(initialize=False).stop()
 
 

--- a/counterparty-lib/counterpartylib/lib/database.py
+++ b/counterparty-lib/counterpartylib/lib/database.py
@@ -108,6 +108,13 @@ def vacuum(db):
     logger.info("Database VACUUM completed.")
 
 
+def optimize(db):
+    logger.info("Running PRAGMA optimize...")
+    cursor = db.cursor()
+    cursor.execute("PRAGMA optimize")
+    logger.info("PRAGMA optimize done.")
+
+
 def field_is_pk(cursor, table, field):
     cursor.execute(f"PRAGMA table_info({table})")
     for row in cursor:


### PR DESCRIPTION
- Use `try: .. finally:` clause instead `sigterm_handler()` with global variable to stop API server and database
- Use Werkzeug `server.shutdown` to stop API server

Fix https://github.com/CounterpartyXCP/counterparty-core/issues/1643
When we stop the server there are no more `-wal` and `-shm` files but only `counterparty.db`.