### PR TITLE
Handle invalid CBOR broadcast payloads

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/broadcast.py
+++ b/counterparty-core/counterpartycore/lib/messages/broadcast.py
@@ -182,9 +182,25 @@ def compose(
 
 
 def load_cbor(message):
-    timestamp, value, fee_fraction_int, mime_type, text = cbor2.loads(message)
+    decoded = cbor2.loads(message)
+    if not isinstance(decoded, (list, tuple)) or len(decoded) != 5:
+        raise exceptions.UnpackError
+
+    timestamp, value, fee_fraction_int, mime_type, text = decoded
+    if (
+        type(timestamp) is not int
+        or type(value) not in (int, float)
+        or type(fee_fraction_int) is not int
+        or (mime_type is not None and not isinstance(mime_type, str))
+        or not isinstance(text, bytes)
+    ):
+        raise exceptions.UnpackError
+
     mime_type = mime_type or "text/plain"
-    text = helpers.bytes_to_content(text, mime_type)
+    try:
+        text = helpers.bytes_to_content(text, mime_type)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        raise exceptions.UnpackError from exc
     return timestamp, value, fee_fraction_int, mime_type, text
 
 
@@ -223,6 +239,8 @@ def unpack(message, block_index, return_dict=False):
             # Unpack the message using cbor2
             try:
                 timestamp, value, fee_fraction_int, mime_type, text = load_cbor(message)
+            except exceptions.UnpackError:
+                raise
             except Exception:
                 timestamp, value, fee_fraction_int, mime_type, text = load_data_legacy(
                     message, block_index
@@ -232,7 +250,7 @@ def unpack(message, block_index, return_dict=False):
                 message, block_index
             )
         status = "valid"
-    except struct.error:
+    except (exceptions.UnpackError, struct.error):
         timestamp, value, fee_fraction_int, mime_type, text = 0, None, 0, "", None
         status = "invalid: could not unpack"
     except AssertionError:

--- a/counterparty-core/counterpartycore/test/units/messages/broadcast_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/broadcast_test.py
@@ -2,7 +2,7 @@ import struct
 
 import pytest
 from bitcoin.core import VarIntSerializer
-from counterpartycore.lib import config
+from counterpartycore.lib import config, exceptions
 from counterpartycore.lib.messages import broadcast
 from counterpartycore.test.mocks.counterpartydbs import ProtocolChangesDisabled
 
@@ -1061,6 +1061,41 @@ def test_parse_invalid_message_legacy(ledger_db, blockchain_mock, defaults, test
         )
 
 
+def test_parse_invalid_cbor_schema(ledger_db, blockchain_mock, defaults, test_helpers):
+    tx = blockchain_mock.dummy_tx(ledger_db, defaults["addresses"][4], use_first_tx=True)
+    message = broadcast.cbor2.dumps([1588000000, "not-a-number", 0, "text/plain", b"x"])
+
+    broadcast.parse(ledger_db, tx, message)
+
+    test_helpers.check_records(
+        ledger_db,
+        [
+            {
+                "table": "broadcasts",
+                "values": {
+                    "block_index": tx["block_index"],
+                    "fee_fraction_int": 0,
+                    "locked": 0,
+                    "source": defaults["addresses"][4],
+                    "status": "invalid: could not unpack",
+                    "text": None,
+                    "timestamp": 0,
+                    "tx_hash": tx["tx_hash"],
+                    "tx_index": tx["tx_index"],
+                    "value": None,
+                },
+            },
+            {
+                "table": "transactions_status",
+                "values": {
+                    "tx_index": tx["tx_index"],
+                    "valid": False,
+                },
+            },
+        ],
+    )
+
+
 def test_loads_cbor(monkeypatch):
     message = (
         b"\x85\x1a^\xa6\xf5\x00\x01\x00`X5Exactly 53 characters test test test test test testt."
@@ -1078,7 +1113,7 @@ def test_loads_cbor(monkeypatch):
     monkeypatch.setattr(
         "counterpartycore.lib.utils.helpers.bytes_to_content", bytes_to_content_mock
     )
-    with pytest.raises(Exception):  # noqa: B017
+    with pytest.raises(exceptions.UnpackError):
         broadcast.load_cbor(message)
 
 


### PR DESCRIPTION
Invalid CBOR broadcast arrays can currently decode as `valid` with non-numeric fields and then raise a `TypeError` in `broadcast.parse()` when `min(value, config.MAX_INT)` runs.

This adds schema/type checks for CBOR broadcast payloads so malformed arrays are recorded as `invalid: could not unpack`, while non-CBOR data can still fall back to the legacy decoder.

Tests run:
- `.venv/bin/pytest counterparty-core/counterpartycore/test/units/messages/broadcast_test.py -q`
- `ruff check counterparty-core/counterpartycore/lib/messages/broadcast.py counterparty-core/counterpartycore/test/units/messages/broadcast_test.py`

Broader check:
- `.venv/bin/pytest counterparty-core/counterpartycore/test/units/messages -q` currently has one order-dependent failure in `issuance_test.py::test_reset_issuance`; rerunning that test alone passes.

Bitcoin address for bounty consideration: `bc1qehva4gmx68nhktywxtcfkwkvqknc3zpe4es75a`