### PR TITLE
Fix reparse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ dist/
 .env.leave
 .venv/
 test-results/
+
+# cursor
+._*

--- a/counterparty-core/counterpartycore/lib/blocks.py
+++ b/counterparty-core/counterpartycore/lib/blocks.py
@@ -263,6 +263,7 @@ def replay_transactions_events(db, transactions):
             "btc_amount": tx["btc_amount"],
             "fee": tx["fee"],
             "data": tx["data"],
+            "utxos_info": tx["utxos_info"],
         }
         ledger.add_to_journal(
             db,


### PR DESCRIPTION
This bug caused an `event_hash` mismatch after a reparse.

* [x] Double-check the spelling and grammar of all strings, code comments, etc.
* [x] Double-check that all code is deterministic that needs to be
* [x] Add tests to cover any new or revised logic
* [x] Ensure that the test suite passes
* [x] Update the project [release notes](release-notes/)
* [x] Update the project documentation, as appropriate, with a corresponding Pull Request in the [Documentation repository](https://github.com/CounterpartyXCP/Documentation)
