### PR TITLE
Handle short subasset issuance payloads

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/issuance.py
+++ b/counterparty-core/counterpartycore/lib/messages/issuance.py
@@ -811,7 +811,7 @@ def unpack(db, message, message_type_id, block_index, return_dict=False):
         except exceptions.AssetIDError:
             asset = None
             status = "invalid: bad asset name"
-    except exceptions.UnpackError as e:
+    except (exceptions.UnpackError, struct.error) as e:
         logger.warning("unpack error: %s", e)
         (
             asset_id,

--- a/counterparty-core/counterpartycore/test/units/messages/issuance_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/issuance_test.py
@@ -7,6 +7,30 @@ from counterpartycore.lib.messages import issuance
 from counterpartycore.test.mocks.counterpartydbs import ProtocolChangesDisabled
 
 
+def test_unpack_short_subasset_message(ledger_db):
+    assert issuance.unpack(
+        ledger_db,
+        b"",
+        issuance.SUBASSET_ID,
+        9999999,
+        return_dict=True,
+    ) == {
+        "asset_id": None,
+        "asset": None,
+        "subasset_longname": None,
+        "quantity": None,
+        "divisible": False,
+        "lock": False,
+        "reset": False,
+        "callable": False,
+        "call_date": None,
+        "call_price": None,
+        "description": None,
+        "mime_type": None,
+        "status": "invalid: could not unpack",
+    }
+
+
 def test_validate(ledger_db, defaults, current_block_index):
     assert issuance.validate(
         ledger_db,


### PR DESCRIPTION
## Summary

Short legacy subasset issuance payloads currently raise `struct.error` inside `issuance.unpack()` after CBOR decode falls back to legacy parsing.

That exception bypasses the existing invalid-unpack handling, so malformed subasset issuance data can escape parsing instead of being classified as `invalid: could not unpack`.

This PR catches `struct.error` in the existing invalid-unpack path and adds a regression test for an empty `SUBASSET_ID` payload.

Bitcoin address for bounty consideration: `bc1qehva4gmx68nhktywxtcfkwkvqknc3zpe4es75a`

## Tests

- `.venv/bin/pytest counterparty-core/counterpartycore/test/units/messages/issuance_test.py::test_unpack_short_subasset_message -q`
- `.venv/bin/pytest counterparty-core/counterpartycore/test/units/messages/issuance_test.py -q`
- `ruff check counterparty-core/counterpartycore/lib/messages/issuance.py counterparty-core/counterpartycore/test/units/messages/issuance_test.py`
