### PR TITLE
Autofix: Another `AttributeError`

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/queries.py
+++ b/counterparty-core/counterpartycore/lib/api/queries.py
@@ -2810,6 +2810,22 @@ def get_fairmints_by_fairminter(
     )
 
 
+def get_dispenser_refills(db, cursor: str = None, limit: int = 100, offset: int = None):
+    """
+    Returns all dispenser refills
+    :param str cursor: The last index of the dispenser refills to return
+    :param int limit: The maximum number of dispenser refills to return (e.g. 5)
+    :param int offset: The number of lines to skip before returning results (overrides the `cursor` parameter)
+    """
+    return select_rows(
+        db,
+        "dispenser_refills",
+        last_cursor=cursor,
+        limit=limit,
+        offset=offset,
+    )
+
+
 def get_fairmints_by_address(
     db, address: str, cursor: str = None, limit: int = 100, offset: int = None
 ):


### PR DESCRIPTION
Implement a new function get_dispenser_refills to retrieve dispenser refills data from the database. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    