### PR TITLE
Handle invalid dispenser asset ids

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/dispenser.py
+++ b/counterparty-core/counterpartycore/lib/messages/dispenser.py
@@ -332,7 +332,7 @@ def unpack(message, return_dict=False, block_index=None):
             oracle_address = address_unpack(message[read : read + 21])
         asset = ledger.issuances.generate_asset_name(assetid)
         status = "valid"
-    except (exceptions.UnpackError, struct.error):
+    except (exceptions.UnpackError, exceptions.AssetIDError, struct.error):
         (
             give_quantity,
             escrow_quantity,

--- a/counterparty-core/counterpartycore/test/units/messages/dispenser_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/dispenser_test.py
@@ -1,7 +1,24 @@
+import struct
+
 import pytest
 from counterpartycore.lib import config, exceptions
 from counterpartycore.lib.messages import dispenser
 from counterpartycore.test.mocks.counterpartydbs import ProtocolChangesDisabled
+
+
+def test_unpack_invalid_asset_id():
+    payload = struct.pack(">QQQQB", 2, 1, 1, 1, dispenser.STATUS_OPEN)
+
+    assert dispenser.unpack(payload, return_dict=True) == {
+        "asset": None,
+        "give_quantity": None,
+        "escrow_quantity": None,
+        "mainchainrate": None,
+        "dispenser_status": None,
+        "action_address": None,
+        "oracle_address": None,
+        "status": "invalid: could not unpack",
+    }
 
 
 def test_validate(ledger_db, defaults):


### PR DESCRIPTION
## Summary

Invalid dispenser payloads with a uint64 value below the Counterparty asset-id range currently raise `AssetIDError` from `ledger.issuances.generate_asset_name()` during `dispenser.unpack()`.

That exception bypasses the existing invalid-unpack handling, so malformed on-chain dispenser data can escape parsing instead of being classified as `invalid: could not unpack`.

This PR catches `AssetIDError` in the existing invalid-unpack path and adds a regression test for asset id `2`.

Bitcoin address for bounty consideration: `bc1qehva4gmx68nhktywxtcfkwkvqknc3zpe4es75a`

## Tests

- `.venv/bin/pytest counterparty-core/counterpartycore/test/units/messages/dispenser_test.py::test_unpack_invalid_asset_id -q`
- `.venv/bin/pytest counterparty-core/counterpartycore/test/units/messages/dispenser_test.py -q`
- `ruff check counterparty-core/counterpartycore/lib/messages/dispenser.py counterparty-core/counterpartycore/test/units/messages/dispenser_test.py`
