### PR TITLE
Support Sub-1 sat/vByte Fee Rates

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/composer.py
+++ b/counterparty-core/counterpartycore/lib/api/composer.py
@@ -1018,7 +1018,7 @@ def prepare_inputs_and_change(db, source, outputs, unspent_list, construct_param
         needed_fee = sat_per_vbyte * adjusted_vsize
         if max_fee is not None:
             needed_fee = min(needed_fee, max_fee)
-        needed_fee = int(needed_fee)
+        needed_fee = math.ceil(needed_fee)
 
         # if change is enough for needed fee, add change output and break
         if change_amount >= needed_fee:

--- a/counterparty-core/counterpartycore/test/integrations/regtest/regtestnode.py
+++ b/counterparty-core/counterpartycore/test/integrations/regtest/regtestnode.py
@@ -2,6 +2,7 @@
 
 import binascii
 import json
+import math
 import os
 import signal
 import struct
@@ -1156,7 +1157,7 @@ class RegtestNode:
             unsigned_tx["signed_tx_estimated_size"]["vsize"],
             unsigned_tx["signed_tx_estimated_size"]["adjusted_vsize"],
         )
-        assert unsigned_tx["btc_fee"] == int(size * 2.31)
+        assert unsigned_tx["btc_fee"] == math.ceil(size * 2.31)
 
         legacy_address = self.bitcoin_wallet("getnewaddress", WALLET_NAME, "legacy").strip()
         self.send_transaction(


### PR DESCRIPTION
Replace \`int()\` with \`math.ceil()\` when calculating transaction fees in the composer. This properly supports fractional sat/vByte rates like 0.5 or 0.1 that can come from Bitcoin Core's \`estimatesmartfee\`.

Without this fix, \`int(0.5 * 100)\` would work correctly (50), but edge cases like \`int(0.1 * 5)\` would truncate to 0 instead of rounding up to 1.