### PR TITLE
Tweak --backend-poll-interval flag

### DIFF
--- a/counterparty-core/counterpartycore/cli.py
+++ b/counterparty-core/counterpartycore/cli.py
@@ -14,6 +14,20 @@ logger = logging.getLogger(config.LOGGER_NAME)
 APP_NAME = "counterparty-server"
 APP_VERSION = config.VERSION_STRING
 
+
+def float_range(min):
+    def float_range_checker(arg):
+        try:
+            f = float(arg)
+        except ValueError as e:
+            raise argparse.ArgumentTypeError("must be a floating point number") from e
+        if f < min:
+            raise argparse.ArgumentTypeError(f"must be in greater than or equal to {min}")
+        return f
+
+    return float_range_checker
+
+
 CONFIG_ARGS = [
     [
         ("-v", "--verbose"),
@@ -112,7 +126,11 @@ CONFIG_ARGS = [
     ],
     [
         ("--backend-poll-interval",),
-        {"type": float, "default": 3.0, "help": "poll interval, in seconds (default: 3.0)"},
+        {
+            "type": float_range(3.0),
+            "default": 3.0,
+            "help": "poll interval, in seconds. Minimum 3.0. (default: 3.0)",
+        },
     ],
     [
         ("--check-asset-conservation",),

--- a/counterparty-core/counterpartycore/cli.py
+++ b/counterparty-core/counterpartycore/cli.py
@@ -15,14 +15,14 @@ APP_NAME = "counterparty-server"
 APP_VERSION = config.VERSION_STRING
 
 
-def float_range(min):
+def float_range(min_value):
     def float_range_checker(arg):
         try:
             f = float(arg)
         except ValueError as e:
             raise argparse.ArgumentTypeError("must be a floating point number") from e
-        if f < min:
-            raise argparse.ArgumentTypeError(f"must be in greater than or equal to {min}")
+        if f < min_value:
+            raise argparse.ArgumentTypeError(f"must be in greater than or equal to {min_value}")
         return f
 
     return float_range_checker

--- a/counterparty-core/counterpartycore/server.py
+++ b/counterparty-core/counterpartycore/server.py
@@ -310,7 +310,6 @@ def initialise_config(
 
     # Backend Poll Interval
     if backend_poll_interval:
-        assert backend_poll_interval >= 3.0
         config.BACKEND_POLL_INTERVAL = backend_poll_interval
     else:
         config.BACKEND_POLL_INTERVAL = 3.0


### PR DESCRIPTION
Using a value lower than 3.0 will display this error:
```
counterparty-server start: error: argument --backend-poll-interval: must be in greater than or equal to 3.0
```