### PR TITLE
Allow subassets on numerics

### DIFF
--- a/counterparty-core/counterpartycore/lib/ledger.py
+++ b/counterparty-core/counterpartycore/lib/ledger.py
@@ -657,7 +657,9 @@ def resolve_subasset_longname(db, asset_name):
     if util.enabled("subassets"):
         subasset_longname = None
         try:
-            subasset_parent, subasset_longname = util.parse_subasset_from_asset_name(asset_name)
+            _subasset_parent, subasset_longname = util.parse_subasset_from_asset_name(
+                asset_name, util.enabled("allow_subassets_on_numerics")
+            )
         except Exception as e:  # noqa: F841
             logger.warning(f"Invalid subasset {asset_name}")
             subasset_longname = None
@@ -1717,7 +1719,7 @@ class OrdersCache(metaclass=util.SingletonMeta):
         select_orders_query = """
             SELECT * FROM (
                 SELECT *, MAX(rowid) FROM orders GROUP BY tx_hash
-            ) WHERE status != 'expired' 
+            ) WHERE status != 'expired'
         """
 
         with db:

--- a/counterparty-core/counterpartycore/lib/messages/issuance.py
+++ b/counterparty-core/counterpartycore/lib/messages/issuance.py
@@ -423,7 +423,9 @@ def compose(
     subasset_parent = None
     subasset_longname = None
     if util.enabled("subassets"):  # Protocol change.
-        subasset_parent, subasset_longname = util.parse_subasset_from_asset_name(asset)
+        subasset_parent, subasset_longname = util.parse_subasset_from_asset_name(
+            asset, util.enabled("allow_subassets_on_numerics")
+        )
         if subasset_longname is not None:
             # try to find an existing subasset
             assets = ledger.get_assets_by_longname(db, subasset_longname)
@@ -851,7 +853,7 @@ def parse(db, tx, message, message_type_id):
             # ensure the subasset_longname is valid
             util.validate_subasset_longname(subasset_longname)
             subasset_parent, subasset_longname = util.parse_subasset_from_asset_name(
-                subasset_longname
+                subasset_longname, util.enabled("allow_subassets_on_numerics")
             )
         except exceptions.AssetNameError as e:  # noqa: F841
             asset = None

--- a/counterparty-core/counterpartycore/protocol_changes.json
+++ b/counterparty-core/counterpartycore/protocol_changes.json
@@ -591,6 +591,13 @@
     "block_index": 900000,
     "testnet_block_index": 2815000
   },
+  "allow_subassets_on_numerics": {
+    "minimum_version_major": 10,
+    "minimum_version_minor": 4,
+    "minimum_version_revision": 0,
+    "block_index": 900000,
+    "testnet_block_index": 2815000
+  },
   "fee_parameters": {
     "minimum_version_major": 0,
     "mainnet":{

--- a/counterparty-core/counterpartycore/test/fixtures/vectors.py
+++ b/counterparty-core/counterpartycore/test/fixtures/vectors.py
@@ -3376,6 +3376,35 @@ UNITTEST_VECTOR = (
                     "error": (exceptions.AssetNameError, "too short"),
                 },
                 {
+                    "comment": "disallow subassets on numerics",
+                    "mock_protocol_changes": {"allow_subassets_on_numerics": False},
+                    "in": (
+                        ADDR[0],
+                        "A9542895.subasset",
+                        1000,
+                        None,
+                        True,
+                        False,
+                        None,
+                        "",
+                    ),
+                    "error": (exceptions.AssetNameError, "parent asset name starts with 'A'"),
+                },
+                {
+                    "comment": "allow subassets on numerics",
+                    "in": (
+                        ADDR[0],
+                        "A95428956661682177.subasset",
+                        1000,
+                        None,
+                        True,
+                        False,
+                        None,
+                        "",
+                    ),
+                    "error": (exceptions.ComposeError, ["parent asset not found"]),
+                },
+                {
                     "in": (ADDR[0], "BSSET", 1000, None, True, False, None, ""),
                     "out": (
                         "mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc",
@@ -8397,7 +8426,7 @@ UNITTEST_VECTOR = (
                 },
                 {
                     "in": ("ABADPARENT.child1",),
-                    "error": (exceptions.AssetNameError, "parent asset name starts with ‘A’"),
+                    "error": (exceptions.AssetNameError, "parent asset name starts with 'A'"),
                 },
                 {
                     "in": ("BTC.child1",),
@@ -8427,6 +8456,27 @@ UNITTEST_VECTOR = (
                     "error": (
                         exceptions.AssetNameError,
                         "subasset name contains consecutive periods",
+                    ),
+                },
+                {
+                    "comment": "numerics disallowed",
+                    "in": ("A95428956661682177.subasset",),
+                    "error": (
+                        exceptions.AssetNameError,
+                        "parent asset name too long",
+                    ),
+                },
+                {
+                    "comment": "numerics allowed",
+                    "in": ("A95428956661682177.subasset", True),
+                    "out": ("A95428956661682177", "A95428956661682177.subasset"),
+                },
+                {
+                    "comment": "numerics allowed but too long",
+                    "in": ("A123456789012345678901.subasset", True),
+                    "error": (
+                        exceptions.AssetNameError,
+                        "parent asset name too long",
                     ),
                 },
             ],

--- a/release-notes/release-notes-v10.4.0.md
+++ b/release-notes/release-notes-v10.4.0.md
@@ -29,6 +29,12 @@ This release includes a variety of protocol upgrades.
 * Expire order matches then orders
     - PR: https://github.com/CounterpartyXCP/counterparty-core/pull/1794
     - Issue: https://github.com/CounterpartyXCP/counterparty-core/pull/1633
+* Free Subassets
+    - PR: https://github.com/CounterpartyXCP/counterparty-core/pull/2194
+    - Issue: https://github.com/CounterpartyXCP/counterparty-core/issues/1840
+* Subassets on Numeric Assets
+    - PR: https://github.com/CounterpartyXCP/counterparty-core/pull/2195
+    - Issue: https://github.com/CounterpartyXCP/counterparty-core/issues/1842
 
 ## Bugfixes
 


### PR DESCRIPTION
#1842 

## Motivation

There is no particular reason to disallow subassets on numeric assets and there is a strong community demand to be able to do so (see for example https://github.com/mikeinspace/Glyphs/blob/main/README.md).

## Design

Currently the `validate_subasset_parent_name` function checks that the parent asset is not numeric. This is the only place where this check is performed.

A protocol change `allow_subassets_on_numerics` will be added in the `protocol_changes.json` file. From this block on, the verification will be removed from the function `validate_subasset_parent_name`.