### PR TITLE
Add cancel-all mode to cancel message (type 70)

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/apiwatcher.py
+++ b/counterparty-core/counterpartycore/lib/api/apiwatcher.py
@@ -43,6 +43,7 @@ EVENTS_ADDRESS_FIELDS = {
     "ORDER_MATCH": ["tx0_address", "tx1_address"],
     "BTC_PAY": ["source", "destination"],
     "CANCEL_ORDER": ["source"],
+    "CANCEL_ALL": ["source"],
     "ORDER_EXPIRATION": ["source"],
     "ORDER_MATCH_EXPIRATION": ["tx0_address", "tx1_address"],
     "OPEN_DISPENSER": ["source", "origin", "oracle_address"],

--- a/counterparty-core/counterpartycore/lib/api/compose.py
+++ b/counterparty-core/counterpartycore/lib/api/compose.py
@@ -106,11 +106,11 @@ def compose_burn(db, address: str, quantity: int, overburn: bool = False, **cons
     return composer.compose_transaction(db, "burn", params, construct_params)
 
 
-def compose_cancel(db, address: str, offer_hash: str, **construct_params):
+def compose_cancel(db, address: str, offer_hash: str = None, **construct_params):
     """
-    Composes a transaction to cancel an open order or bet.
+    Composes a transaction to cancel an open order or bet. If offer_hash is omitted, cancels all open orders and bets for the address.
     :param address: The address that placed the order/bet to be cancelled (e.g. $ADDRESS_6)
-    :param offer_hash: The hash of the order/bet to be cancelled (e.g. $LAST_OPEN_ORDER_TX_HASH)
+    :param offer_hash: The hash of the order/bet to be cancelled (e.g. $LAST_OPEN_ORDER_TX_HASH). If not provided, all open orders and bets for the address will be cancelled.
     """
     params = {"source": address, "offer_hash": offer_hash}
     return composer.compose_transaction(db, "cancel", params, construct_params)

--- a/counterparty-core/counterpartycore/lib/ledger/markets.py
+++ b/counterparty-core/counterpartycore/lib/ledger/markets.py
@@ -129,6 +129,22 @@ def get_open_btc_orders(db, address):
     return cursor.fetchall()
 
 
+def get_open_orders_by_source(db, source):
+    cursor = db.cursor()
+    query = """
+        SELECT * FROM (
+            SELECT *, MAX(rowid)
+            FROM orders
+            WHERE source = ?
+            GROUP BY tx_hash
+        ) WHERE status = ?
+        ORDER BY tx_index, tx_hash
+    """
+    bindings = (source, "open")
+    cursor.execute(query, bindings)
+    return cursor.fetchall()
+
+
 def get_matching_orders_no_cache(db, tx_hash, give_asset, get_asset):
     cursor = db.cursor()
     query = """

--- a/counterparty-core/counterpartycore/lib/ledger/other.py
+++ b/counterparty-core/counterpartycore/lib/ledger/other.py
@@ -246,6 +246,22 @@ def get_bet_by_feed(db, address: str, status: str = "open"):
     return cursor.fetchall()
 
 
+def get_open_bets_by_source(db, source):
+    cursor = db.cursor()
+    query = """
+        SELECT * FROM (
+            SELECT *, MAX(rowid)
+            FROM bets
+            WHERE source = ?
+            GROUP BY tx_hash
+        ) WHERE status = ?
+        ORDER BY tx_index, tx_hash
+    """
+    bindings = (source, "open")
+    cursor.execute(query, bindings)
+    return cursor.fetchall()
+
+
 ### UPDATES ###
 
 

--- a/counterparty-core/counterpartycore/lib/messages/cancel.py
+++ b/counterparty-core/counterpartycore/lib/messages/cancel.py
@@ -7,7 +7,7 @@ import logging
 import struct
 
 from counterpartycore.lib import config, exceptions, ledger
-from counterpartycore.lib.parser import messagetype
+from counterpartycore.lib.parser import messagetype, protocol
 
 from . import bet, order
 
@@ -16,6 +16,8 @@ logger = logging.getLogger(config.LOGGER_NAME)
 FORMAT = ">32s"
 LENGTH = 32
 ID = 70
+CANCEL_ALL_FLAG = b"\x01"
+CANCEL_ALL_FEE_PER_OFFER = int(0.0002 * config.UNIT)  # 0.0002 XCP per cancelled offer
 
 
 def validate(db, source, offer_hash):
@@ -44,7 +46,35 @@ def validate(db, source, offer_hash):
     return offer, offer_type, problems
 
 
-def compose(db, source: str, offer_hash: str, skip_validation: bool = False):
+def validate_cancel_all(db, source):
+    problems = []
+    open_orders = ledger.markets.get_open_orders_by_source(db, source)
+    open_bets = ledger.other.get_open_bets_by_source(db, source)
+    if not open_orders and not open_bets:
+        problems.append("no open offers for this address")
+
+    offer_count = len(open_orders) + len(open_bets)
+    fee = CANCEL_ALL_FEE_PER_OFFER * offer_count
+    if not problems and fee:
+        balance = ledger.balances.get_balance(db, source, config.XCP)
+        if balance < fee:
+            problems.append(f"insufficient funds ({config.XCP})")
+
+    return open_orders, open_bets, problems, fee
+
+
+def compose(db, source: str, offer_hash: str = None, skip_validation: bool = False):
+    if offer_hash is None:
+        # Cancel all open orders and bets
+        if not protocol.enabled("cancel_all_offers"):
+            raise exceptions.ComposeError(["cancel all not yet enabled"])
+        _open_orders, _open_bets, problems, _fee = validate_cancel_all(db, source)
+        if problems and not skip_validation:
+            raise exceptions.ComposeError(problems)
+        data = messagetype.pack(ID)
+        data += CANCEL_ALL_FLAG
+        return (source, [], data)
+
     # Check that offer exists.
     _offer, _offer_type, problems = validate(db, source, offer_hash)
     if problems and not skip_validation:
@@ -57,12 +87,18 @@ def compose(db, source: str, offer_hash: str, skip_validation: bool = False):
 
 
 def unpack(message, return_dict=False):
+    cancel_all = False
     try:
-        if len(message) != LENGTH:
+        if len(message) == 1 and message == CANCEL_ALL_FLAG:
+            offer_hash = None
+            status = "valid"
+            cancel_all = True
+        elif len(message) == LENGTH:
+            offer_hash_bytes = struct.unpack(FORMAT, message)[0]
+            offer_hash = binascii.hexlify(offer_hash_bytes).decode("utf-8")
+            status = "valid"
+        else:
             raise exceptions.UnpackError
-        offer_hash_bytes = struct.unpack(FORMAT, message)[0]
-        offer_hash = binascii.hexlify(offer_hash_bytes).decode("utf-8")
-        status = "valid"
     except (exceptions.UnpackError, struct.error):
         offer_hash = None
         status = "invalid: could not unpack"
@@ -70,49 +106,97 @@ def unpack(message, return_dict=False):
         return {
             "offer_hash": offer_hash,
             "status": status,
+            "cancel_all": cancel_all,
         }
-    return offer_hash, status
+    return offer_hash, status, cancel_all
 
 
 def parse(db, tx, message):
     cursor = db.cursor()
 
     # Unpack message.
-    offer_hash, status = unpack(message)
+    offer_hash, status, cancel_all = unpack(message)
 
-    if status == "valid":
-        offer, offer_type, problems = validate(db, tx["source"], offer_hash)
+    offer_type = None
+
+    # Before the protocol change, treat cancel_all as an invalid unpack
+    # to preserve identical behavior with the original code.
+    if cancel_all and not protocol.enabled("cancel_all_offers"):
+        offer_hash = None
+        status = "invalid: could not unpack"
+        cancel_all = False
+
+    if cancel_all:
+        open_orders, open_bets, problems, fee = validate_cancel_all(db, tx["source"])
         if problems:
             status = "invalid: " + "; ".join(problems)
-
-    if status == "valid":
-        # Cancel if order.
-        if offer_type == "order":
-            order.cancel_order(db, offer, "cancelled", tx["block_index"], tx["tx_index"])
-        # Cancel if bet.
-        elif offer_type == "bet":
-            bet.cancel_bet(db, offer, "cancelled", tx["tx_index"])
-        # If neither order or bet, mark as invalid.
         else:
-            assert False  # noqa: B011
+            # Debit anti-spam fee.
+            if fee:
+                ledger.events.debit(
+                    db,
+                    tx["source"],
+                    config.XCP,
+                    fee,
+                    tx["tx_index"],
+                    action="cancel all fee",
+                    event=tx["tx_hash"],
+                )
+            for o in open_orders:
+                order.cancel_order(db, o, "cancelled", tx["block_index"], tx["tx_index"])
+            for b in open_bets:
+                bet.cancel_bet(db, b, "cancelled", tx["tx_index"])
 
-    # Add parsed transaction to message-type–specific table.
-    bindings = {
-        "tx_index": tx["tx_index"],
-        "tx_hash": tx["tx_hash"],
-        "block_index": tx["block_index"],
-        "source": tx["source"],
-        "offer_hash": offer_hash,
-        "status": status,
-    }
-    if "integer overflow" not in status:
-        event_name = f"CANCEL_{offer_type.upper()}" if offer_type else "INVALID_CANCEL"
+        # Add parsed transaction to message-type–specific table.
+        bindings = {
+            "tx_index": tx["tx_index"],
+            "tx_hash": tx["tx_hash"],
+            "block_index": tx["block_index"],
+            "source": tx["source"],
+            "offer_hash": "all",
+            "status": status,
+        }
+        event_name = "CANCEL_ALL" if status == "valid" else "INVALID_CANCEL"
         ledger.events.insert_record(db, "cancels", bindings, event_name)
 
-    log_data = bindings | {
-        "offer_type": offer_type.capitalize() if offer_type else "Invalid",
-    }
-    logger.info("Cancel %(offer_type)s %(offer_hash)s (%(tx_hash)s) [%(status)s]", log_data)
+        logger.info(
+            "Cancel All open offers for %(source)s (%(tx_hash)s) [%(status)s]",
+            bindings,
+        )
+    else:
+        if status == "valid":
+            offer, offer_type, problems = validate(db, tx["source"], offer_hash)
+            if problems:
+                status = "invalid: " + "; ".join(problems)
+
+        if status == "valid":
+            # Cancel if order.
+            if offer_type == "order":
+                order.cancel_order(db, offer, "cancelled", tx["block_index"], tx["tx_index"])
+            # Cancel if bet.
+            elif offer_type == "bet":
+                bet.cancel_bet(db, offer, "cancelled", tx["tx_index"])
+            # If neither order or bet, mark as invalid.
+            else:
+                assert False  # noqa: B011
+
+        # Add parsed transaction to message-type–specific table.
+        bindings = {
+            "tx_index": tx["tx_index"],
+            "tx_hash": tx["tx_hash"],
+            "block_index": tx["block_index"],
+            "source": tx["source"],
+            "offer_hash": offer_hash,
+            "status": status,
+        }
+        if "integer overflow" not in status:
+            event_name = f"CANCEL_{offer_type.upper()}" if offer_type else "INVALID_CANCEL"
+            ledger.events.insert_record(db, "cancels", bindings, event_name)
+
+        log_data = bindings | {
+            "offer_type": offer_type.capitalize() if offer_type else "Invalid",
+        }
+        logger.info("Cancel %(offer_type)s %(offer_hash)s (%(tx_hash)s) [%(status)s]", log_data)
 
     cursor.close()
 

--- a/counterparty-core/counterpartycore/protocol_changes.json
+++ b/counterparty-core/counterpartycore/protocol_changes.json
@@ -1185,5 +1185,14 @@
         "testnet3_block_index": 4410000,
         "testnet4_block_index": 85000,
         "signet_block_index": 0
+    },
+    "cancel_all_offers": {
+        "minimum_version_major": 11,
+        "minimum_version_minor": 0,
+        "minimum_version_revision": 0,
+        "block_index": 902000,
+        "testnet3_block_index": 4410000,
+        "testnet4_block_index": 85000,
+        "signet_block_index": 0
     }
 }

--- a/counterparty-core/counterpartycore/test/units/messages/cancel_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/cancel_test.py
@@ -6,11 +6,23 @@ from counterpartycore.lib.messages import cancel
 def get_open_order(ledger_db):
     return ledger_db.execute(
         """
-            SELECT * FROM 
-                (SELECT tx_hash, status, source, MAX(rowid) FROM orders GROUP BY tx_hash) 
+            SELECT * FROM
+                (SELECT tx_hash, status, source, MAX(rowid) FROM orders GROUP BY tx_hash)
             WHERE status='open' ORDER BY tx_hash DESC LIMIT 1
         """
     ).fetchone()
+
+
+def get_open_orders_for_source(ledger_db, source):
+    return ledger_db.execute(
+        """
+            SELECT * FROM
+                (SELECT *, MAX(rowid) FROM orders GROUP BY tx_hash)
+            WHERE status='open' AND source=?
+            ORDER BY tx_index, tx_hash
+        """,
+        (source,),
+    ).fetchall()
 
 
 def test_compose(ledger_db, defaults):
@@ -37,17 +49,62 @@ def test_compose(ledger_db, defaults):
         cancel.compose(ledger_db, closed_bet["source"], closed_bet["tx_hash"])
 
 
+def test_compose_cancel_all(ledger_db, defaults):
+    """Test composing a cancel-all message."""
+    open_order = get_open_order(ledger_db)
+    source = open_order["source"]
+
+    result = cancel.compose(ledger_db, source)
+    assert result[0] == source
+    assert result[1] == []
+    # The data should be the packed message type ID + CANCEL_ALL_FLAG (0x01)
+    assert result[2].endswith(b"\x01")
+
+
+def test_compose_cancel_all_no_open_offers(ledger_db, defaults):
+    """Test composing cancel-all when no open offers exist raises ComposeError."""
+    # Use an address that has no open orders or bets
+    source = defaults["addresses"][5]
+    # First check there are actually no open orders for this address
+    open_orders = get_open_orders_for_source(ledger_db, source)
+    if open_orders:
+        # If there are open orders, skip this specific check
+        return
+    with pytest.raises(exceptions.ComposeError, match="no open offers for this address"):
+        cancel.compose(ledger_db, source)
+
+
 def test_unpack_invalid_length():
     """Test unpack with invalid message length."""
-    # Too short message
-    offer_hash, status = cancel.unpack(b"short")
+    # Too short message (but not 1-byte cancel-all flag)
+    offer_hash, status, cancel_all = cancel.unpack(b"short")
     assert offer_hash is None
     assert status == "invalid: could not unpack"
+    assert cancel_all is False
 
     # Empty message
-    offer_hash, status = cancel.unpack(b"")
+    offer_hash, status, cancel_all = cancel.unpack(b"")
     assert offer_hash is None
     assert status == "invalid: could not unpack"
+    assert cancel_all is False
+
+
+def test_unpack_cancel_all():
+    """Test unpack with 1-byte cancel-all flag."""
+    offer_hash, status, cancel_all = cancel.unpack(b"\x01")
+    assert offer_hash is None
+    assert status == "valid"
+    assert cancel_all is True
+
+
+def test_unpack_cancel_all_return_dict():
+    """Test unpack cancel-all with return_dict=True."""
+    result = cancel.unpack(b"\x01", return_dict=True)
+    assert result == {
+        "offer_hash": None,
+        "status": "valid",
+        "cancel_all": True,
+    }
 
 
 def test_unpack_return_dict():
@@ -56,6 +113,7 @@ def test_unpack_return_dict():
     assert result == {
         "offer_hash": None,
         "status": "invalid: could not unpack",
+        "cancel_all": False,
     }
 
 
@@ -96,3 +154,47 @@ def test_parse_cancel_order(ledger_db, blockchain_mock, test_helpers, current_bl
             },
         ],
     )
+
+
+def test_parse_cancel_all(ledger_db, blockchain_mock, test_helpers, current_block_index):
+    """Test parsing a cancel-all message cancels all open orders for the source."""
+    open_order = get_open_order(ledger_db)
+    source = open_order["source"]
+
+    # Count open orders before
+    open_orders_before = get_open_orders_for_source(ledger_db, source)
+    assert len(open_orders_before) > 0
+
+    tx = blockchain_mock.dummy_tx(ledger_db, source)
+    message = b"\x01"  # CANCEL_ALL_FLAG
+
+    cancel.parse(ledger_db, tx, message)
+
+    # Check that a cancels record was inserted with offer_hash="all"
+    test_helpers.check_records(
+        ledger_db,
+        [
+            {
+                "table": "cancels",
+                "values": {
+                    "block_index": tx["block_index"],
+                    "source": source,
+                    "offer_hash": "all",
+                    "status": "valid",
+                    "tx_hash": tx["tx_hash"],
+                    "tx_index": tx["tx_index"],
+                },
+            },
+            {
+                "table": "transactions_status",
+                "values": {
+                    "tx_index": tx["tx_index"],
+                    "valid": True,
+                },
+            },
+        ],
+    )
+
+    # Verify all orders for this source are now cancelled
+    open_orders_after = get_open_orders_for_source(ledger_db, source)
+    assert len(open_orders_after) == 0

--- a/release-notes/release-notes-v11.0.5.md
+++ b/release-notes/release-notes-v11.0.5.md
@@ -32,6 +32,8 @@ counterparty-server start
 
 ## Features
 
+- Add cancel-all mode to the `cancel` message (type 70): omit `offer_hash` to cancel all open orders and bets for the source address in a single transaction. Gated behind the `cancel_all_offers` protocol change. An anti-spam fee of 0.0002 XCP per cancelled offer is charged.
+
 ## Bugfixes
 
 - `excludes_utxos` supports now `<txid>:<vout>` and `<txid>` alone


### PR DESCRIPTION
## Summary

- Adds a "cancel all" mode to the existing `cancel` message (type ID 70) that cancels all open orders and bets for the source address in a single transaction
- Triggered by omitting the `offer_hash` parameter when composing a cancel message
- Wire format: `[type_id: 1 byte][flag: 1 byte (0x01)]` = 2 bytes total
- Gated behind the `cancel_all_offers` protocol change
- Charges an anti-spam fee of 0.0002 XCP per cancelled offer (same rate as dividend fees)

### Files Changed

| File | Change |
|------|--------|
| `protocol_changes.json` | Add `cancel_all_offers` protocol change entry |
| `lib/ledger/markets.py` | Add `get_open_orders_by_source()` query |
| `lib/ledger/other.py` | Add `get_open_bets_by_source()` query |
| `lib/messages/cancel.py` | Core logic: validate, compose, unpack, parse for cancel-all |
| `lib/api/compose.py` | Make `offer_hash` optional in `compose_cancel()` |
| `lib/api/apiwatcher.py` | Add `CANCEL_ALL` event to address fields |
| `test/units/messages/cancel_test.py` | Unit tests for compose, unpack, and parse paths |
| `release-notes-v11.0.5.md` | Document the new feature |

### Design Decisions

- **Reuses message type ID 70** with a 1-byte flag (`0x01`) rather than creating a new message type
- **Anti-spam fee** (0.0002 XCP per offer, matching dividend rate) prevents DoS via unbounded parse-time work
- **Pre-protocol-change guard** in `parse()` normalizes `0x01` messages back to `"invalid: could not unpack"` before the activation block, preserving identical behavior with the original code
- **Deterministic iteration** via `ORDER BY tx_index, tx_hash` on all queries
- **Fee validation** follows the dividend pattern: check balance in `validate_cancel_all()`, debit in `parse()` only after validation passes

### Edge Cases

- No open offers → `ComposeError` at compose time; `"invalid: no open offers for this address"` at parse time
- Insufficient XCP for fee → `ComposeError` at compose time; `"invalid: insufficient funds"` at parse time
- Protocol not yet enabled → `ComposeError` at compose time; treated as invalid unpack at parse time (backward compatible)
- BTC orders → `cancel_order()` handles correctly (credits non-BTC assets only)

## PR Checklist

- [x] Double-check the spelling and grammar of all strings, code comments, etc.
- [x] Double-check that all code is deterministic that needs to be
- [x] Add tests to cover any new or revised logic
- [ ] Ensure that the test suite passes
- [x] Update the project release notes

## Test Plan

- [ ] Run cancel unit tests: `cd counterparty-core && hatch run pytest counterpartycore/test/units/messages/cancel_test.py -s -vv -x`
- [ ] Run ruff linter: `cd counterparty-core && hatch run ruff check counterpartycore/lib/messages/cancel.py`
- [ ] Run broader unit test suite: `cd counterparty-core && hatch run pytest counterpartycore/test/units/ -s -vv -x`
- [ ] Verify existing single-cancel behavior is unchanged
- [ ] Verify cancel-all with multiple open orders
- [ ] Verify cancel-all with no open offers returns error
- [ ] Verify cancel-all before protocol activation is rejected