### PR TITLE
Allow extra metadata when parsing Counterparty inscriptions

### DIFF
--- a/counterparty-rs/src/indexer/bitcoin_client.rs
+++ b/counterparty-rs/src/indexer/bitcoin_client.rs
@@ -543,7 +543,27 @@ fn extract_data_from_witness(script: &Script) -> Result<Vec<u8>, Error> {
                             let type_id = arr.remove(0);
                             (type_id, Value::Array(arr))
                         },
-                        _ => return Err(Error::ParseVout("Expected CBOR array, found different type".to_string())),
+                        Value::Map(map) => {
+                            // Ordinals metadata format: CBOR map with "xcp" key
+                            // containing the Counterparty message as an array.
+                            // Other keys (artist, name, etc.) are ordinals metadata
+                            // visible on ordinals.com.
+                            let xcp_key = Value::Text("xcp".to_string());
+                            match map.get(&xcp_key) {
+                                Some(Value::Array(arr)) if !arr.is_empty() => {
+                                    let mut arr = arr.clone();
+                                    let type_id = arr.remove(0);
+                                    (type_id, Value::Array(arr))
+                                },
+                                Some(Value::Array(_)) => {
+                                    return Err(Error::ParseVout("xcp array in metadata is empty".to_string()));
+                                },
+                                _ => {
+                                    return Err(Error::ParseVout("No xcp key found in metadata map".to_string()));
+                                },
+                            }
+                        },
+                        _ => return Err(Error::ParseVout("Expected CBOR array or map, found different type".to_string())),
                     };
                     
                     // Ensure message_type_id is an integer


### PR DESCRIPTION
## Context

When using inscribe to issue Counterparty assets, I wanted to include provenance metadata — artist name, collection title, description — alongside the issuance data. Currently Counterparty's inscription parser only accepts a CBOR array in the metadata field (tag 0x05), which contains strictly issuance parameters. There's no room for additional information that ordinals explorers could display.

Ordinals inscriptions support arbitrary CBOR metadata in tag 0x05 (per the [ordinals spec](https://docs.ordinals.com/inscriptions/metadata.html)). Explorers like ordinals.com render this as human-readable provenance information. But Counterparty rejects anything that isn't a CBOR array with a message type ID as the first element.

## Idea

Allow tag 0x05 to contain a **CBOR map** in addition to the existing CBOR array format. When the parser encounters a map, it extracts Counterparty message data from the `"xcp"` key. Other keys in the map (artist, title, collection, etc.) are ordinals metadata — visible on explorers, ignored by Counterparty.

This means a single inscription can serve both purposes:
- **Counterparty** reads the `"xcp"` array and processes the issuance
- **Ordinals explorers** display the rest of the map as provenance metadata

## Example

Tag 0x05 metadata (CBOR):
```json
{
  "artist": "Satoshi Nakamoto",
  "title": "Genesis Block #1",
  "collection": "Rare Artifacts",
  "xcp": [20, 95428959342453541, 100000000, 1, 0, 0]
}
```

Ordinals.com shows: artist, title, collection.
Counterparty extracts: the `xcp` array as an issuance message.

## Change

One file: `counterparty-rs/src/indexer/bitcoin_client.rs`

The CBOR decode section in `extract_data_from_witness()` gains a `Value::Map` arm alongside the existing `Value::Array` arm. ~20 lines of Rust. The existing array format continues to work unchanged.

This is a **parse-only change** — no modifications to compose endpoints. If someone wants to create inscriptions with provenance metadata, they'd construct the transaction directly (advanced usage).

## Status

Draft — exploring the idea. The change compiles and preserves backward compatibility with existing inscriptions. Needs testing and review to determine if the `"xcp"` key convention is the right approach.