### PR TITLE
Handle invalid UTXO messages

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/utxo.py
+++ b/counterparty-core/counterpartycore/lib/messages/utxo.py
@@ -154,7 +154,20 @@ def unpack(message, return_dict=False):
 
 
 def parse(db, tx, message):
-    (source, destination, asset, quantity) = unpack(message)
+    try:
+        (source, destination, asset, quantity) = unpack(message)
+    except exceptions.UnpackError:
+        bindings = {
+            "tx_index": tx["tx_index"],
+            "tx_hash": tx["tx_hash"],
+            "msg_index": ledger.other.get_send_msg_index(db, tx["tx_hash"]),
+            "block_index": tx["block_index"],
+            "status": "invalid: could not unpack",
+            "send_type": "utxo",
+        }
+        ledger.events.insert_record(db, "sends", bindings, "UTXO_MOVE")
+        ledger.blocks.set_transaction_status(db, tx["tx_index"], False)
+        return
 
     problems = validate(db, source, destination, asset, quantity, tx["block_index"])
 

--- a/counterparty-core/counterpartycore/test/units/messages/utxo_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/utxo_test.py
@@ -69,6 +69,27 @@ def test_unpack(defaults):
     )
 
 
+def test_parse_invalid_unpack(ledger_db, blockchain_mock, defaults, test_helpers):
+    tx = blockchain_mock.dummy_tx(ledger_db, defaults["addresses"][0])
+
+    utxo.parse(ledger_db, tx, b"not-enough-fields")
+
+    test_helpers.check_records(
+        ledger_db,
+        [
+            {
+                "table": "sends",
+                "values": {
+                    "tx_hash": tx["tx_hash"],
+                    "tx_index": tx["tx_index"],
+                    "send_type": "utxo",
+                    "status": "invalid: could not unpack",
+                },
+            },
+        ],
+    )
+
+
 def test_parse_attach(ledger_db, blockchain_mock, defaults, test_helpers, current_block_index):
     tx = blockchain_mock.dummy_tx(ledger_db, defaults["addresses"][0])
     destination_uxo = "344dcc8909ca3a137630726d0071dfd2df4f7c855bac150c7d3a8367835c90bc:0"


### PR DESCRIPTION
## Summary

Malformed legacy UTXO messages currently raise `UnpackError` from `utxo.unpack()` before `utxo.parse()` can record an invalid transaction.

That exception can escape block parsing instead of classifying the transaction as `invalid: could not unpack`.

This PR handles UTXO unpack failures in `parse()`, records an invalid `sends` row, marks the transaction invalid, and adds a regression test for a payload without the required four fields.

Bitcoin address for bounty consideration: `bc1qehva4gmx68nhktywxtcfkwkvqknc3zpe4es75a`

## Tests

- `.venv/bin/pytest counterparty-core/counterpartycore/test/units/messages/utxo_test.py::test_parse_invalid_unpack -q`
- `.venv/bin/pytest counterparty-core/counterpartycore/test/units/messages/utxo_test.py -q`
- `ruff check counterparty-core/counterpartycore/lib/messages/utxo.py counterparty-core/counterpartycore/test/units/messages/utxo_test.py`
