### PR TITLE
Improve version check failure message

### DIFF
--- a/counterparty-core/counterpartycore/lib/parser/check.py
+++ b/counterparty-core/counterpartycore/lib/parser/check.py
@@ -155,9 +155,10 @@ def software_version():
         TimeoutError,
         json.decoder.JSONDecodeError,
     ) as e:
-        logger.error(e, exc_info=True)
+        logger.error("Unable to check Counterparty version from %s: %s", config.PROTOCOL_CHANGES_URL, e)
         raise exceptions.VersionCheckError(
-            "Unable to check Counterparty version. Use --force to ignore verfication."
+            f"Unable to check Counterparty version from {config.PROTOCOL_CHANGES_URL}: {e}. "
+            "Use --force to ignore verification."
         ) from e
 
     for change_name in versions:

--- a/counterparty-core/counterpartycore/test/units/parser/check_test.py
+++ b/counterparty-core/counterpartycore/test/units/parser/check_test.py
@@ -95,10 +95,14 @@ def test_software_version_connection_error(monkeypatch):
     monkeypatch.setattr("requests.get", mock_get)
 
     try:
-        with pytest.raises(
-            exceptions.VersionCheckError, match="Unable to check Counterparty version"
-        ):
+        with pytest.raises(exceptions.VersionCheckError) as exc_info:
             check.software_version()
+        message = str(exc_info.value)
+        assert "Unable to check Counterparty version from" in message
+        assert config.PROTOCOL_CHANGES_URL in message
+        assert "Connection refused" in message
+        assert "Use --force to ignore verification." in message
+        assert "verfication" not in message
     finally:
         config.FORCE = original_force
 
@@ -116,10 +120,12 @@ def test_software_version_timeout_error(monkeypatch):
     monkeypatch.setattr("requests.get", mock_get)
 
     try:
-        with pytest.raises(
-            exceptions.VersionCheckError, match="Unable to check Counterparty version"
-        ):
+        with pytest.raises(exceptions.VersionCheckError) as exc_info:
             check.software_version()
+        message = str(exc_info.value)
+        assert "Unable to check Counterparty version from" in message
+        assert "Read timed out" in message
+        assert "Use --force to ignore verification." in message
     finally:
         config.FORCE = original_force
 
@@ -140,10 +146,12 @@ def test_software_version_json_decode_error(monkeypatch):
     monkeypatch.setattr("requests.get", mock_get)
 
     try:
-        with pytest.raises(
-            exceptions.VersionCheckError, match="Unable to check Counterparty version"
-        ):
+        with pytest.raises(exceptions.VersionCheckError) as exc_info:
             check.software_version()
+        message = str(exc_info.value)
+        assert "Unable to check Counterparty version from" in message
+        assert "Expecting value" in message
+        assert "Use --force to ignore verification." in message
     finally:
         config.FORCE = original_force
 


### PR DESCRIPTION
## Summary

- Replace traceback-heavy version check failure logging with a concise URL + reason message.
- Include the protocol changes URL and underlying failure reason in `VersionCheckError`.
- Fix the `verfication` typo in the `--force` guidance.

Fixes #3092.

## Tests

- `.venv/bin/python -m pytest counterpartycore/test/units/parser/check_test.py -q`
- `git diff --check`

## Bounty claim

This PR fixes a code issue covered by the Counterparty bug bounty program. Bitcoin payout address: `12VVq7LDaVHMcK822HpEp5uYQ61SdNc7fF`.

## Checklist

* [x] Double-check the spelling and grammar of all strings, code comments, etc.
* [x] Double-check that all code is deterministic that needs to be
* [x] Add tests to cover any new or revised logic
* [x] Ensure that the relevant test suite passes
* [x] Update the project release notes, as appropriate: not needed for this narrow diagnostic-message fix
* [x] Update the project documentation, as appropriate: not needed for this internal error-message fix
