### PR TITLE
Test `p2sh` encoding with regtest (Failing)

### DIFF
--- a/counterparty-core/counterpartycore/lib/transaction.py
+++ b/counterparty-core/counterpartycore/lib/transaction.py
@@ -102,6 +102,7 @@ def check_transaction_sanity(db, source, tx_info, unsigned_tx_hex, encoding, inp
         if encoding == "p2sh":
             # make_canonical can't determine the address, so we blindly change the desired to the parsed
             desired_source = parsed_source
+            # desired_destination = parsed_destination
     except exceptions.BTCOnlyError:
         # Skip BTC‐only transactions.
         return

--- a/counterparty-core/counterpartycore/lib/transaction.py
+++ b/counterparty-core/counterpartycore/lib/transaction.py
@@ -102,7 +102,7 @@ def check_transaction_sanity(db, source, tx_info, unsigned_tx_hex, encoding, inp
         if encoding == "p2sh":
             # make_canonical can't determine the address, so we blindly change the desired to the parsed
             desired_source = parsed_source
-            # desired_destination = parsed_destination
+            desired_destination = parsed_destination
     except exceptions.BTCOnlyError:
         # Skip BTC‐only transactions.
         return

--- a/counterparty-core/counterpartycore/lib/transaction.py
+++ b/counterparty-core/counterpartycore/lib/transaction.py
@@ -102,7 +102,6 @@ def check_transaction_sanity(db, source, tx_info, unsigned_tx_hex, encoding, inp
         if encoding == "p2sh":
             # make_canonical can't determine the address, so we blindly change the desired to the parsed
             desired_source = parsed_source
-            desired_destination = parsed_destination
     except exceptions.BTCOnlyError:
         # Skip BTC‐only transactions.
         return

--- a/counterparty-core/counterpartycore/test/regtest/regtestnode.py
+++ b/counterparty-core/counterpartycore/test/regtest/regtestnode.py
@@ -196,6 +196,7 @@ class RegtestNode:
             "-zmqpubsequence=tcp://0.0.0.0:29332",
             "-zmqpubrawblock=tcp://0.0.0.0:29333",
             "-fallbackfee=0.0002",
+            "-acceptnonstdtxn",
             f"-datadir={self.datadir}",
             _bg=True,
             _out=sys.stdout,

--- a/counterparty-core/counterpartycore/test/regtest/testp2sh.py
+++ b/counterparty-core/counterpartycore/test/regtest/testp2sh.py
@@ -1,0 +1,179 @@
+import hashlib
+import json
+import sys
+import time
+import urllib.parse
+
+import sh
+from bitcoin import SelectParams
+from bitcoin.core import (
+    CMutableTransaction,
+    CScriptWitness,
+    CTxIn,
+    CTxInWitness,
+    CTxWitness,
+    Hash160,
+    b2lx,
+)
+from bitcoin.core.script import OP_0, SIGHASH_ALL, SIGVERSION_WITNESS_V0, CScript, SignatureHash
+from bitcoin.wallet import CBitcoinSecret, P2WPKHBitcoinAddress
+
+SelectParams("regtest")
+
+SERVER = "http://localhost:24000/v2/"
+
+
+def api_call(route, params=None):
+    params = params or {}
+    params_in_url = []
+    for key, value in params.items():
+        if f"<{key}>" in route:
+            route = route.replace(f"<{key}>", value)
+            params_in_url.append(key)
+    for key in params_in_url:
+        del params[key]
+    query_string = urllib.parse.urlencode(params)
+    url = f"{SERVER}{route}?{query_string}"
+    return json.loads(sh.curl(url).strip())
+
+
+def bake_bitcoin_clients():
+    bitcoin_cli = sh.bitcoin_cli.bake(
+        "-rpcuser=rpc",
+        "-rpcpassword=rpc",
+        "-rpcconnect=localhost",
+        "-regtest",
+    )
+    return bitcoin_cli
+
+
+def get_tx_out_amount(tx_hash, vout):
+    raw_tx = json.loads(bitcoin_cli("getrawtransaction", tx_hash, 1).strip())
+    return raw_tx["vout"][vout]["value"]
+
+
+def get_new_address(seed: str):
+    secret_key = CBitcoinSecret.from_secret_bytes(hashlib.sha256(bytes(seed, "utf-8")).digest())
+    public_key = secret_key.pub
+    scriptPubKey = CScript([OP_0, Hash160(public_key)])
+    address = P2WPKHBitcoinAddress.from_scriptPubKey(scriptPubKey)
+    print(
+        {
+            "address": str(address),
+            "secret_key": str(secret_key),
+            "public_key": public_key.hex(),
+        }
+    )
+    return address, secret_key
+
+
+def sign_rawtransaction(rawtransaction, address, secret_key, amount=None):
+    tx = CMutableTransaction.deserialize(bytes.fromhex(rawtransaction))
+    txin_index = 0
+    redeem_script = address.to_redeemScript()
+    prev_txid = b2lx(tx.vin[txin_index].prevout.hash)
+    if not amount:
+        amount = get_tx_out_amount(prev_txid, tx.vin[txin_index].prevout.n)
+        amount = int(amount * 10e8)
+    # amount = int(10 * 10e8)
+    print("AMount", amount)
+    sighash = SignatureHash(
+        redeem_script, tx, txin_index, SIGHASH_ALL, amount=amount, sigversion=SIGVERSION_WITNESS_V0
+    )
+    signature = secret_key.sign(sighash) + bytes([SIGHASH_ALL])
+    witness = [signature, secret_key.pub]
+    ctxinwitnesses = [CTxInWitness(CScriptWitness(witness))]
+    # clean scriptSig
+    vins = [CTxIn(tx.vin[0].prevout, CScript())]
+    signed_tx = CMutableTransaction(vins, tx.vout)
+    signed_tx.wit = CTxWitness(ctxinwitnesses)
+    return signed_tx.serialize().hex()
+
+
+def send_funds_to_address(address):
+    source_with_xcp = api_call("assets/XCP/balances", {"limit": 1})["result"][0]["address"]
+    sh.python3(
+        "tools/xcpcli.py",
+        "send_send",
+        "--address",
+        source_with_xcp,
+        "--asset",
+        "XCP",
+        "--quantity",
+        int(10 * 10e8),
+        "--destination",
+        str(address),
+        _out=sys.stdout,
+        _err=sys.stdout,
+    )
+    sh.python3(
+        "tools/xcpcli.py",
+        "send_send",
+        "--address",
+        source_with_xcp,
+        "--asset",
+        "BTC",
+        "--quantity",
+        int(10 * 10e8),
+        "--destination",
+        str(address),
+        _out=sys.stdout,
+        _err=sys.stdout,
+    )
+    return source_with_xcp
+
+
+bitcoin_cli = bake_bitcoin_clients()
+
+# generate a new address
+address, secret_key = get_new_address("correct horse battery staple")
+# send XCP and BTC to this address
+destination_address = send_funds_to_address(address)
+# mine a block
+bitcoin_cli("generatetoaddress", 1, destination_address)
+time.sleep(10)
+
+# generate unsigned pretx
+unsigned_pretx_hex = api_call(
+    f"addresses/{str(address)}/compose/send",
+    {
+        "asset": "XCP",
+        "quantity": 5000,
+        "destination": destination_address,
+        "encoding": "p2sh",
+        "fee_per_kb": 1000,
+        "pubkeys": secret_key.pub.hex(),
+    },
+)["result"]["unsigned_pretx_hex"]
+print("unsigned_pretx_hex:", unsigned_pretx_hex)
+
+# sign pretx
+signed_pretx_hex = sign_rawtransaction(unsigned_pretx_hex, address, secret_key, int(10 * 10e8))
+print("signed_pretx_hex:", signed_pretx_hex)
+
+# broadcast pretx and get pretx_txid
+pretx_txid = bitcoin_cli("sendrawtransaction", signed_pretx_hex).strip()
+print("pretx_txid", pretx_txid)
+# mine a block
+bitcoin_cli("generatetoaddress", 1, destination_address)
+time.sleep(10)
+
+# generate final tx
+unsigned_finaltx_hex = api_call(
+    f"addresses/{str(address)}/compose/send",
+    {
+        "asset": "XCP",
+        "quantity": 5000,
+        "destination": destination_address,
+        "encoding": "p2sh",
+        "fee_per_kb": 1000,
+        "pubkeys": secret_key.pub.hex(),
+        "p2sh_pretx_txid": pretx_txid,
+    },
+)["result"]["rawtransaction"]
+print("unsigned_finaltx_hex:", unsigned_finaltx_hex)
+
+# sign and broadcast final tx
+signed_finaltx_hex = sign_rawtransaction(unsigned_finaltx_hex, address, secret_key)
+print("signed_finaltx_hex:", signed_finaltx_hex)
+txid = bitcoin_cli("sendrawtransaction", signed_finaltx_hex).strip()

--- a/counterparty-core/counterpartycore/test/regtest/testp2sh.py
+++ b/counterparty-core/counterpartycore/test/regtest/testp2sh.py
@@ -145,11 +145,12 @@ time.sleep(10)
 
 # generate unsigned pretx
 unsigned_pretx_hex = api_call(
-    f"addresses/{str(address)}/compose/send",
+    f"addresses/{str(address)}/compose/broadcast",
     {
-        "asset": "XCP",
-        "quantity": 5000,
-        "destination": destination_address,
+        "value": 1,
+        "fee_fraction": 0.5,
+        "timestamp": 4003903985,
+        "text": "un broadcast avec une transaction p2sh",
         "encoding": "p2sh",
         "fee_per_kb": 1000,
         "pubkeys": secret_key.pub.hex(),
@@ -172,11 +173,12 @@ time.sleep(10)
 
 # generate final tx
 unsigned_finaltx_hex = api_call(
-    f"addresses/{str(address)}/compose/send",
+    f"addresses/{str(address)}/compose/broadcast",
     {
-        "asset": "XCP",
-        "quantity": 5000,
-        "destination": destination_address,
+        "value": 1,
+        "fee_fraction": 0.5,
+        "timestamp": 4003903985,
+        "text": "un broadcast avec une transaction p2sh",
         "encoding": "p2sh",
         "fee_per_kb": 1000,
         "pubkeys": secret_key.pub.hex(),

--- a/counterparty-core/tools/xcpcli.py
+++ b/counterparty-core/tools/xcpcli.py
@@ -184,9 +184,10 @@ def sign_and_send_transaction(result):
         return
     check_bitcoin_cli_is_installed()
     bitcoin_cli, bitcoin_wallet = bake_bitcoin_clients()
-    signed_transaction_json = bitcoin_wallet(
-        "signrawtransactionwithwallet", result["result"]["rawtransaction"]
-    ).strip()
+    rawtransaction = result["result"].get("rawtransaction") or result["result"].get(
+        "unsigned_pretx_hex"
+    )
+    signed_transaction_json = bitcoin_wallet("signrawtransactionwithwallet", rawtransaction).strip()
     signed_transaction = json.loads(signed_transaction_json)["hex"]
     tx_hash = bitcoin_wallet("sendrawtransaction", signed_transaction, 0).strip()
     cprint(f"Transaction sent: {tx_hash}", "green")


### PR DESCRIPTION
It seems that the `p2sh` encoding is no longer supported by the latest versions of Bitcoin Core.
When we try to broadcast the second transaction we get the following error:
```
mandatory-script-verify-flag-failed (Operation not valid with the current stack size)
```
Here is the transaction not signed:
```
01000000018a3dc8eb1a64037ef4ec078bc7e55ffe506d39f4c1c9591e469b5f9f51b69dc1000000005a4c582e434e5452505254590200000000000000010000000000001388807b0e97b29c9eb1c4dfb5 9ba2c2261a39e9f0aa8a75210378d430274f8c5ec1321338151e9f27f4c676a008bdf8638d07c0b6be9ab35c71ad0075740087ffffffff0100000000000000000e6a0c0f03fa46c0245f1b32e7fc6800000000
```
and the same transaction signed:
```
010000000001018a3dc8eb1a64037ef4ec078bc7e55ffe506d39f4c1c9591e469b5f9f51b69dc10000000000ffffffff0100000000000000000e6a0c0f03fa46c0245f1b32e7fc68024830450221008fcf00afccc09536f1f005dd4d29801ce666461 c350ffbe834ad290013a9d17302205804841b4923e34f1fcaca7f48ecfc0f1fe6ec639a5bbd12660a7c9fbb3175f801210378d430274f8c5ec1321338151e9f27f4c6 76a008bdf8638d07c0b6be9ab35c7100000000 
``` 
(https://btc.com/tools/tx/decode)

it is possible to reproduce the error with the script `test/regtest/testp2sh.py` whose output is as follows:

```
$ python3 counterpartycore/test/regtest/testp2sh.py 
{'address': 'bcrt1q08alc0e5ua69scxhvyma568nvguqccrvah6ml0', 'secret_key': 'cUB8G5cFtxc4usfgfovqRgCo8qTQUJtctLV8t6YYNfULg3GtehdX', 'public_key': '0378d430274f8c5ec1321338151e9f27f4c676a008bdf8638d07c0b6be9ab35c71'}
{
  "result": {
    "params": {
      "source": "bcrt1q0v8f0v5un6cufha4nw3vyfs6885lp252fehe5d",
      "destination": "bcrt1q08alc0e5ua69scxhvyma568nvguqccrvah6ml0",
      "asset": "XCP",
      "quantity": 10000000000,
      "memo": null,
      "memo_is_hex": false,
      "use_enhanced_send": false
    },
    "name": "send",
    "data": "434e54525052545900000000000000000000000100000002540be400",
    "btc_in": 5000000000,
    "btc_out": 546,
    "btc_change": 4999992879,
    "btc_fee": 6575,
    "rawtransaction": "020000000001017413b5f17308caf75d330f2e492ed091537fd7707288fab07fa6fa4b3e88c08f000000001600147b0e97b29c9eb1c4dfb59ba2c2261a39e9f0aa8affffffff03220200000000000016001479fbfc3f34e7745860d76137da68f362380c606c00000000000000001e6a1c421e2e08c91ee41858882b4b6ef00e32a43ee4869de9c48a2538afd32fd6052a010000001600147b0e97b29c9eb1c4dfb59ba2c2261a39e9f0aa8a02000000000000"
  }
}
Transaction sent: 4c23ffba7743e536edc8d5f2a2e40a31a0bd5daf8c4d416ad810fbbff722f6f2
{
  "result": {
    "params": {
      "source": "bcrt1q0v8f0v5un6cufha4nw3vyfs6885lp252fehe5d",
      "destination": "bcrt1q08alc0e5ua69scxhvyma568nvguqccrvah6ml0",
      "asset": "BTC",
      "quantity": 10000000000,
      "memo": null,
      "memo_is_hex": false,
      "use_enhanced_send": false
    },
    "name": "send",
    "data": null,
    "btc_in": 15000000000,
    "btc_out": 10000000000,
    "btc_change": 4999985325,
    "btc_fee": 14675,
    "rawtransaction": "0200000000010369be192a9182b3b9325ef97e26cc8b5dd27ca7fe572b2dfb1b972319cd5f2bec000000001600147b0e97b29c9eb1c4dfb59ba2c2261a39e9f0aa8affffffff39ac255fbcf1b4e04daaf16eb495972577346c7047ceaef3cfb0c7322b7df295000000001600147b0e97b29c9eb1c4dfb59ba2c2261a39e9f0aa8affffffff4032b4b103363b8508429197df749819f9430e1c17b441af535549bad0354779000000001600147b0e97b29c9eb1c4dfb59ba2c2261a39e9f0aa8affffffff0200e40b540200000016001479fbfc3f34e7745860d76137da68f362380c606cadb8052a010000001600147b0e97b29c9eb1c4dfb59ba2c2261a39e9f0aa8a02000002000002000000000000"
  }
}
Transaction sent: e1f28ecb82633ffc031744587b39ad83213279413680f08ae2f62914245f5e41
unsigned_pretx_hex: 0100000001415e5f241429f6e28af080364179322183ad397b58441703fc3f6382cb8ef2e10000000016001479fbfc3f34e7745860d76137da68f362380c606cffffffff02220200000000000017a9146ea36487cfd933605f8b1d56a37c3216981ff9f587f8e00b540200000016001479fbfc3f34e7745860d76137da68f362380c606c00000000
AMount 10000000000
signed_pretx_hex: 01000000000101415e5f241429f6e28af080364179322183ad397b58441703fc3f6382cb8ef2e10000000000ffffffff02220200000000000017a9146ea36487cfd933605f8b1d56a37c3216981ff9f587f8e00b540200000016001479fbfc3f34e7745860d76137da68f362380c606c02483045022100b649cb853319dd90c33444e0a5c88383a07aeb795b0c7285713a55c4c2c4712902204d494ff3b4671d033b87f29de45a912153dc2e2d9c46dec55ca65366d998814201210378d430274f8c5ec1321338151e9f27f4c676a008bdf8638d07c0b6be9ab35c7100000000
pretx_txid c19db6519f5f9b461e59c9c1f4396d50fe5fe5c78b07ecf47e03641aebc83d8a
unsigned_finaltx_hex: 01000000018a3dc8eb1a64037ef4ec078bc7e55ffe506d39f4c1c9591e469b5f9f51b69dc1000000005a4c582e434e5452505254590200000000000000010000000000001388807b0e97b29c9eb1c4dfb59ba2c2261a39e9f0aa8a75210378d430274f8c5ec1321338151e9f27f4c676a008bdf8638d07c0b6be9ab35c71ad0075740087ffffffff0100000000000000000e6a0c0f03fa46c0245f1b32e7fc6800000000
signed_finaltx_hex: 010000000001018a3dc8eb1a64037ef4ec078bc7e55ffe506d39f4c1c9591e469b5f9f51b69dc10000000000ffffffff0100000000000000000e6a0c0f03fa46c0245f1b32e7fc68024830450221008fcf00afccc09536f1f005dd4d29801ce666461c350ffbe834ad290013a9d17302205804841b4923e34f1fcaca7f48ecfc0f1fe6ec639a5bbd12660a7c9fbb3175f801210378d430274f8c5ec1321338151e9f27f4c676a008bdf8638d07c0b6be9ab35c7100000000
Traceback (most recent call last):
  File "/home/ouziel/counterparty/counterparty-core/counterparty-core/counterpartycore/test/regtest/testp2sh.py", line 152, in <module>
    txid = bitcoin_cli("sendrawtransaction", signed_finaltx_hex).strip()
  File "/home/ouziel/.local/lib/python3.10/site-packages/sh.py", line 1508, in __call__
    rc = self.__class__.RunningCommandCls(cmd, call_args, stdin, stdout, stderr)
  File "/home/ouziel/.local/lib/python3.10/site-packages/sh.py", line 737, in __init__
    self.wait()
  File "/home/ouziel/.local/lib/python3.10/site-packages/sh.py", line 799, in wait
    self.handle_command_exit_code(exit_code)
  File "/home/ouziel/.local/lib/python3.10/site-packages/sh.py", line 826, in handle_command_exit_code
    raise exc
sh.ErrorReturnCode_26: 

  RAN: /home/ouziel/bitcoin-27.0/bin/bitcoin-cli -rpcuser=rpc -rpcpassword=rpc -rpcconnect=localhost -regtest sendrawtransaction 010000000001018a3dc8eb1a64037ef4ec078bc7e55ffe506d39f4c1c9591e469b5f9f51b69dc10000000000ffffffff0100000000000000000e6a0c0f03fa46c0245f1b32e7fc68024830450221008fcf00afccc09536f1f005dd4d29801ce666461c350ffbe834ad290013a9d17302205804841b4923e34f1fcaca7f48ecfc0f1fe6ec639a5bbd12660a7c9fbb3175f801210378d430274f8c5ec1321338151e9f27f4c676a008bdf8638d07c0b6be9ab35c7100000000

  STDOUT:


  STDERR:
error code: -26
error message:
mandatory-script-verify-flag-failed (Operation not valid with the current stack size)
```

If this is confirmed, it would be necessary to disable the `p2sh` encoding.