### PR TITLE
Parse the blocks while bitcoind is catching up

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/api_v1.py
+++ b/counterparty-core/counterpartycore/lib/api/api_v1.py
@@ -170,7 +170,7 @@ def check_backend_state():
         raise BackendError(f"Bitcoind is running about {round(time_behind / 3600)} hours behind.")
 
     # check backend index
-    blocks_behind = backend.bitcoind.getindexblocksbehind()
+    blocks_behind = backend.bitcoind.get_blocks_behind()
     if blocks_behind > 5:
         raise BackendError(f"Indexd is running {blocks_behind} blocks behind.")
 
@@ -824,7 +824,7 @@ class APIServer(threading.Thread):
                 last_message = None
 
             try:
-                indexd_blocks_behind = backend.bitcoind.getindexblocksbehind()
+                indexd_blocks_behind = backend.bitcoind.get_blocks_behind()
             except:  # noqa: E722
                 indexd_blocks_behind = latest_block_index if latest_block_index > 0 else 999999
             indexd_caught_up = indexd_blocks_behind <= 1

--- a/counterparty-core/counterpartycore/lib/api/util.py
+++ b/counterparty-core/counterpartycore/lib/api/util.py
@@ -140,7 +140,7 @@ def get_oldest_transaction_by_address(address: str, block_index: int = None):
 
 def get_backend_height():
     block_count = backend.bitcoind.getblockcount()
-    blocks_behind = backend.bitcoind.getindexblocksbehind()
+    blocks_behind = backend.bitcoind.get_blocks_behind()
     return block_count + blocks_behind
 
 

--- a/counterparty-core/counterpartycore/lib/backend/addrindexrs.py
+++ b/counterparty-core/counterpartycore/lib/backend/addrindexrs.py
@@ -585,9 +585,14 @@ class AddrindexrsSocket:
         self.connect()
 
     def connect(self):
-        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.sock.settimeout(ADDRINDEXRS_CLIENT_TIMEOUT)
-        self.sock.connect((config.INDEXD_CONNECT, config.INDEXD_PORT))
+        try:
+            self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.sock.settimeout(ADDRINDEXRS_CLIENT_TIMEOUT)
+            self.sock.connect((config.INDEXD_CONNECT, config.INDEXD_PORT))
+        except Exception:
+            logger.warning("Failed to connect to addrindexrs, retrying in 10s...")
+            time.sleep(10)
+            self.connect()
 
     def _send(self, query, timeout=ADDRINDEXRS_CLIENT_TIMEOUT):
         query["id"] = self.next_message_id

--- a/counterparty-core/counterpartycore/lib/backend/bitcoind.py
+++ b/counterparty-core/counterpartycore/lib/backend/bitcoind.py
@@ -161,10 +161,22 @@ def get_btc_supply(normalize=False):
     return total_supply if normalize else int(total_supply * config.UNIT)
 
 
-def getindexblocksbehind():
+def get_chain_tip():
+    return rpc("getchaintips", [])[0]["height"]
+
+
+def get_blocks_behind():
     block_count = getblockcount()
-    chain_tip = rpc("getchaintips", [])[0]["height"]
+    chain_tip = get_chain_tip()
     return chain_tip - block_count
+
+
+def wait_for_block(block_index):
+    block_count = getblockcount()
+    while block_count < block_index:
+        logger.debug(f"Waiting for bitcoind to catch up {block_index - block_count} blocks...")
+        time.sleep(10)
+        block_count = getblockcount()
 
 
 def add_transaction_in_cache(tx_hash, tx):

--- a/counterparty-core/counterpartycore/lib/blocks.py
+++ b/counterparty-core/counterpartycore/lib/blocks.py
@@ -1163,7 +1163,7 @@ def catch_up(db, check_asset_conservation=True):
 
         parsed_blocks += 1
         duration = timedelta(seconds=int(time.time() - start_time))
-        logger.info(f"{parsed_blocks} block parsed in {duration}")
+        logger.info(f"{parsed_blocks} blocks parsed in {duration}")
 
         # Refresh block count.
         if util.CURRENT_BLOCK_INDEX == block_count:

--- a/counterparty-core/counterpartycore/lib/blocks.py
+++ b/counterparty-core/counterpartycore/lib/blocks.py
@@ -1137,6 +1137,11 @@ def catch_up(db, check_asset_conservation=True):
     # Get block count.
     block_count = backend.bitcoind.getblockcount()
 
+    # Wait for bitcoind to catch up at least one block after util.CURRENT_BLOCK_INDEX
+    if backend.bitcoind.get_blocks_behind() > 0 and block_count <= util.CURRENT_BLOCK_INDEX:
+        backend.bitcoind.wait_for_block(util.CURRENT_BLOCK_INDEX + 1)
+        block_count = backend.bitcoind.getblockcount()
+
     # initialize blocks fetcher
     # block_fetcher = backend.bitcoind.BlockFetcher(util.CURRENT_BLOCK_INDEX + 1)
     fetcher.initialize(util.CURRENT_BLOCK_INDEX + 1)
@@ -1161,7 +1166,11 @@ def catch_up(db, check_asset_conservation=True):
         logger.info(f"{parsed_blocks} block parsed in {duration}")
 
         # Refresh block count.
-        block_count = backend.bitcoind.getblockcount()
+        if util.CURRENT_BLOCK_INDEX == block_count:
+            # if bitcoind is catching up, wait for the next block
+            if backend.bitcoind.get_blocks_behind() > 0:
+                backend.bitcoind.wait_for_block(util.CURRENT_BLOCK_INDEX + 1)
+            block_count = backend.bitcoind.getblockcount()
 
     fetcher.stop()
 


### PR DESCRIPTION
For the moment, as long as `get_oldest_tx()` is not disabled, the parsing will stop after block 819300 and wait until Addrindexrs is ready and therefore until bitcoind has finished catching up.