### PR TITLE
Don't cache failed parent tx lookups in Rust BATCH_CLIENT

### DIFF
--- a/counterparty-core/counterpartycore/lib/backend/bitcoind.py
+++ b/counterparty-core/counterpartycore/lib/backend/bitcoind.py
@@ -605,6 +605,11 @@ def get_vin_info_legacy(vin, no_retry=False):
             composer.is_segwit_output(vout["script_pub_key"]),
         )
     except exceptions.BitcoindRPCError as e:
+        logger.warning(
+            "Failed to lookup parent transaction %s for VIN resolution. "
+            "This transaction will be skipped. Is `txindex` enabled in Bitcoin Core?",
+            vin["hash"],
+        )
         raise exceptions.DecodeError("vin not found") from e
 
 

--- a/counterparty-core/counterpartycore/test/units/backend/bitcoind_test.py
+++ b/counterparty-core/counterpartycore/test/units/backend/bitcoind_test.py
@@ -499,3 +499,69 @@ def test_get_vin_info_legacy_error(monkeypatch):
 
     with pytest.raises(exceptions.DecodeError, match="vin not found"):
         bitcoind.get_vin_info_legacy({"hash": "hash", "n": 0})
+
+
+def test_get_vin_info_legacy_error_logs_warning(monkeypatch):
+    """When a parent transaction cannot be found, a warning must be logged
+    so operators can diagnose why a Counterparty transaction was skipped."""
+    from unittest.mock import patch
+
+    def raise_error(*args, **kwargs):
+        raise exceptions.BitcoindRPCError
+
+    monkeypatch.setattr(bitcoind, "get_decoded_transaction", raise_error)
+
+    parent_txid = "fba2aa8d334a6c74eaa8b0998be6c29477ff4d927449e9a07efa0ec374fc73bf"
+    with patch.object(bitcoind.logger, "warning") as mock_warning:
+        with pytest.raises(exceptions.DecodeError, match="vin not found"):
+            bitcoind.get_vin_info_legacy({"hash": parent_txid, "n": 1})
+
+    mock_warning.assert_called_once()
+    logged_message = mock_warning.call_args[0][0] % mock_warning.call_args[0][1:]
+    assert parent_txid in logged_message
+    assert "txindex" in logged_message
+
+
+def test_get_vin_info_falls_back_to_legacy(monkeypatch):
+    """When Rust VIN info is None, get_vin_info falls back to legacy lookup."""
+    monkeypatch.setattr(
+        bitcoind,
+        "get_decoded_transaction",
+        lambda *args, **kwargs: {
+            "vout": [
+                {"value": 10554, "script_pub_key": "76a9140132c2887759f123166b3048b5ec599ea0d5b8f988ac"}
+            ]
+        },
+    )
+    vin = {
+        "hash": "01f38776b07990118cb3720b9143adbde3725af12e0394cdd02c36458c6b3a03",
+        "n": 0,
+        "info": None,
+    }
+    value, script_pub_key, is_segwit = original_get_vin_info(vin)
+    assert value == 10554
+    assert script_pub_key == "76a9140132c2887759f123166b3048b5ec599ea0d5b8f988ac"
+    assert is_segwit is False
+
+
+def test_get_vin_info_fallback_also_fails(monkeypatch):
+    """When Rust VIN info is None AND the legacy fallback also fails,
+    a warning is logged and DecodeError is raised. This is the scenario
+    that caused a transaction to be silently skipped on a user's server."""
+    from unittest.mock import patch
+
+    def raise_error(*args, **kwargs):
+        raise exceptions.BitcoindRPCError("No such mempool or blockchain transaction")
+
+    monkeypatch.setattr(bitcoind, "get_decoded_transaction", raise_error)
+
+    parent_txid = "01f38776b07990118cb3720b9143adbde3725af12e0394cdd02c36458c6b3a03"
+    vin_without_info = {"hash": parent_txid, "n": 1, "info": None}
+
+    with patch.object(bitcoind.logger, "warning") as mock_warning:
+        with pytest.raises(exceptions.DecodeError, match="vin not found"):
+            original_get_vin_info(vin_without_info)
+
+    mock_warning.assert_called_once()
+    logged_message = mock_warning.call_args[0][0] % mock_warning.call_args[0][1:]
+    assert parent_txid in logged_message

--- a/counterparty-core/counterpartycore/test/units/backend/bitcoind_test.py
+++ b/counterparty-core/counterpartycore/test/units/backend/bitcoind_test.py
@@ -529,7 +529,10 @@ def test_get_vin_info_falls_back_to_legacy(monkeypatch):
         "get_decoded_transaction",
         lambda *args, **kwargs: {
             "vout": [
-                {"value": 10554, "script_pub_key": "76a9140132c2887759f123166b3048b5ec599ea0d5b8f988ac"}
+                {
+                    "value": 10554,
+                    "script_pub_key": "76a9140132c2887759f123166b3048b5ec599ea0d5b8f988ac",
+                }
             ]
         },
     )

--- a/counterparty-core/tools/compareledger.py
+++ b/counterparty-core/tools/compareledger.py
@@ -149,7 +149,7 @@ def get_last_block(database_file_1, database_file_2):
 database_file_1 = sys.argv[1]
 database_file_2 = sys.argv[2]
 
-LAST_BLOCK = 99277
+LAST_BLOCK = 939011
 # compare_ledger(database_file_1, database_file_2)
 check_hashes(database_file_1, database_file_2, "txlist_hash")
 # get_checkpoints(database_file_1)

--- a/counterparty-rs/src/indexer/rpc_client.rs
+++ b/counterparty-rs/src/indexer/rpc_client.rs
@@ -175,7 +175,9 @@ impl BatchRpcClient {
                 _ => None,
             };
 
-            cache.insert(*txid, tx.clone());
+            if tx.is_some() {
+                cache.insert(*txid, tx.clone());
+            }
             result_map.insert(*txid, tx);
         }
 

--- a/release-notes/release-notes-v11.0.5.md
+++ b/release-notes/release-notes-v11.0.5.md
@@ -39,6 +39,8 @@ counterparty-server start
 - Fix shutdown during rate limit backoff
 - Fix missing `limit` parameter validation in API v2 (was not enforced unlike API v1)
 - Fix `MalformedPointError` when searching for pubkey in P2WSH multisig witness data
+- Fix Rust `BATCH_CLIENT` permanently caching failed parent transaction lookups, which could cause valid Counterparty transactions to be silently skipped
+- Add warning log when a parent transaction cannot be found during VIN resolution
 
 ## Codebase
 


### PR DESCRIPTION
Transient getrawtransaction failures (e.g. Bitcoin Core restart, txindex rebuild) were permanently cached as None, causing valid Counterparty transactions to be silently skipped. The Python fallback retry was never reached because subsequent lookups returned the cached None directly.

Also adds a warning log when VIN resolution fails so operators can diagnose skipped transactions.

That should fix https://github.com/CounterpartyXCP/counterparty-core/issues/3276

-------------------------------------

* [x] Double-check the spelling and grammar of all strings, code comments, etc.
* [x] Double-check that all code is deterministic that needs to be
* [x] Add tests to cover any new or revised logic
* [x] Ensure that the test suite passes
* [x] Update the project [release notes](release-notes/)
* [x] Update the project documentation, as appropriate, with a corresponding Pull Request in the [Documentation repository](https://github.com/CounterpartyXCP/Documentation)
