### PR TITLE
Fix `verbose=True` when `give_asset` or `get_asset` contain an `asset_longname`

### DIFF
--- a/counterparty-core/counterpartycore/lib/ledger.py
+++ b/counterparty-core/counterpartycore/lib/ledger.py
@@ -904,7 +904,7 @@ def get_assets_last_issuance(state_db, asset_list):
         },
     }
     for asset_info in assets_info:
-        if asset_info["asset_longname"] in asset_list:
+        if asset_info["asset_longname"] and asset_info["asset_longname"] in asset_list:
             result[asset_info["asset_longname"]] = asset_info
             result[asset_info["asset"]] = asset_info
         else:

--- a/counterparty-core/counterpartycore/test/fixtures/api_v2_fixtures.json
+++ b/counterparty-core/counterpartycore/test/fixtures/api_v2_fixtures.json
@@ -6534,6 +6534,7 @@
                         "fee_required": 900000,
                         "status": "open",
                         "give_asset_info": {
+                            "asset": "XCP",
                             "asset_longname": null,
                             "description": "The Counterparty protocol native currency",
                             "issuer": null,

--- a/counterparty-core/counterpartycore/test/fixtures/api_v2_fixtures.json
+++ b/counterparty-core/counterpartycore/test/fixtures/api_v2_fixtures.json
@@ -6534,7 +6534,6 @@
                         "fee_required": 900000,
                         "status": "open",
                         "give_asset_info": {
-                            "asset": "XCP",
                             "asset_longname": null,
                             "description": "The Counterparty protocol native currency",
                             "issuer": null,

--- a/release-notes/release-notes-v10.9.0.md
+++ b/release-notes/release-notes-v10.9.0.md
@@ -13,6 +13,7 @@
 - Catch errors correctly when composing MPMA send
 - Fix query to fill `issuances.asset_events` field
 - Fix `assets_info.supply` field
+- Fix `verbose=True` when `give_asset` or `get_asset` contain an `asset_longname`
 
 ## Codebase
 


### PR DESCRIPTION
* [x] Double-check the spelling and grammar of all strings, code comments, etc.
* [x] Double-check that all code is deterministic that needs to be
* [x] Add tests to cover any new or revised logic
* [x] Ensure that the test suite passes
* [x] Update the project [release notes](release-notes/)
* [x] Update the project documentation, as appropriate, with a corresponding Pull Request in the [Documentation repository](https://github.com/CounterpartyXCP/Documentation)
