### PR TITLE
Fix/verbose response size limit #3193

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/apiserver.py
+++ b/counterparty-core/counterpartycore/lib/api/apiserver.py
@@ -393,6 +393,14 @@ def handle_route(**kwargs):
         # inject details
         is_verbose = request.args.get("verbose", "False")
         if is_verbose.lower() in ["true", "1"]:
+            # Add a safety check for verbose mode with large result sets
+            if isinstance(result, list) and len(result) > 100:
+                return return_result(
+                    413, 
+                    error="Response too large for verbose mode. Please use verbose=false or reduce the limit parameter to 100 or less.",
+                    start_time=start_time,
+                    query_args=query_args
+                )
             with LedgerDBConnectionPool().connection() as ledger_db:
                 with StateDBConnectionPool().connection() as state_db:
                     result = verbose.inject_details(ledger_db, state_db, result, table)


### PR DESCRIPTION
This commit addresses issue #3193 where the V2 API returns HTTP 500 errors when using verbose=true with large result sets (>25 transactions).

Changes:
- Add batch processing in inject_transactions_events() to process transactions in groups of 25 to prevent memory issues
- Add response size check in apiserver.py that returns HTTP 413 error with clear message when verbose mode is requested with >100 results
- Add test coverage for the new verbose mode limit

The fix ensures users get clear error messages instead of cryptic HTTP 500 errors and prevents server overload from large verbose responses.

Fixes #3193

## NOTE: This is not yet fully tested, pushing in to hopefully speed up patch time of the issue :) 