### PR TITLE
Fix divisible dispenser prices

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/queries.py
+++ b/counterparty-core/counterpartycore/lib/api/queries.py
@@ -2436,7 +2436,14 @@ def prepare_dispenser_where(status, other_conditions=None, exclude_with_oracle=F
     return where
 
 
-SELECT_DISPENSERS = "*, (satoshirate * 1.0) / (give_quantity * 1.0) AS price"
+SELECT_DISPENSERS = """
+*,
+CASE
+    WHEN COALESCE((SELECT divisible FROM assets_info WHERE assets_info.asset = dispensers.asset), 0) = 1
+    THEN (satoshirate * 100000000.0) / (give_quantity * 1.0)
+    ELSE (satoshirate * 1.0) / (give_quantity * 1.0)
+END AS price
+"""
 
 
 def get_dispensers(

--- a/counterparty-core/counterpartycore/test/units/api/queries_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/queries_test.py
@@ -631,6 +631,69 @@ def test_prepare_dispenser_where_with_invalid_status():
     assert len(result) == 0
 
 
+def test_get_dispensers_by_asset_prices_divisible_lots(state_db):
+    """Test dispenser price is satoshis per whole asset unit for divisible assets."""
+    state_db.execute(
+        "INSERT INTO assets_info (asset, divisible) VALUES (?, ?)",
+        ("UNITTESTDIV", True),
+    )
+    state_db.execute(
+        """
+        INSERT INTO dispensers (
+            tx_index, tx_hash, block_index, source, asset, give_quantity,
+            escrow_quantity, satoshirate, status, give_remaining, origin,
+            dispense_count
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            9001,
+            "a" * 64,
+            9001,
+            "addr1",
+            "UNITTESTDIV",
+            100000000,
+            100000000,
+            12345,
+            0,
+            100000000,
+            "addr1",
+            0,
+        ),
+    )
+    state_db.execute(
+        """
+        INSERT INTO dispensers (
+            tx_index, tx_hash, block_index, source, asset, give_quantity,
+            escrow_quantity, satoshirate, status, give_remaining, origin,
+            dispense_count
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            9002,
+            "b" * 64,
+            9002,
+            "addr2",
+            "UNITTESTDIV",
+            200000000,
+            200000000,
+            12345,
+            0,
+            200000000,
+            "addr2",
+            0,
+        ),
+    )
+
+    result = queries.get_dispensers_by_asset(
+        state_db,
+        "UNITTESTDIV",
+        status="open",
+        sort="price:asc",
+    )
+
+    assert [row["price"] for row in result.result] == [6172.5, 12345]
+
+
 # =============================================================================
 # Tests for assets
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes #2882.

The API-derived dispenser `price` currently uses raw atomic `give_quantity`, so divisible asset dispensers report satoshis-per-atomic-unit instead of satoshis-per-whole-asset-unit. For a divisible asset lot of `2.0` units at `12345` sats, the raw API `price` should be `6172.5`, not `0.000061725`.

This PR scales the SQL-derived raw `price` by `1e8` when `assets_info.divisible` is true, while leaving indivisible assets on the existing raw lot-size calculation.

Bitcoin address for bounty consideration: `bc1qehva4gmx68nhktywxtcfkwkvqknc3zpe4es75a`

## Tests

- `.venv/bin/pytest counterparty-core/counterpartycore/test/units/api/queries_test.py::test_get_dispensers_by_asset_prices_divisible_lots -q`
- `.venv/bin/pytest counterparty-core/counterpartycore/test/units/api/queries_test.py -q`
- `ruff check counterparty-core/counterpartycore/lib/api/queries.py counterparty-core/counterpartycore/test/units/api/queries_test.py`
