### PR TITLE
Support Multiple Electrs Backends with Failover

### DIFF
--- a/counterparty-core/counterpartycore/lib/backend/__init__.py
+++ b/counterparty-core/counterpartycore/lib/backend/__init__.py
@@ -10,7 +10,7 @@ def list_unspent(source, allow_unconfirmed_inputs):
         return unspent_list
 
     # then try with Electrs
-    if config.ELECTRS_URL is None:
+    if not config.ELECTRS_URLS:
         raise exceptions.ComposeError(
             "No UTXOs found with Bitcoin Core and Electrs is not configured, use the `inputs_set` parameter to provide UTXOs"
         )
@@ -24,7 +24,7 @@ def search_pubkey(source, tx_hashes=None):
         if pubkey is not None:
             return pubkey
     # then search with Electrs
-    if config.ELECTRS_URL is None:
+    if not config.ELECTRS_URLS:
         return None
     pubkey = electrs.search_pubkey(source)
     if pubkey is not None:

--- a/counterparty-core/counterpartycore/lib/backend/electrs.py
+++ b/counterparty-core/counterpartycore/lib/backend/electrs.py
@@ -10,14 +10,22 @@ logger = logging.getLogger(config.LOGGER_NAME)
 
 
 def electr_query(url):
-    if config.ELECTRS_URL is None:
+    if not config.ELECTRS_URLS:
         raise exceptions.ElectrsError("Electrs server not configured")
-    try:
-        full_url = f"{config.ELECTRS_URL}/{url}"
-        logger.debug("Querying Electrs: %s", full_url)
-        return requests.get(full_url, timeout=10).json()
-    except requests.exceptions.RequestException as e:
-        raise exceptions.ElectrsError(f"Electrs error: {e}") from e
+    last_error = None
+    for base_url in config.ELECTRS_URLS:
+        try:
+            full_url = f"{base_url}/{url}"
+            logger.debug("Querying Electrs: %s", full_url)
+            response = requests.get(full_url, timeout=10)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            logger.warning("Electrs request failed for %s: %s", base_url, e)
+            last_error = e
+    raise exceptions.ElectrsError(
+        f"All Electrs backends failed. Last error: {last_error}"
+    ) from last_error
 
 
 def get_utxos(address, unconfirmed: bool = False, unspent_tx_hash: str = None):

--- a/counterparty-core/counterpartycore/lib/cli/initialise.py
+++ b/counterparty-core/counterpartycore/lib/cli/initialise.py
@@ -532,20 +532,25 @@ def initialise_config(
     config.GUNICORN_WORKERS = gunicorn_workers
 
     if electrs_url:
-        if not helpers.is_url(electrs_url):
-            raise exceptions.ConfigurationError("Invalid Electrs URL")
-        config.ELECTRS_URL = electrs_url
+        if isinstance(electrs_url, str):
+            electrs_url = [electrs_url]
+        for url in electrs_url:
+            if not helpers.is_url(url):
+                raise exceptions.ConfigurationError(f"Invalid Electrs URL: {url}")
+        config.ELECTRS_URLS = electrs_url
+        config.ELECTRS_URLS_IS_DEFAULT = False
     else:
         if config.NETWORK_NAME == "testnet":
-            config.ELECTRS_URL = config.DEFAULT_ELECTRS_URL_TESTNET3
-        if config.NETWORK_NAME == "testnet4":
-            config.ELECTRS_URL = config.DEFAULT_ELECTRS_URL_TESTNET4
+            config.ELECTRS_URLS = config.DEFAULT_ELECTRS_URLS_TESTNET3
+        elif config.NETWORK_NAME == "testnet4":
+            config.ELECTRS_URLS = config.DEFAULT_ELECTRS_URLS_TESTNET4
         elif config.NETWORK_NAME == "mainnet":
-            config.ELECTRS_URL = config.DEFAULT_ELECTRS_URL_MAINNET
+            config.ELECTRS_URLS = config.DEFAULT_ELECTRS_URLS_MAINNET
         elif config.NETWORK_NAME == "signet":
-            config.ELECTRS_URL = config.DEFAULT_ELECTRS_URL_SIGNET
+            config.ELECTRS_URLS = config.DEFAULT_ELECTRS_URLS_SIGNET
         else:
-            config.ELECTRS_URL = None
+            config.ELECTRS_URLS = None
+        config.ELECTRS_URLS_IS_DEFAULT = config.ELECTRS_URLS is not None
 
     config.API_ONLY = api_only
     config.PROFILE = profile

--- a/counterparty-core/counterpartycore/lib/cli/main.py
+++ b/counterparty-core/counterpartycore/lib/cli/main.py
@@ -388,7 +388,8 @@ CONFIG_ARGS = [
     [
         ("--electrs-url",),
         {
-            "help": "the complete URL of the Electrs API, possibly including a specific port, for example: `https://mempool.space/api`",
+            "action": "append",
+            "help": "the complete URL of an Electrs API. Can be specified multiple times for failover. Example: `https://mempool.space/api`",
         },
     ],
     [
@@ -481,6 +482,13 @@ def welcome_message(action, server_configfile):
         cprint(f"API Access Log: {config.API_LOG}", "light_grey")
     else:
         cprint("Warning: API access log disabled", "yellow")
+
+    if getattr(config, "ELECTRS_URLS_IS_DEFAULT", False):
+        cprint(
+            "Warning: Using default Electrs URLs; not recommended for production. "
+            "Set --electrs-url to your own Electrs server.",
+            "yellow",
+        )
 
     cprint(f"Python version: {sys.version}", "light_grey")
 

--- a/counterparty-core/counterpartycore/lib/cli/setup.py
+++ b/counterparty-core/counterpartycore/lib/cli/setup.py
@@ -147,6 +147,13 @@ def add_config_arguments(parser, args, configfile, add_default=False):
                 and key in configfile["Default"]
             ):
                 arg[1]["default"] = configfile["Default"].getboolean(key)
+            elif (
+                "action" in arg[1]
+                and arg[1]["action"] == "append"
+                and key in configfile["Default"]
+                and configfile["Default"][key]
+            ):
+                arg[1]["default"] = [configfile["Default"][key]]
             elif key in configfile["Default"] and configfile["Default"][key]:
                 arg[1]["default"] = configfile["Default"][key]
             elif (

--- a/counterparty-core/counterpartycore/lib/config.py
+++ b/counterparty-core/counterpartycore/lib/config.py
@@ -15,10 +15,13 @@ VERSION_MINOR = int(version[1])
 VERSION_REVISION = int(version[2])
 VERSION_PRE_RELEASE = "-".join(VERSION_STRING.split("-")[1:])
 
-DEFAULT_ELECTRS_URL_MAINNET = "https://blockstream.info/api"
-DEFAULT_ELECTRS_URL_TESTNET3 = "https://blockstream.info/testnet/api"
-DEFAULT_ELECTRS_URL_TESTNET4 = "https://mempool.space/testnet4/api"
-DEFAULT_ELECTRS_URL_SIGNET = "https://mempool.space/signet/api"
+DEFAULT_ELECTRS_URLS_MAINNET = [
+    "https://blockstream.info/api",
+    "https://mempool.space/api",
+]
+DEFAULT_ELECTRS_URLS_TESTNET3 = ["https://blockstream.info/testnet/api"]
+DEFAULT_ELECTRS_URLS_TESTNET4 = ["https://mempool.space/testnet4/api"]
+DEFAULT_ELECTRS_URLS_SIGNET = ["https://mempool.space/signet/api"]
 
 
 UPGRADE_ACTIONS = {

--- a/counterparty-core/counterpartycore/test/units/backend/backend_init_test.py
+++ b/counterparty-core/counterpartycore/test/units/backend/backend_init_test.py
@@ -48,15 +48,15 @@ def test_list_unspent_fallback_to_electrs_direct(monkeypatch):
 
     importlib.reload(backend)
 
-    # Save original and set ELECTRS_URL
-    original_electrs_url = getattr(config, "ELECTRS_URL", None)
-    config.ELECTRS_URL = "http://localhost:3000"
+    # Save original and set ELECTRS_URLS
+    original_electrs_url = getattr(config, "ELECTRS_URLS", None)
+    config.ELECTRS_URLS = ["http://localhost:3000"]
 
     try:
         result = backend.list_unspent("test_source", True)
         assert result == expected_utxos
     finally:
-        config.ELECTRS_URL = original_electrs_url
+        config.ELECTRS_URLS = original_electrs_url
 
 
 def test_list_unspent_no_electrs_configured_direct(monkeypatch):
@@ -72,12 +72,12 @@ def test_list_unspent_no_electrs_configured_direct(monkeypatch):
 
     importlib.reload(backend)
 
-    # Save original and set ELECTRS_URL to None
-    original_electrs_url = getattr(config, "ELECTRS_URL", None)
-    config.ELECTRS_URL = None
+    # Save original and set ELECTRS_URLS to None
+    original_electrs_url = getattr(config, "ELECTRS_URLS", None)
+    config.ELECTRS_URLS = None
 
     try:
         with pytest.raises(exceptions.ComposeError, match="No UTXOs found"):
             backend.list_unspent("test_source", True)
     finally:
-        config.ELECTRS_URL = original_electrs_url
+        config.ELECTRS_URLS = original_electrs_url

--- a/counterparty-core/counterpartycore/test/units/backend/electrs_test.py
+++ b/counterparty-core/counterpartycore/test/units/backend/electrs_test.py
@@ -17,9 +17,9 @@ def mock_requests_get():
 # Tests for electr_query
 def test_electr_query_success(mock_requests_get):
     """Test the electr_query function with a successful result"""
-    # Ensure config.ELECTRS_URL is set before calling electr_query
-    previous_url = config.ELECTRS_URL
-    config.ELECTRS_URL = "http://localhost:3000"
+    # Ensure config.ELECTRS_URLS is set before calling electr_query
+    previous_url = config.ELECTRS_URLS
+    config.ELECTRS_URLS = ["http://localhost:3000"]
 
     mock_response = mock.Mock()
     mock_response.json.return_value = {"test": "data"}
@@ -31,25 +31,36 @@ def test_electr_query_success(mock_requests_get):
     assert result == {"test": "data"}
 
     # Restore original URL
-    config.ELECTRS_URL = previous_url
+    config.ELECTRS_URLS = previous_url
 
 
 def test_electr_query_no_url():
     """Test the electr_query function without a configured URL"""
-    previous_url = config.ELECTRS_URL
-    config.ELECTRS_URL = None
+    previous_url = config.ELECTRS_URLS
+    config.ELECTRS_URLS = None
 
     with pytest.raises(exceptions.ElectrsError, match="Electrs server not configured"):
         electrum_connector.electr_query("test/url")
 
     # Restore original URL
-    config.ELECTRS_URL = previous_url
+    config.ELECTRS_URLS = previous_url
+
+
+def test_electr_query_empty_list():
+    """Test the electr_query function with an empty URL list"""
+    previous_url = config.ELECTRS_URLS
+    config.ELECTRS_URLS = []
+
+    with pytest.raises(exceptions.ElectrsError, match="Electrs server not configured"):
+        electrum_connector.electr_query("test/url")
+
+    config.ELECTRS_URLS = previous_url
 
 
 def test_electr_query_request_exception(mock_requests_get):
     """Test the electr_query function when a request exception is raised"""
-    previous_url = config.ELECTRS_URL
-    config.ELECTRS_URL = "http://localhost:3000"
+    previous_url = config.ELECTRS_URLS
+    config.ELECTRS_URLS = ["http://localhost:3000"]
 
     mock_requests_get.side_effect = requests.RequestException("Connection error")
 
@@ -57,7 +68,63 @@ def test_electr_query_request_exception(mock_requests_get):
         electrum_connector.electr_query("test/url")
 
     # Restore original URL
-    config.ELECTRS_URL = previous_url
+    config.ELECTRS_URLS = previous_url
+
+
+def test_electr_query_failover(mock_requests_get):
+    """Test failover to second URL when first fails."""
+    previous_urls = config.ELECTRS_URLS
+    config.ELECTRS_URLS = ["http://first:3000", "http://second:3000"]
+
+    success_response = mock.Mock()
+    success_response.json.return_value = {"test": "data"}
+
+    mock_requests_get.side_effect = [
+        requests.RequestException("Connection refused"),
+        success_response,
+    ]
+
+    result = electrum_connector.electr_query("test/url")
+    assert result == {"test": "data"}
+    assert mock_requests_get.call_count == 2
+    mock_requests_get.assert_called_with("http://second:3000/test/url", timeout=10)
+
+    config.ELECTRS_URLS = previous_urls
+
+
+def test_electr_query_all_fail(mock_requests_get):
+    """Test error when all backends fail."""
+    previous_urls = config.ELECTRS_URLS
+    config.ELECTRS_URLS = ["http://first:3000", "http://second:3000"]
+
+    mock_requests_get.side_effect = requests.RequestException("Connection refused")
+
+    with pytest.raises(exceptions.ElectrsError, match="All Electrs backends failed"):
+        electrum_connector.electr_query("test/url")
+
+    assert mock_requests_get.call_count == 2
+
+    config.ELECTRS_URLS = previous_urls
+
+
+def test_electr_query_http_error_failover(mock_requests_get):
+    """Test failover on HTTP error (e.g. 500) to next backend."""
+    previous_urls = config.ELECTRS_URLS
+    config.ELECTRS_URLS = ["http://first:3000", "http://second:3000"]
+
+    fail_response = mock.Mock()
+    fail_response.raise_for_status.side_effect = requests.exceptions.HTTPError("500 Server Error")
+
+    success_response = mock.Mock()
+    success_response.json.return_value = {"test": "data"}
+
+    mock_requests_get.side_effect = [fail_response, success_response]
+
+    result = electrum_connector.electr_query("test/url")
+    assert result == {"test": "data"}
+    assert mock_requests_get.call_count == 2
+
+    config.ELECTRS_URLS = previous_urls
 
 
 # Tests for get_utxos
@@ -208,8 +275,8 @@ def test_get_utxos_empty_list():
 # Tests for get_history
 def test_get_history_confirmed_only():
     """Test get_history including only confirmed transactions"""
-    previous_url = config.ELECTRS_URL
-    config.ELECTRS_URL = "http://localhost:3000"
+    previous_url = config.ELECTRS_URLS
+    config.ELECTRS_URLS = ["http://localhost:3000"]
 
     with mock.patch("counterpartycore.lib.backend.electrs.electr_query") as mock_query:
         mock_query.return_value = [
@@ -224,13 +291,13 @@ def test_get_history_confirmed_only():
         mock_query.assert_called_once_with("address/test_address/txs")
 
     # Restore original URL
-    config.ELECTRS_URL = previous_url
+    config.ELECTRS_URLS = previous_url
 
 
 def test_get_history_include_unconfirmed():
     """Test get_history including unconfirmed transactions"""
-    previous_url = config.ELECTRS_URL
-    config.ELECTRS_URL = "http://localhost:3000"
+    previous_url = config.ELECTRS_URLS
+    config.ELECTRS_URLS = ["http://localhost:3000"]
 
     with mock.patch("counterpartycore.lib.backend.electrs.electr_query") as mock_query:
         mock_query.return_value = [
@@ -247,13 +314,13 @@ def test_get_history_include_unconfirmed():
         assert result == expected
 
     # Restore original URL
-    config.ELECTRS_URL = previous_url
+    config.ELECTRS_URLS = previous_url
 
 
 def test_get_history_empty_list():
     """Test get_history with an empty transaction list"""
-    previous_url = config.ELECTRS_URL
-    config.ELECTRS_URL = "http://localhost:3000"
+    previous_url = config.ELECTRS_URLS
+    config.ELECTRS_URLS = ["http://localhost:3000"]
 
     with mock.patch("counterpartycore.lib.backend.electrs.electr_query") as mock_query:
         mock_query.return_value = []
@@ -263,14 +330,14 @@ def test_get_history_empty_list():
         assert result == []
 
     # Restore original URL
-    config.ELECTRS_URL = previous_url
+    config.ELECTRS_URLS = previous_url
 
 
 # Tests for get_utxos_by_addresses
 def test_get_utxos_by_addresses():
     """Test get_utxos_by_addresses with multiple addresses"""
-    previous_url = config.ELECTRS_URL
-    config.ELECTRS_URL = "http://localhost:3000"
+    previous_url = config.ELECTRS_URLS
+    config.ELECTRS_URLS = ["http://localhost:3000"]
 
     with mock.patch("counterpartycore.lib.backend.electrs.get_utxos") as mock_get_utxos:
         mock_get_utxos.side_effect = [
@@ -318,13 +385,13 @@ def test_get_utxos_by_addresses():
         assert mock_get_utxos.call_count == 2
 
     # Restore original URL
-    config.ELECTRS_URL = previous_url
+    config.ELECTRS_URLS = previous_url
 
 
 def test_get_utxos_by_addresses_with_params():
     """Test get_utxos_by_addresses with additional parameters"""
-    previous_url = config.ELECTRS_URL
-    config.ELECTRS_URL = "http://localhost:3000"
+    previous_url = config.ELECTRS_URLS
+    config.ELECTRS_URLS = ["http://localhost:3000"]
 
     with mock.patch("counterpartycore.lib.backend.electrs.get_utxos") as mock_get_utxos:
         mock_get_utxos.return_value = [
@@ -355,13 +422,13 @@ def test_get_utxos_by_addresses_with_params():
         mock_get_utxos.assert_called_once_with("addr1", True, "tx1")
 
     # Restore original URL
-    config.ELECTRS_URL = previous_url
+    config.ELECTRS_URLS = previous_url
 
 
 def test_get_utxos_by_addresses_empty_string():
     """Test get_utxos_by_addresses with an empty string"""
-    previous_url = config.ELECTRS_URL
-    config.ELECTRS_URL = "http://localhost:3000"
+    previous_url = config.ELECTRS_URLS
+    config.ELECTRS_URLS = ["http://localhost:3000"]
 
     # Mock get_utxos to return an empty list when called
     with mock.patch("counterpartycore.lib.backend.electrs.get_utxos") as mock_get_utxos:
@@ -378,7 +445,7 @@ def test_get_utxos_by_addresses_empty_string():
         mock_get_utxos.assert_called_with("", False, None)
 
     # Restore original URL
-    config.ELECTRS_URL = previous_url
+    config.ELECTRS_URLS = previous_url
 
 
 # Tests for pubkey_from_tx
@@ -578,8 +645,8 @@ def test_pubkey_from_tx_coinbase():
 # Tests for search_pubkey
 def test_search_pubkey_found():
     """Test search_pubkey when the public key is found"""
-    previous_url = config.ELECTRS_URL
-    config.ELECTRS_URL = "http://localhost:3000"
+    previous_url = config.ELECTRS_URLS
+    config.ELECTRS_URLS = ["http://localhost:3000"]
 
     with (
         mock.patch("counterpartycore.lib.backend.electrs.get_history") as mock_get_history,
@@ -594,13 +661,13 @@ def test_search_pubkey_found():
         assert mock_pubkey_from_tx.call_count == 2
 
     # Restore original URL
-    config.ELECTRS_URL = previous_url
+    config.ELECTRS_URLS = previous_url
 
 
 def test_search_pubkey_not_found():
     """Test search_pubkey when the public key is not found"""
-    previous_url = config.ELECTRS_URL
-    config.ELECTRS_URL = "http://localhost:3000"
+    previous_url = config.ELECTRS_URLS
+    config.ELECTRS_URLS = ["http://localhost:3000"]
 
     with (
         mock.patch("counterpartycore.lib.backend.electrs.get_history") as mock_get_history,
@@ -615,13 +682,13 @@ def test_search_pubkey_not_found():
         assert mock_pubkey_from_tx.call_count == 2
 
     # Restore original URL
-    config.ELECTRS_URL = previous_url
+    config.ELECTRS_URLS = previous_url
 
 
 def test_search_pubkey_empty_history():
     """Test search_pubkey with an empty history"""
-    previous_url = config.ELECTRS_URL
-    config.ELECTRS_URL = "http://localhost:3000"
+    previous_url = config.ELECTRS_URLS
+    config.ELECTRS_URLS = ["http://localhost:3000"]
 
     with mock.patch("counterpartycore.lib.backend.electrs.get_history") as mock_get_history:
         mock_get_history.return_value = []
@@ -631,7 +698,7 @@ def test_search_pubkey_empty_history():
         assert result is None
 
     # Restore original URL
-    config.ELECTRS_URL = previous_url
+    config.ELECTRS_URLS = previous_url
 
 
 # Tests for list_unspent
@@ -639,8 +706,8 @@ def test_list_unspent_with_utxos():
     """Test list_unspent with available UTXOs"""
     previous_unit = getattr(config, "UNIT", None)
     config.UNIT = 10**8
-    previous_url = config.ELECTRS_URL
-    config.ELECTRS_URL = "http://localhost:3000"
+    previous_url = config.ELECTRS_URLS
+    config.ELECTRS_URLS = ["http://localhost:3000"]
 
     with mock.patch("counterpartycore.lib.backend.electrs.get_utxos") as mock_get_utxos:
         mock_get_utxos.return_value = [
@@ -659,15 +726,15 @@ def test_list_unspent_with_utxos():
 
     # Restore original values
     config.UNIT = previous_unit
-    config.ELECTRS_URL = previous_url
+    config.ELECTRS_URLS = previous_url
 
 
 def test_list_unspent_no_utxos():
     """Test list_unspent without available UTXOs"""
     previous_unit = getattr(config, "UNIT", None)
     config.UNIT = 10**8
-    previous_url = config.ELECTRS_URL
-    config.ELECTRS_URL = "http://localhost:3000"
+    previous_url = config.ELECTRS_URLS
+    config.ELECTRS_URLS = ["http://localhost:3000"]
 
     with mock.patch("counterpartycore.lib.backend.electrs.get_utxos") as mock_get_utxos:
         mock_get_utxos.return_value = []
@@ -679,14 +746,14 @@ def test_list_unspent_no_utxos():
 
     # Restore original values
     config.UNIT = previous_unit
-    config.ELECTRS_URL = previous_url
+    config.ELECTRS_URLS = previous_url
 
 
 # Tests for pubkeyhash_to_pubkey
 def test_pubkeyhash_to_pubkey():
     """Test pubkeyhash_to_pubkey"""
-    previous_url = config.ELECTRS_URL
-    config.ELECTRS_URL = "http://localhost:3000"
+    previous_url = config.ELECTRS_URLS
+    config.ELECTRS_URLS = ["http://localhost:3000"]
 
     with mock.patch("counterpartycore.lib.backend.electrs.search_pubkey") as mock_search_pubkey:
         mock_search_pubkey.return_value = "found_pubkey"
@@ -697,4 +764,31 @@ def test_pubkeyhash_to_pubkey():
         mock_search_pubkey.assert_called_once_with("test_address")
 
     # Restore original URL
-    config.ELECTRS_URL = previous_url
+    config.ELECTRS_URLS = previous_url
+
+
+# Tests for default URL configuration
+def test_default_electrs_urls_mainnet():
+    """Test that mainnet defaults include both blockstream and mempool."""
+    assert isinstance(config.DEFAULT_ELECTRS_URLS_MAINNET, list)
+    assert len(config.DEFAULT_ELECTRS_URLS_MAINNET) >= 2
+    assert "https://blockstream.info/api" in config.DEFAULT_ELECTRS_URLS_MAINNET
+    assert "https://mempool.space/api" in config.DEFAULT_ELECTRS_URLS_MAINNET
+
+
+def test_default_electrs_urls_testnet3():
+    """Test testnet3 default URL."""
+    assert isinstance(config.DEFAULT_ELECTRS_URLS_TESTNET3, list)
+    assert "https://blockstream.info/testnet/api" in config.DEFAULT_ELECTRS_URLS_TESTNET3
+
+
+def test_default_electrs_urls_testnet4():
+    """Test testnet4 default URL."""
+    assert isinstance(config.DEFAULT_ELECTRS_URLS_TESTNET4, list)
+    assert "https://mempool.space/testnet4/api" in config.DEFAULT_ELECTRS_URLS_TESTNET4
+
+
+def test_default_electrs_urls_signet():
+    """Test signet default URL."""
+    assert isinstance(config.DEFAULT_ELECTRS_URLS_SIGNET, list)
+    assert "https://mempool.space/signet/api" in config.DEFAULT_ELECTRS_URLS_SIGNET

--- a/counterparty-core/counterpartycore/test/units/cli/main_test.py
+++ b/counterparty-core/counterpartycore/test/units/cli/main_test.py
@@ -3,6 +3,32 @@ import os
 from counterpartycore.lib import cli
 
 
+def test_argparser_multiple_electrs_urls():
+    """Test that --electrs-url can be specified multiple times."""
+    parser = cli.main.arg_parser(no_config_file=True, app_name="counterparty-test")
+    args = parser.parse_args(
+        [
+            "--regtest",
+            "--electrs-url=http://first:3000",
+            "--electrs-url=http://second:3000",
+            "start",
+        ]
+    )
+    assert vars(args)["electrs_url"] == ["http://first:3000", "http://second:3000"]
+
+
+def test_argparser_no_electrs_url():
+    """Test that omitting --electrs-url results in None."""
+    parser = cli.main.arg_parser(no_config_file=True, app_name="counterparty-test")
+    args = parser.parse_args(
+        [
+            "--regtest",
+            "start",
+        ]
+    )
+    assert vars(args)["electrs_url"] is None
+
+
 def test_argparser():
     parser = cli.main.arg_parser(no_config_file=True, app_name="counterparty-test")
     args = parser.parse_args(
@@ -75,7 +101,7 @@ def test_argparser():
         "gunicorn_workers": 2,
         "gunicorn_threads_per_worker": 2,
         "bootstrap_url": None,
-        "electrs_url": "http://localhost:3002",
+        "electrs_url": ["http://localhost:3002"],
         "refresh_state_db": False,
         "rebuild_state_db": False,
         "action": "start",

--- a/counterparty-core/counterpartycore/test/units/cli/main_test.py
+++ b/counterparty-core/counterpartycore/test/units/cli/main_test.py
@@ -1,6 +1,9 @@
+import configparser
 import os
+import unittest.mock as mock
 
-from counterpartycore.lib import cli
+from counterpartycore.lib import cli, config
+from counterpartycore.lib.cli import initialise, main, setup
 
 
 def test_argparser_multiple_electrs_urls():
@@ -112,3 +115,137 @@ def test_argparser():
         "memory_profile": False,
         "enable_all_protocol_changes": False,
     }
+
+
+WELCOME_MSG_CONFIG_STUBS = [
+    ("VERBOSE", 0),
+    ("QUIET", False),
+    ("NETWORK_NAME", "mainnet"),
+    ("DATABASE", "test.db"),
+    ("STATE_DATABASE", "state.db"),
+    ("FETCHER_DB", "fetcher.db"),
+    ("LOG", "test.log"),
+    ("API_LOG", "api.log"),
+]
+
+
+def test_welcome_message_default_urls_warning():
+    """Test that welcome_message prints a warning when using default Electrs URLs."""
+    original = getattr(config, "ELECTRS_URLS_IS_DEFAULT", None)
+    config.ELECTRS_URLS_IS_DEFAULT = True
+    for attr, val in WELCOME_MSG_CONFIG_STUBS:
+        if not hasattr(config, attr):
+            setattr(config, attr, val)
+
+    with mock.patch("counterpartycore.lib.cli.main.cprint") as mock_cprint:
+        main.welcome_message("start", "server.conf")
+        warning_calls = [c for c in mock_cprint.call_args_list if "default Electrs URLs" in str(c)]
+        assert len(warning_calls) == 1
+        assert warning_calls[0][0][1] == "yellow"
+
+    if original is None:
+        del config.ELECTRS_URLS_IS_DEFAULT
+    else:
+        config.ELECTRS_URLS_IS_DEFAULT = original
+
+
+def test_welcome_message_no_warning_when_custom_urls():
+    """Test that welcome_message does not warn when user provided custom URLs."""
+    original = getattr(config, "ELECTRS_URLS_IS_DEFAULT", None)
+    config.ELECTRS_URLS_IS_DEFAULT = False
+    for attr, val in WELCOME_MSG_CONFIG_STUBS:
+        if not hasattr(config, attr):
+            setattr(config, attr, val)
+
+    with mock.patch("counterpartycore.lib.cli.main.cprint") as mock_cprint:
+        main.welcome_message("start", "server.conf")
+        warning_calls = [c for c in mock_cprint.call_args_list if "default Electrs URLs" in str(c)]
+        assert len(warning_calls) == 0
+
+    if original is None:
+        del config.ELECTRS_URLS_IS_DEFAULT
+    else:
+        config.ELECTRS_URLS_IS_DEFAULT = original
+
+
+INITIALISE_DEFAULTS = {
+    "backend_password": "rpc",
+    "backend_connect": "localhost",
+}
+
+
+def test_initialise_config_electrs_mainnet_defaults():
+    """Test that mainnet defaults set ELECTRS_URLS and IS_DEFAULT correctly."""
+    original_urls = getattr(config, "ELECTRS_URLS", None)
+    original_default = getattr(config, "ELECTRS_URLS_IS_DEFAULT", None)
+
+    initialise.initialise_config(electrs_url=None, **INITIALISE_DEFAULTS)
+
+    assert config.ELECTRS_URLS == config.DEFAULT_ELECTRS_URLS_MAINNET
+    assert config.ELECTRS_URLS_IS_DEFAULT is True
+
+    config.ELECTRS_URLS = original_urls
+    config.ELECTRS_URLS_IS_DEFAULT = original_default
+
+
+def test_initialise_config_electrs_custom_list():
+    """Test that a custom URL list sets IS_DEFAULT to False."""
+    original_urls = getattr(config, "ELECTRS_URLS", None)
+    original_default = getattr(config, "ELECTRS_URLS_IS_DEFAULT", None)
+
+    initialise.initialise_config(electrs_url=["http://my-server:3000"], **INITIALISE_DEFAULTS)
+
+    assert config.ELECTRS_URLS == ["http://my-server:3000"]
+    assert config.ELECTRS_URLS_IS_DEFAULT is False
+
+    config.ELECTRS_URLS = original_urls
+    config.ELECTRS_URLS_IS_DEFAULT = original_default
+
+
+def test_initialise_config_electrs_string_coerced_to_list():
+    """Test that a plain string electrs_url is coerced to a list."""
+    original_urls = getattr(config, "ELECTRS_URLS", None)
+    original_default = getattr(config, "ELECTRS_URLS_IS_DEFAULT", None)
+
+    initialise.initialise_config(electrs_url="http://my-server:3000", **INITIALISE_DEFAULTS)
+
+    assert config.ELECTRS_URLS == ["http://my-server:3000"]
+    assert config.ELECTRS_URLS_IS_DEFAULT is False
+
+    config.ELECTRS_URLS = original_urls
+    config.ELECTRS_URLS_IS_DEFAULT = original_default
+
+
+def test_initialise_config_electrs_regtest_none():
+    """Test that regtest with no electrs_url sets ELECTRS_URLS to None."""
+    original_urls = getattr(config, "ELECTRS_URLS", None)
+    original_default = getattr(config, "ELECTRS_URLS_IS_DEFAULT", None)
+
+    initialise.initialise_config(electrs_url=None, regtest=True, **INITIALISE_DEFAULTS)
+
+    assert config.ELECTRS_URLS is None
+    assert config.ELECTRS_URLS_IS_DEFAULT is False
+
+    config.ELECTRS_URLS = original_urls
+    config.ELECTRS_URLS_IS_DEFAULT = original_default
+
+
+def test_add_config_arguments_append_action():
+    """Test that add_config_arguments wraps append-action values from config file in a list."""
+    parser = cli.main.argparse.ArgumentParser()
+    configfile = configparser.ConfigParser()
+    configfile["Default"] = {"electrs-url": "http://from-config:3000"}
+
+    config_args = [
+        [
+            ("--electrs-url",),
+            {
+                "action": "append",
+                "help": "test",
+            },
+        ],
+    ]
+
+    setup.add_config_arguments(parser, config_args, configfile, add_default=True)
+    args = parser.parse_args([])
+    assert args.electrs_url == ["http://from-config:3000"]

--- a/release-notes/release-notes-v11.0.5.md
+++ b/release-notes/release-notes-v11.0.5.md
@@ -1,0 +1,9 @@
+# Release Notes - Counterparty Core v11.0.5 (TBD)
+
+# ChangeLog
+
+## Features
+
+- Support multiple Electrs backends with automatic failover on connection, timeout, or HTTP errors; `--electrs-url` can now be specified multiple times
+- Default mainnet Electrs backends to both `blockstream.info` and `mempool.space`
+- Print a startup warning when using default Electrs URLs (not recommended for production)


### PR DESCRIPTION
## Summary

The service previously relied on a single Blockstream API endpoint for UTXO lookups and pubkey searches, which is unreliable. This changes `config.ELECTRS_URL` (single string) to `config.ELECTRS_URLS` (list) with automatic failover on connection, timeout, or HTTP errors.

- `--electrs-url` can now be specified multiple times for failover
- Mainnet defaults to both `blockstream.info/api` and `mempool.space/api`
- Prints a startup warning when using default URLs (not recommended for production)
- Fixes a pre-existing `if`/`if` bug in `initialise.py` for testnet/testnet4 network selection

## Checklist

- [x] Double-check the spelling and grammar of all strings, code comments, etc.
- [x] Double-check that all code is deterministic that needs to be
- [x] Add tests to cover any new or revised logic
- [x] Ensure that the test suite passes
- [x] Update the project [release notes](release-notes/) (`release-notes-v11.0.5.md`)
- [x] Update the project documentation, as appropriate, with a corresponding Pull Request in the [Documentation repository](https://github.com/CounterpartyXCP/Documentation/pull/245)