### PR TITLE
Validate issuance CBOR payloads

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/issuance.py
+++ b/counterparty-core/counterpartycore/lib/messages/issuance.py
@@ -34,6 +34,76 @@ DESCRIPTION_MARK_BYTE = b"\xc0"
 DESCRIPTION_NULL_ACTION = "NULL"
 
 
+def _is_int(value):
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_boolish(value):
+    return isinstance(value, bool) or (_is_int(value) and value in (0, 1))
+
+
+def _is_optional_text(value):
+    return value is None or isinstance(value, str)
+
+
+def _is_optional_bytes(value):
+    return value is None or isinstance(value, bytes)
+
+
+def _load_cbor_payload(message, message_type_id):
+    payload = cbor2.loads(message)
+    if not isinstance(payload, list):
+        raise ValueError("Not an issuance CBOR payload")
+
+    if message_type_id in [ID, LR_ISSUANCE_ID]:
+        if len(payload) != 7:
+            raise ValueError("Not an issuance CBOR payload")
+
+        asset_id, quantity, divisible, lock, reset, mime_type, description = payload
+        if not (
+            _is_int(asset_id)
+            and _is_int(quantity)
+            and _is_boolish(divisible)
+            and _is_boolish(lock)
+            and _is_boolish(reset)
+            and _is_optional_text(mime_type)
+            and _is_optional_bytes(description)
+        ):
+            raise exceptions.UnpackError("Invalid issuance CBOR payload")
+        return payload
+
+    if message_type_id in [SUBASSET_ID, LR_SUBASSET_ID]:
+        if len(payload) != 9:
+            raise ValueError("Not an issuance CBOR payload")
+
+        (
+            asset_id,
+            quantity,
+            divisible,
+            lock,
+            reset,
+            compacted_subasset_length,
+            compacted_subasset_longname,
+            mime_type,
+            description,
+        ) = payload
+        if not (
+            _is_int(asset_id)
+            and _is_int(quantity)
+            and _is_boolish(divisible)
+            and _is_boolish(lock)
+            and _is_boolish(reset)
+            and _is_int(compacted_subasset_length)
+            and isinstance(compacted_subasset_longname, bytes)
+            and _is_optional_text(mime_type)
+            and _is_optional_bytes(description)
+        ):
+            raise exceptions.UnpackError("Invalid issuance CBOR payload")
+        return payload
+
+    raise exceptions.UnpackError("Invalid message type ID")
+
+
 def validate(
     db,
     source,
@@ -644,7 +714,7 @@ def unpack(db, message, message_type_id, block_index, return_dict=False):
                         reset,
                         mime_type,
                         description,
-                    ) = cbor2.loads(message)
+                    ) = _load_cbor_payload(message, message_type_id)
                 elif message_type_id in [SUBASSET_ID, LR_SUBASSET_ID]:
                     (
                         asset_id,
@@ -656,7 +726,7 @@ def unpack(db, message, message_type_id, block_index, return_dict=False):
                         compacted_subasset_longname,
                         mime_type,
                         description,
-                    ) = cbor2.loads(message)
+                    ) = _load_cbor_payload(message, message_type_id)
                     subasset_longname = assetnames.expand_subasset_longname(
                         compacted_subasset_longname
                     )
@@ -669,6 +739,8 @@ def unpack(db, message, message_type_id, block_index, return_dict=False):
                 callable_, call_date, call_price = False, 0, 0.0
 
                 unpacked = True
+            except exceptions.UnpackError:
+                raise
             except Exception:  # pylint: disable=broad-exception-caught
                 unpacked = False  # Fallback to legacy unpacking
 

--- a/counterparty-core/counterpartycore/test/units/messages/issuance_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/issuance_test.py
@@ -1,5 +1,6 @@
 import binascii
 
+import cbor2
 import pytest
 from counterpartycore.lib import config, exceptions
 from counterpartycore.lib.api import apiwatcher
@@ -2075,6 +2076,36 @@ def test_parse_divisible_legacy_taproot_acivated(
                     "block_index": current_block_index,
                     "event": tx["tx_hash"],
                     "quantity": 0,
+                },
+            },
+        ],
+    )
+
+
+def test_parse_invalid_cbor_schema(ledger_db, blockchain_mock, defaults, test_helpers):
+    tx = blockchain_mock.dummy_tx(ledger_db, defaults["addresses"][0])
+    message = cbor2.dumps([17576, "not-int", False, False, False, "text/plain", b"desc"])
+
+    issuance.parse(ledger_db, tx, message, issuance.ID)
+
+    test_helpers.check_records(
+        ledger_db,
+        [
+            {
+                "table": "issuances",
+                "values": {
+                    "block_index": tx["block_index"],
+                    "source": defaults["addresses"][0],
+                    "status": "invalid: could not unpack",
+                    "tx_hash": tx["tx_hash"],
+                    "tx_index": tx["tx_index"],
+                },
+            },
+            {
+                "table": "transactions_status",
+                "values": {
+                    "tx_index": tx["tx_index"],
+                    "valid": False,
                 },
             },
         ],


### PR DESCRIPTION
Malformed taproot/CBOR issuance payloads can currently reach `validate()` with incorrectly typed fields while still marked `valid`. For example, a CBOR issuance array with a string `quantity` raises `ValueError: not enough values to unpack` in `parse()` because `validate()` returns its shorter invalid tuple contract.

This PR validates decoded issuance CBOR payload shape and field types before accepting them as unpacked messages. Decode failures and non-issuance CBOR shapes still fall back to legacy unpacking, preserving legacy payload behavior; decoded issuance arrays with invalid field types now become `invalid: could not unpack`.

Verification:
- `../.venv/bin/pytest counterpartycore/test/units/messages/issuance_test.py::test_parse_invalid_cbor_schema -q`
- `../.venv/bin/pytest counterpartycore/test/units/messages/issuance_test.py::test_parse_invalid_cbor_schema counterpartycore/test/units/messages/issuance_test.py::test_parse_too_short counterpartycore/test/units/messages/issuance_test.py::test_parse_divisible_legacy_taproot_acivated -q`
- `../.venv/bin/pytest counterpartycore/test/units/messages/issuance_test.py -q`
- `ruff check counterpartycore/lib/messages/issuance.py counterpartycore/test/units/messages/issuance_test.py`
- `git diff --check`

BTC payout address: `bc1qehva4gmx68nhktywxtcfkwkvqknc3zpe4es75a`