### PR TITLE
No taproot encoding for detach

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/composer.py
+++ b/counterparty-core/counterpartycore/lib/api/composer.py
@@ -174,12 +174,17 @@ def determine_encoding(data, destinations, construct_params):
             encoding = "multisig"
     else:
         encoding = desired_encoding
-    if len(destinations) > 0 and encoding == "taproot":
-        raise exceptions.ComposeError(
-            "Cannot use `taproot` encoding for transactions with destinations"
-        )
+    if encoding == "taproot":
+        if len(destinations) > 0:
+            raise exceptions.ComposeError(
+                "Cannot use `taproot` encoding for transactions with destinations"
+            )
+        message_type_id, _message = messagetype.unpack(data)
+        if message_type_id == messages.detach.ID:
+            raise exceptions.ComposeError("Cannot use `taproot` encoding for `detach` transaction")
     if encoding not in ("multisig", "opreturn", "taproot"):
         raise exceptions.ComposeError(f"Not supported encoding: {encoding}")
+
     return encoding
 
 

--- a/counterparty-core/counterpartycore/test/integrations/regtest/taprootdata_test.py
+++ b/counterparty-core/counterpartycore/test/integrations/regtest/taprootdata_test.py
@@ -2,9 +2,11 @@ import binascii
 import os
 import time
 
+import pytest
 from bitcoinutils.keys import PrivateKey
 from bitcoinutils.setup import setup
 from bitcoinutils.transactions import Transaction, TxWitnessInput
+from counterpartycore.lib import exceptions
 from regtestnode import RegtestNodeThread, rpc_call
 
 SENDS_COUNT = {}
@@ -600,7 +602,11 @@ def test_p2ptr_inscription():
         utxo = check_fairmint(node, source_private_key, utxo)
         utxo = check_dispensers(node, source_private_key, utxo)
         attached_utxo = send_funds_to_utxo(node, source_private_key)
-        utxo = check_detach(node, source_private_key, attached_utxo)
+        with pytest.raises(
+            exceptions.ComposeError, match="Cannot use `taproot` encoding for `detach` transaction"
+        ):
+            check_detach(node, source_private_key, attached_utxo)
+
         utxo_2 = check_issuance(node, source_private_key_2, utxo_2)
         utxo_2, order_hash = check_order(node, source_private_key_2, utxo_2)
         utxo_2 = check_cancel(node, source_private_key_2, utxo_2, order_hash)

--- a/release-notes/release-notes-v11.0.0.md
+++ b/release-notes/release-notes-v11.0.0.md
@@ -50,7 +50,7 @@ counterparty-server start
 - Add `max_mint_per_address` parameter to Fairminters
 - Ensure Fairminter hard cap is a multiple of the lot size
 - Use asset ID instead of asset name in Fairminter and Fairmint messages
-- Add Taproot envelope data encoding support
+- Add Taproot envelope data encoding support (disabled for transactions with a destination output and `detach`)
 - Add support for Taproot change address
 - Remove P2SH data encoding support
 - Use an envelope script compatible with Ordinals when the description/text of a Fairminter, Issuance or Broadcast is not empty


### PR DESCRIPTION
This works if the destination is specified, otherwise it goes to the commit address which is generated with a random private key. Anyway, OP_RETURN is more than enough for the `detach`

---------------

* [x] Double-check the spelling and grammar of all strings, code comments, etc.
* [x] Double-check that all code is deterministic that needs to be
* [x] Add tests to cover any new or revised logic
* [x] Ensure that the test suite passes
* [x] Update the project [release notes](release-notes/)
* [x] Update the project documentation, as appropriate, with a corresponding Pull Request in the [Documentation repository](https://github.com/CounterpartyXCP/Documentation)
