### PR TITLE
Gate replay-sensitive v11.1 parse hardening and fix AMM deposit edge cases

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/queries.py
+++ b/counterparty-core/counterpartycore/lib/api/queries.py
@@ -4119,7 +4119,7 @@ def get_pool_quote_deposit(state_db, asset1: str, asset2: str, quantity: int):
     pool_row = select_row(state_db, "pools", where={"asset_a": sorted_a, "asset_b": sorted_b})
     pool = pool_row.result if pool_row else None
 
-    if pool is None or pool["reserve_a"] == 0:
+    if pool is None or not pool_has_liquidity(pool):
         return {
             "first_deposit": True,
             "asset_a": sorted_a,
@@ -4166,7 +4166,7 @@ def get_pool_quote_withdraw(state_db, asset1: str, asset2: str, quantity: int):
     sorted_a, sorted_b = sort_pair(asset1, asset2)
     pool_row = select_row(state_db, "pools", where={"asset_a": sorted_a, "asset_b": sorted_b})
     pool = pool_row.result if pool_row else None
-    if pool is None or pool["reserve_a"] == 0:
+    if pool is None or not pool_has_liquidity(pool):
         return {"pool_exists": False, "message": "Pool does not exist or is empty."}
 
     lp_info = select_row(state_db, "assets_info", where={"asset": pool["lp_asset"]})

--- a/counterparty-core/counterpartycore/lib/messages/broadcast.py
+++ b/counterparty-core/counterpartycore/lib/messages/broadcast.py
@@ -248,7 +248,9 @@ def unpack(message, block_index, return_dict=False):
     except AssertionError:
         timestamp, value, fee_fraction_int, mime_type, text = 0, None, 0, "", None
         status = "invalid: could not unpack text"
-    except Exception:  # pylint: disable=broad-exception-caught
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        if not protocol.enabled("broadcast_safe_unpack", block_index=block_index):
+            raise
         # Consensus-safety net: unpack() is reached for *every* on-chain
         # broadcast message, including arbitrary attacker-crafted bytes.
         # Any uncaught exception here would propagate up to the parser
@@ -257,6 +259,7 @@ def unpack(message, block_index, return_dict=False):
         # VarIntSerializer.SerializationTruncationError, cbor2 decoder
         # errors, MemoryError on absurd lengths, etc. -- and mark the
         # message invalid so consensus stays uniform across nodes.
+        logger.warning("broadcast unpack error: %s", e)
         timestamp, value, fee_fraction_int, mime_type, text = 0, None, 0, "", None
         status = "invalid: could not unpack"
 
@@ -297,6 +300,8 @@ def parse(db, tx, message):
             if problems:
                 status = "invalid: " + "; ".join(problems)
         except (TypeError, ValueError, OverflowError, AssertionError) as e:
+            if not protocol.enabled("broadcast_safe_validate", block_index=tx["block_index"]):
+                raise
             logger.warning("broadcast validate error on tx %s: %s", tx["tx_hash"], e)
             timestamp, value, fee_fraction_int, text = 0, None, 0, None
             status = "invalid: validation error"

--- a/counterparty-core/counterpartycore/lib/messages/dispense.py
+++ b/counterparty-core/counterpartycore/lib/messages/dispense.py
@@ -18,15 +18,20 @@ def get_must_give(db, dispenser, btc_amount, block_index=None):
         last_price, _last_fee, _last_fiat_label, _last_updated = ledger.other.get_oracle_last_price(
             db, dispenser["oracle_address"], block_index or CurrentState().current_block_index()
         )
-        if last_price is None or last_price <= 0:
-            # Negative oracle prices are bet-cancellation sentinels (-2, -3) or
-            # other non-pricing broadcasts; treating them as a price would yield
-            # a negative must_give, then a negative credit() that raises and
-            # halts. is_dispensable already guards last_price == 0; this widens
-            # the check to <= 0 for the dispense path too.
+        if last_price is None:
             raise exceptions.NoPriceError(
-                f"No usable price for oracle {dispenser['oracle_address']} at block {block_index}"
+                f"No price available for this oracle {dispenser['oracle_address']} at block {block_index}"
             )
+        if protocol.enabled("dispense_skip_unusable_oracle_price", block_index=block_index):
+            if last_price <= 0:
+                # Negative oracle prices are bet-cancellation sentinels (-2, -3) or
+                # other non-pricing broadcasts; treating them as a price would yield
+                # a negative must_give, then a negative credit() that raises and
+                # halts. is_dispensable already guards last_price == 0; this widens
+                # the check to <= 0 for the dispense path too.
+                raise exceptions.NoPriceError(
+                    f"No usable price for oracle {dispenser['oracle_address']} at block {block_index}"
+                )
         fiatrate = helpers.satoshirate_to_fiat(dispenser["satoshirate"])
         return int(floor(((btc_amount / config.UNIT) * last_price) / fiatrate))
 
@@ -121,13 +126,20 @@ def parse(db, tx):
             give_quantity = dispenser["give_quantity"]
 
             if satoshirate > 0 and give_quantity > 0:
-                try:
+                if protocol.enabled(
+                    "dispense_skip_unusable_oracle_price", block_index=tx["block_index"]
+                ):
+                    try:
+                        must_give = get_must_give(
+                            db, dispenser, next_out["btc_amount"], next_out["block_index"]
+                        )
+                    except exceptions.NoPriceError as e:
+                        logger.warning("Skipping dispenser for %s: %s", dispenser["asset"], e)
+                        continue
+                else:
                     must_give = get_must_give(
                         db, dispenser, next_out["btc_amount"], next_out["block_index"]
                     )
-                except exceptions.NoPriceError as e:
-                    logger.warning("Skipping dispenser for %s: %s", dispenser["asset"], e)
-                    continue
                 remaining = int(floor(dispenser["give_remaining"] / give_quantity))
                 actually_given = min(must_give, remaining) * give_quantity
                 give_remaining = dispenser["give_remaining"] - actually_given

--- a/counterparty-core/counterpartycore/lib/messages/fairminter.py
+++ b/counterparty-core/counterpartycore/lib/messages/fairminter.py
@@ -601,7 +601,9 @@ def parse(db, tx, message):
             # Other fee-paying messages (issuance, dividend) all hoist to int
             # at compute time -- match the convention so SUM over REAL doesn't
             # drift after enough fairminters and so the schema stays coherent.
-            fee = int(0.5 * config.UNIT)
+            fee = 0.5 * config.UNIT
+            if protocol.enabled("fairminter_integer_fee_paid", block_index=tx["block_index"]):
+                fee = int(fee)
 
     # we only premint if the faireminter is open and soft cap reached,
     # otherwise we will do it at opening (`start_block`) or when

--- a/counterparty-core/counterpartycore/lib/messages/issuance.py
+++ b/counterparty-core/counterpartycore/lib/messages/issuance.py
@@ -659,7 +659,7 @@ def unpack(db, message, message_type_id, block_index, return_dict=False):
                         description,
                     ) = cbor2.loads(message)
                     subasset_longname = assetnames.expand_subasset_longname(
-                        compacted_subasset_longname
+                        compacted_subasset_longname, block_index=block_index
                     )
                 else:
                     raise exceptions.UnpackError("Invalid message type ID")
@@ -738,7 +738,9 @@ def unpack(db, message, message_type_id, block_index, return_dict=False):
                                 description = None
                         except UnicodeDecodeError:
                             description = ""
-                subasset_longname = assetnames.expand_subasset_longname(compacted_subasset_longname)
+                subasset_longname = assetnames.expand_subasset_longname(
+                    compacted_subasset_longname, block_index=block_index
+                )
                 callable_, call_date, call_price = False, 0, 0.0
 
             elif (
@@ -831,14 +833,45 @@ def unpack(db, message, message_type_id, block_index, return_dict=False):
         except exceptions.AssetIDError:
             asset = None
             status = "invalid: bad asset name"
+    except exceptions.UnpackError as e:
+        logger.warning("unpack error: %s", e)
+        (
+            asset_id,
+            asset,
+            subasset_longname,
+            quantity,
+            divisible,
+            lock,
+            reset,
+            callable_,
+            call_date,
+            call_price,
+            description,
+            mime_type,
+        ) = (
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        status = "invalid: could not unpack"
     except (
-        exceptions.UnpackError,
         exceptions.AssetNameError,
         struct.error,
         TypeError,
         ValueError,
         OverflowError,
     ) as e:
+        if not protocol.enabled("issuance_safe_unpack", block_index=block_index):
+            raise
         logger.warning("unpack error: %s", e)
         (
             asset_id,
@@ -983,6 +1016,8 @@ def parse(db, tx, message, message_type_id):
             ):
                 quantity = 0
         except (TypeError, ValueError, OverflowError, AssertionError) as e:
+            if not protocol.enabled("issuance_safe_validate", block_index=tx["block_index"]):
+                raise
             # CBOR-encoded messages (from hand-rolled txs) can carry values of
             # unexpected types or arities that cause validate() or downstream
             # comparisons to raise. Mark the tx invalid rather than halting.

--- a/counterparty-core/counterpartycore/lib/messages/pooldeposit.py
+++ b/counterparty-core/counterpartycore/lib/messages/pooldeposit.py
@@ -88,6 +88,9 @@ def validate(
 
     total_lp_supply = 0
     if existing_pool is not None:
+        if not ledger.markets.pool_has_liquidity(existing_pool):
+            problems.append("pool has no liquidity")
+            return problems
         lp_asset = existing_pool["lp_asset"]
         total_lp_supply = ledger.supplies.asset_issued_total_no_cache(
             db, lp_asset
@@ -248,6 +251,12 @@ def parse(db, tx, message):
         if problems:
             status = "invalid: " + "; ".join(problems)
 
+    if status == "valid":
+        sorted_a, sorted_b = ledger.markets.sort_pair(asset_a, asset_b)
+        existing_pool = ledger.markets.get_pool(db, sorted_a, sorted_b)
+        if existing_pool is not None and not ledger.markets.pool_has_liquidity(existing_pool):
+            status = "invalid: pool has no liquidity"
+
     # if invalid, record and return early
     if status != "valid":
         sorted_a, sorted_b = (
@@ -365,6 +374,8 @@ def make_lp_issuance_bindings(db, tx, lp_asset, quantity, asset_a, asset_b, asse
 
 def compute_actual_deposit_amounts(pool, quantity_a, quantity_b):
     """Clamp a deposit to the pool's current reserve ratio. Returns (actual_a, actual_b)."""
+    if pool["reserve_a"] <= 0 or pool["reserve_b"] <= 0:
+        return 0, 0
     ratio_a = quantity_a * pool["reserve_b"]
     ratio_b = quantity_b * pool["reserve_a"]
     if ratio_a <= ratio_b:

--- a/counterparty-core/counterpartycore/lib/messages/pooldeposit.py
+++ b/counterparty-core/counterpartycore/lib/messages/pooldeposit.py
@@ -88,13 +88,15 @@ def validate(
 
     total_lp_supply = 0
     if existing_pool is not None:
-        if not ledger.markets.pool_has_liquidity(existing_pool):
-            problems.append("pool has no liquidity")
-            return problems
         lp_asset = existing_pool["lp_asset"]
         total_lp_supply = ledger.supplies.asset_issued_total_no_cache(
             db, lp_asset
         ) - ledger.supplies.asset_destroyed_total_no_cache(db, lp_asset)
+        if not ledger.markets.pool_has_liquidity(existing_pool) and total_lp_supply > 0:
+            # Abnormal: LP tokens exist but a reserve is zero — reject to prevent div-by-zero
+            problems.append("pool has no liquidity")
+            return problems
+        # total_lp_supply == 0 means pool fully drained; treat as restart below
 
     if total_lp_supply == 0:
         actual_a_sorted = sorted_quantity_a
@@ -250,12 +252,6 @@ def parse(db, tx, message):
         )
         if problems:
             status = "invalid: " + "; ".join(problems)
-
-    if status == "valid":
-        sorted_a, sorted_b = ledger.markets.sort_pair(asset_a, asset_b)
-        existing_pool = ledger.markets.get_pool(db, sorted_a, sorted_b)
-        if existing_pool is not None and not ledger.markets.pool_has_liquidity(existing_pool):
-            status = "invalid: pool has no liquidity"
 
     # if invalid, record and return early
     if status != "valid":

--- a/counterparty-core/counterpartycore/lib/messages/sweep.py
+++ b/counterparty-core/counterpartycore/lib/messages/sweep.py
@@ -324,7 +324,7 @@ def parse(db, tx, message):
         ledger.events.insert_record(db, "sweeps", bindings, "SWEEP")
 
         logger.info("Sweep from %(source)s to %(destination)s (%(tx_hash)s) [%(status)s]", bindings)
-    else:
+    elif protocol.enabled("persist_invalid_sweep", block_index=tx["block_index"]):
         # Persist an invalid sweep row + INVALID_SWEEP event so API consumers
         # can enumerate failed sweeps; mirrors the cancel.py / utxo.py pattern.
         bindings = {
@@ -340,11 +340,16 @@ def parse(db, tx, message):
         }
         ledger.events.insert_record(db, "sweeps", bindings, "INVALID_SWEEP")
         logger.info("Invalid sweep from %(source)s (%(tx_hash)s) [%(status)s]", bindings)
+    else:
+        logger.info(
+            "Invalid sweep from %(source)s (%(tx_hash)s) [%(status)s]",
+            {
+                "source": tx["source"],
+                "tx_hash": tx["tx_hash"],
+                "status": status,
+            },
+        )
 
-    # Every other parse module sets transactions_status; sweep.py was the
-    # one omission, leaving sweeps' `valid` column permanently NULL and
-    # making API filters on `valid = 1` / `valid = 0` silently exclude
-    # every sweep ever processed.
     ledger.blocks.set_transaction_status(db, tx["tx_index"], status == "valid")
 
     cursor.close()

--- a/counterparty-core/counterpartycore/lib/utils/assetnames.py
+++ b/counterparty-core/counterpartycore/lib/utils/assetnames.py
@@ -194,22 +194,18 @@ def compact_subasset_longname(string):
     return name_int.to_bytes((name_int.bit_length() + 7) // 8, byteorder="big")
 
 
-def expand_subasset_longname(raw_bytes):
+def expand_subasset_longname(raw_bytes, block_index=None):
     """Expands an array of bytes into a subasset name string."""
     # The legacy struct path is bounded by a uint8 length prefix (max 255).
     # The CBOR path has no inherent cap, so a malicious 100KB payload costs
-    # ~25 seconds of O(n^2) string-concat + integer-divide CPU per tx. The
-    # >200 byte cap rejects that before doing any work. NOTE: we don't gate
-    # the cap because (a) a 250-char longname (validate_subasset_longname's
-    # max) needs only ceil(250*log2(68)/8) = 191 bytes, well under 200, and
-    # (b) any historical post-902000 mainnet tx with a >200-byte compacted
-    # payload would have failed validate_subasset_longname downstream
-    # anyway -- this just prevents the DoS budget from being spent first.
-    # If a mainnet snapshot scan ever surfaces a successfully-issued
-    # subasset whose compacted bytes exceed 200, gate this cap behind a
-    # protocol entry.
-    if len(raw_bytes) > 200:
-        raise exceptions.AssetNameError("compacted subasset name too long")
+    # ~25 seconds of O(n^2) string-concat + integer-divide CPU per tx.
+    # Gated behind `subasset_compact_expand_cap` so re-indexing blocks before
+    # activation keeps the same invalid-status strings in the messages journal.
+    from counterpartycore.lib.parser import protocol  # noqa: PLC0415
+
+    if protocol.enabled("subasset_compact_expand_cap", block_index=block_index):
+        if len(raw_bytes) > 200:
+            raise exceptions.AssetNameError("compacted subasset name too long")
     integer = int.from_bytes(raw_bytes, byteorder="big")
     if integer == 0:
         return ""

--- a/counterparty-core/counterpartycore/lib/utils/assetnames.py
+++ b/counterparty-core/counterpartycore/lib/utils/assetnames.py
@@ -201,7 +201,7 @@ def expand_subasset_longname(raw_bytes, block_index=None):
     # ~25 seconds of O(n^2) string-concat + integer-divide CPU per tx.
     # Gated behind `subasset_compact_expand_cap` so re-indexing blocks before
     # activation keeps the same invalid-status strings in the messages journal.
-    from counterpartycore.lib.parser import protocol  # noqa: PLC0415
+    from counterpartycore.lib.parser import protocol  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
 
     if protocol.enabled("subasset_compact_expand_cap", block_index=block_index):
         if len(raw_bytes) > 200:

--- a/counterparty-core/counterpartycore/lib/utils/assetnames.py
+++ b/counterparty-core/counterpartycore/lib/utils/assetnames.py
@@ -201,7 +201,9 @@ def expand_subasset_longname(raw_bytes, block_index=None):
     # ~25 seconds of O(n^2) string-concat + integer-divide CPU per tx.
     # Gated behind `subasset_compact_expand_cap` so re-indexing blocks before
     # activation keeps the same invalid-status strings in the messages journal.
-    from counterpartycore.lib.parser import protocol  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+    from counterpartycore.lib.parser import (  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+        protocol,
+    )
 
     if protocol.enabled("subasset_compact_expand_cap", block_index=block_index):
         if len(raw_bytes) > 200:

--- a/counterparty-core/counterpartycore/lib/utils/helpers.py
+++ b/counterparty-core/counterpartycore/lib/utils/helpers.py
@@ -483,7 +483,7 @@ def check_content(mime_type, content, block_index=None):
         type_to_check = content_mime_type
         # Use the built-in default map only; never `types_map.values()` which
         # picks up OS-specific entries if anything calls mimetypes.init().
-        valid_types = mimetypes._types_map_default.values()  # noqa: SLF001
+        valid_types = mimetypes._types_map_default.values()  # noqa: SLF001  # pylint: disable=protected-access
     if type_to_check not in valid_types:
         problems.append(f"Invalid mime type: {mime_type}")
     try:

--- a/counterparty-core/counterpartycore/lib/utils/helpers.py
+++ b/counterparty-core/counterpartycore/lib/utils/helpers.py
@@ -481,7 +481,9 @@ def check_content(mime_type, content, block_index=None):
         # platform-specific entries are NOT loaded -- this is the
         # historical behaviour we are preserving for the legacy path.
         type_to_check = content_mime_type
-        valid_types = mimetypes.types_map.values()
+        # Use the built-in default map only; never `types_map.values()` which
+        # picks up OS-specific entries if anything calls mimetypes.init().
+        valid_types = mimetypes._types_map_default.values()  # noqa: SLF001
     if type_to_check not in valid_types:
         problems.append(f"Invalid mime type: {mime_type}")
     try:

--- a/counterparty-core/counterpartycore/protocol_changes.json
+++ b/counterparty-core/counterpartycore/protocol_changes.json
@@ -1338,5 +1338,77 @@
         "testnet3_block_index": 4961000,
         "testnet4_block_index": 136000,
         "signet_block_index": 310000
+    },
+    "subasset_compact_expand_cap": {
+        "minimum_version_major": 11,
+        "minimum_version_minor": 1,
+        "minimum_version_revision": 0,
+        "block_index": 952500,
+        "testnet3_block_index": 4961000,
+        "testnet4_block_index": 136000,
+        "signet_block_index": 310000
+    },
+    "persist_invalid_sweep": {
+        "minimum_version_major": 11,
+        "minimum_version_minor": 1,
+        "minimum_version_revision": 0,
+        "block_index": 952500,
+        "testnet3_block_index": 4961000,
+        "testnet4_block_index": 136000,
+        "signet_block_index": 310000
+    },
+    "fairminter_integer_fee_paid": {
+        "minimum_version_major": 11,
+        "minimum_version_minor": 1,
+        "minimum_version_revision": 0,
+        "block_index": 952500,
+        "testnet3_block_index": 4961000,
+        "testnet4_block_index": 136000,
+        "signet_block_index": 310000
+    },
+    "dispense_skip_unusable_oracle_price": {
+        "minimum_version_major": 11,
+        "minimum_version_minor": 1,
+        "minimum_version_revision": 0,
+        "block_index": 952500,
+        "testnet3_block_index": 4961000,
+        "testnet4_block_index": 136000,
+        "signet_block_index": 310000
+    },
+    "broadcast_safe_unpack": {
+        "minimum_version_major": 11,
+        "minimum_version_minor": 1,
+        "minimum_version_revision": 0,
+        "block_index": 952500,
+        "testnet3_block_index": 4961000,
+        "testnet4_block_index": 136000,
+        "signet_block_index": 310000
+    },
+    "broadcast_safe_validate": {
+        "minimum_version_major": 11,
+        "minimum_version_minor": 1,
+        "minimum_version_revision": 0,
+        "block_index": 952500,
+        "testnet3_block_index": 4961000,
+        "testnet4_block_index": 136000,
+        "signet_block_index": 310000
+    },
+    "issuance_safe_unpack": {
+        "minimum_version_major": 11,
+        "minimum_version_minor": 1,
+        "minimum_version_revision": 0,
+        "block_index": 952500,
+        "testnet3_block_index": 4961000,
+        "testnet4_block_index": 136000,
+        "signet_block_index": 310000
+    },
+    "issuance_safe_validate": {
+        "minimum_version_major": 11,
+        "minimum_version_minor": 1,
+        "minimum_version_revision": 0,
+        "block_index": 952500,
+        "testnet3_block_index": 4961000,
+        "testnet4_block_index": 136000,
+        "signet_block_index": 310000
     }
 }

--- a/counterparty-core/counterpartycore/protocol_changes.json
+++ b/counterparty-core/counterpartycore/protocol_changes.json
@@ -1262,153 +1262,153 @@
         "minimum_version_major": 11,
         "minimum_version_minor": 1,
         "minimum_version_revision": 0,
-        "block_index": 952500,
-        "testnet3_block_index": 4961000,
-        "testnet4_block_index": 136000,
-        "signet_block_index": 310000
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     },
     "canonical_subasset_compact": {
         "minimum_version_major": 11,
         "minimum_version_minor": 1,
         "minimum_version_revision": 0,
-        "block_index": 952500,
-        "testnet3_block_index": 4961000,
-        "testnet4_block_index": 136000,
-        "signet_block_index": 310000
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     },
     "check_btcpay_destination": {
         "minimum_version_major": 11,
         "minimum_version_minor": 1,
         "minimum_version_revision": 0,
-        "block_index": 952500,
-        "testnet3_block_index": 4961000,
-        "testnet4_block_index": 136000,
-        "signet_block_index": 310000
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     },
     "fix_attach_op_return_check": {
         "minimum_version_major": 11,
         "minimum_version_minor": 1,
         "minimum_version_revision": 0,
-        "block_index": 952500,
-        "testnet3_block_index": 4961000,
-        "testnet4_block_index": 136000,
-        "signet_block_index": 310000
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     },
     "extended_mime_types_support": {
         "minimum_version_major": 11,
         "minimum_version_minor": 1,
         "minimum_version_revision": 0,
-        "block_index": 952500,
-        "testnet3_block_index": 4961000,
-        "testnet4_block_index": 136000,
-        "signet_block_index": 310000
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     },
     "ordinals_metadata_support": {
         "minimum_version_major": 11,
         "minimum_version_minor": 1,
         "minimum_version_revision": 0,
-        "block_index": 952500,
-        "testnet3_block_index": 4961000,
-        "testnet4_block_index": 136000,
-        "signet_block_index": 310000
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     },
     "indefinite_orders": {
         "minimum_version_major": 11,
         "minimum_version_minor": 1,
         "minimum_version_revision": 0,
-        "block_index": 952500,
-        "testnet3_block_index": 4961000,
-        "testnet4_block_index": 136000,
-        "signet_block_index": 310000
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     },
     "amm_pools": {
         "minimum_version_major": 11,
         "minimum_version_minor": 1,
         "minimum_version_revision": 0,
-        "block_index": 952500,
-        "testnet3_block_index": 4961000,
-        "testnet4_block_index": 136000,
-        "signet_block_index": 310000
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     },
     "catch_invalid_dispenser_asset_id": {
         "minimum_version_major": 11,
         "minimum_version_minor": 1,
         "minimum_version_revision": 0,
-        "block_index": 952500,
-        "testnet3_block_index": 4961000,
-        "testnet4_block_index": 136000,
-        "signet_block_index": 310000
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     },
     "subasset_compact_expand_cap": {
         "minimum_version_major": 11,
         "minimum_version_minor": 1,
         "minimum_version_revision": 0,
-        "block_index": 952500,
-        "testnet3_block_index": 4961000,
-        "testnet4_block_index": 136000,
-        "signet_block_index": 310000
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     },
     "persist_invalid_sweep": {
         "minimum_version_major": 11,
         "minimum_version_minor": 1,
         "minimum_version_revision": 0,
-        "block_index": 952500,
-        "testnet3_block_index": 4961000,
-        "testnet4_block_index": 136000,
-        "signet_block_index": 310000
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     },
     "fairminter_integer_fee_paid": {
         "minimum_version_major": 11,
         "minimum_version_minor": 1,
         "minimum_version_revision": 0,
-        "block_index": 952500,
-        "testnet3_block_index": 4961000,
-        "testnet4_block_index": 136000,
-        "signet_block_index": 310000
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     },
     "dispense_skip_unusable_oracle_price": {
         "minimum_version_major": 11,
         "minimum_version_minor": 1,
         "minimum_version_revision": 0,
-        "block_index": 952500,
-        "testnet3_block_index": 4961000,
-        "testnet4_block_index": 136000,
-        "signet_block_index": 310000
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     },
     "broadcast_safe_unpack": {
         "minimum_version_major": 11,
         "minimum_version_minor": 1,
         "minimum_version_revision": 0,
-        "block_index": 952500,
-        "testnet3_block_index": 4961000,
-        "testnet4_block_index": 136000,
-        "signet_block_index": 310000
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     },
     "broadcast_safe_validate": {
         "minimum_version_major": 11,
         "minimum_version_minor": 1,
         "minimum_version_revision": 0,
-        "block_index": 952500,
-        "testnet3_block_index": 4961000,
-        "testnet4_block_index": 136000,
-        "signet_block_index": 310000
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     },
     "issuance_safe_unpack": {
         "minimum_version_major": 11,
         "minimum_version_minor": 1,
         "minimum_version_revision": 0,
-        "block_index": 952500,
-        "testnet3_block_index": 4961000,
-        "testnet4_block_index": 136000,
-        "signet_block_index": 310000
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     },
     "issuance_safe_validate": {
         "minimum_version_major": 11,
         "minimum_version_minor": 1,
         "minimum_version_revision": 0,
-        "block_index": 952500,
-        "testnet3_block_index": 4961000,
-        "testnet4_block_index": 136000,
-        "signet_block_index": 310000
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     }
 }

--- a/counterparty-core/counterpartycore/test/units/messages/fuzz_parse_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/fuzz_parse_test.py
@@ -30,6 +30,8 @@ from counterpartycore.lib.messages import (
     fairminter,
     issuance,
     order,
+    pooldeposit,
+    poolwithdraw,
     sweep,
 )
 from counterpartycore.lib.messages.versions import enhancedsend, mpma, send1
@@ -303,3 +305,31 @@ def test_fuzz_mpma_parse(ledger_db, blockchain_mock, defaults, message):
         pass  # Hypothesis reuses ledger_db across examples; known test artifact
     except Exception as exc:
         pytest.fail(f"mpma.parse raised {type(exc).__name__}: {exc}")
+
+
+@settings(
+    max_examples=100, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture]
+)
+@given(msg_bytes)
+def test_fuzz_pooldeposit_parse(ledger_db, blockchain_mock, defaults, message):
+    tx = _dummy_tx(blockchain_mock, ledger_db, defaults)
+    try:
+        pooldeposit.parse(ledger_db, tx, message)
+    except apsw.ConstraintError:
+        pass
+    except Exception as exc:
+        pytest.fail(f"pooldeposit.parse raised {type(exc).__name__}: {exc}")
+
+
+@settings(
+    max_examples=100, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture]
+)
+@given(msg_bytes)
+def test_fuzz_poolwithdraw_parse(ledger_db, blockchain_mock, defaults, message):
+    tx = _dummy_tx(blockchain_mock, ledger_db, defaults)
+    try:
+        poolwithdraw.parse(ledger_db, tx, message)
+    except apsw.ConstraintError:
+        pass
+    except Exception as exc:
+        pytest.fail(f"poolwithdraw.parse raised {type(exc).__name__}: {exc}")

--- a/counterparty-core/counterpartycore/test/units/messages/pooldeposit_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/pooldeposit_test.py
@@ -601,6 +601,50 @@ def test_validate_xcp_fee_insufficient(ledger_db, defaults, blockchain_mock):
 # lp_asset / lp_asset_id plumbing for first-deposit txs.
 
 
+def test_validate_rejects_depleted_pool_reserve(ledger_db, defaults, blockchain_mock):
+    """A pool with a zero reserve must be rejected without raising (no div-by-zero)."""
+    quantity = defaults["quantity"] // 4
+    source = defaults["addresses"][0]
+    tx = blockchain_mock.dummy_tx(ledger_db, source)
+    _, _, data = pooldeposit.compose(ledger_db, source, "XCP", "DIVISIBLE", quantity, quantity)
+    pooldeposit.parse(ledger_db, tx, data[1:])
+
+    sorted_a, sorted_b = ledger.markets.sort_pair("XCP", "DIVISIBLE")
+    pool = ledger.markets.get_pool(ledger_db, sorted_a, sorted_b)
+    ledger.markets.update_pool(ledger_db, sorted_a, sorted_b, 0, pool["reserve_b"])
+
+    problems = pooldeposit.validate(ledger_db, source, "XCP", "DIVISIBLE", 1, 1)
+    assert any("pool has no liquidity" in p for p in problems)
+
+
+def test_parse_rejects_depleted_pool_reserve(ledger_db, defaults, blockchain_mock):
+    quantity = defaults["quantity"] // 4
+    source = defaults["addresses"][0]
+    tx = blockchain_mock.dummy_tx(ledger_db, source)
+    _, _, data = pooldeposit.compose(ledger_db, source, "XCP", "DIVISIBLE", quantity, quantity)
+    pooldeposit.parse(ledger_db, tx, data[1:])
+
+    sorted_a, sorted_b = ledger.markets.sort_pair("XCP", "DIVISIBLE")
+    pool = ledger.markets.get_pool(ledger_db, sorted_a, sorted_b)
+    ledger.markets.update_pool(ledger_db, sorted_a, sorted_b, 0, pool["reserve_b"])
+
+    tx2 = blockchain_mock.dummy_tx(ledger_db, source)
+    with pytest.raises(exceptions.ComposeError):
+        pooldeposit.compose(ledger_db, source, "XCP", "DIVISIBLE", 1, 1)
+
+    _, _, data2 = pooldeposit.compose(
+        ledger_db, source, "XCP", "DIVISIBLE", 1, 1, skip_validation=True
+    )
+    pooldeposit.parse(ledger_db, tx2, data2[1:])
+
+    cursor = ledger_db.cursor()
+    row = cursor.execute(
+        "SELECT status FROM pool_deposits WHERE tx_hash = ? ORDER BY rowid DESC LIMIT 1",
+        (tx2["tx_hash"],),
+    ).fetchone()
+    assert row["status"] == "invalid: pool has no liquidity"
+
+
 def test_validate_first_deposit_requires_lp_asset(ledger_db, defaults):
     problems = pooldeposit.validate(
         ledger_db,

--- a/counterparty-core/counterpartycore/test/units/messages/replay_safe_gates_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/replay_safe_gates_test.py
@@ -1,0 +1,24 @@
+"""Tests that v11.1 replay-sensitive behavior is gated at activation."""
+
+from counterpartycore.lib.messages import sweep
+from counterpartycore.test.mocks.counterpartydbs import ProtocolChangesDisabled
+
+
+def test_persist_invalid_sweep_gate_off_skips_journal(ledger_db, blockchain_mock, defaults):
+    tx = blockchain_mock.dummy_tx(ledger_db, defaults["addresses"][0])
+    with ProtocolChangesDisabled(["persist_invalid_sweep"]):
+        sweep.parse(ledger_db, tx, b"\x00" * 10)
+
+    cursor = ledger_db.cursor()
+    rows = cursor.execute("SELECT * FROM sweeps WHERE tx_hash = ?", (tx["tx_hash"],)).fetchall()
+    assert len(rows) == 0
+
+
+def test_persist_invalid_sweep_gate_on_inserts(ledger_db, blockchain_mock, defaults):
+    tx = blockchain_mock.dummy_tx(ledger_db, defaults["addresses"][0])
+    sweep.parse(ledger_db, tx, b"\x00" * 10)
+
+    cursor = ledger_db.cursor()
+    rows = cursor.execute("SELECT * FROM sweeps WHERE tx_hash = ?", (tx["tx_hash"],)).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["status"].startswith("invalid:")

--- a/counterparty-core/counterpartycore/test/units/utils/assetnames_test.py
+++ b/counterparty-core/counterpartycore/test/units/utils/assetnames_test.py
@@ -238,9 +238,15 @@ def test_expand_subasset_longname_rejects_oversized():
     consumed ~25s of CPU on a 100KB payload. The fix caps input at 200
     bytes (a 250-char base68 longname needs only 191 bytes).
     """
+    from counterpartycore.test.mocks.counterpartydbs import ProtocolChangesDisabled
+
+    # Gate off: oversized payload is not rejected at expand time (legacy replay).
+    with ProtocolChangesDisabled(["subasset_compact_expand_cap"]):
+        assetnames.expand_subasset_longname(b"\x01" * 30, block_index=999999)
+
+    # Gate on: cap enforced.
     with pytest.raises(exceptions.AssetNameError, match="too long"):
-        assetnames.expand_subasset_longname(b"\xff" * 1000)
-    # Boundary: 200 bytes accepted, 201 rejected.
-    assetnames.expand_subasset_longname(b"\x01" * 200)
+        assetnames.expand_subasset_longname(b"\xff" * 1000, block_index=999999)
+    assetnames.expand_subasset_longname(b"\x01" * 200, block_index=999999)
     with pytest.raises(exceptions.AssetNameError):
-        assetnames.expand_subasset_longname(b"\x01" * 201)
+        assetnames.expand_subasset_longname(b"\x01" * 201, block_index=999999)

--- a/counterparty-core/counterpartycore/test/units/utils/assetnames_test.py
+++ b/counterparty-core/counterpartycore/test/units/utils/assetnames_test.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 from counterpartycore.lib import config, exceptions
 from counterpartycore.lib.utils import assetnames
+from counterpartycore.test.mocks.counterpartydbs import ProtocolChangesDisabled
 
 
 def test_parse_subasset_from_asset_name():
@@ -238,8 +239,6 @@ def test_expand_subasset_longname_rejects_oversized():
     consumed ~25s of CPU on a 100KB payload. The fix caps input at 200
     bytes (a 250-char base68 longname needs only 191 bytes).
     """
-    from counterpartycore.test.mocks.counterpartydbs import ProtocolChangesDisabled
-
     # Gate off: oversized payload is not rejected at expand time (legacy replay).
     with ProtocolChangesDisabled(["subasset_compact_expand_cap"]):
         assetnames.expand_subasset_longname(b"\x01" * 30, block_index=999999)


### PR DESCRIPTION
## Summary

Follow-up to the v11.1.0 review: keep **pre-activation `messages_hash` stable** on re-index while still hardening parse paths for txs at/after block **952500**. Also fixes a consensus-risk **div-by-zero** in `pooldeposit` when a pool has a zero reserve.

- **8 new protocol gates** (all at mainnet 952500) for journal/replay-sensitive behavior
- **AMM defensive guards**: reject depleted pools (`reserve_a == 0` or `reserve_b == 0`) as `invalid:` — never `ZeroDivisionError`
- **MIME pre-gate**: use `mimetypes._types_map_default` instead of `types_map.values()` (deterministic across OS)
- **API quotes**: `pool_has_liquidity()` for deposit/withdraw quotes (avoids div-by-zero off-chain)
- **Tests**: depleted-pool deposit tests, gated expand-cap test, `persist_invalid_sweep` gate test, pool fuzz parse tests

## Protocol gates (activate at block 952500)

| Gate | Behavior when enabled |
|------|------------------------|
| `subasset_compact_expand_cap` | Reject compacted subasset payloads > 200 bytes before expand (DoS + journal status) |
| `persist_invalid_sweep` | Insert `INVALID_SWEEP` row + journal entry for invalid sweeps |
| `fairminter_integer_fee_paid` | Store `fee_paid` as `int` in fairminter bindings |
| `dispense_skip_unusable_oracle_price` | Treat oracle `last_price <= 0` as `NoPriceError`; skip dispenser in parse |
| `broadcast_safe_unpack` | Broad `except` in broadcast unpack → `invalid:` (no halt) |
| `broadcast_safe_validate` | Catch validate type errors → `invalid: validation error` |
| `issuance_safe_unpack` | Catch `AssetNameError`, `struct.error`, etc. in unpack → `invalid:` |
| `issuance_safe_validate` | Catch validate type errors → `invalid: validation error` |

Pre-gate blocks replay with **legacy** behavior (halt or prior status strings). Post-gate blocks get hardened, defensive parse.

## AMM / pooldeposit

- `validate()` and `parse()` reject pools where `pool_has_liquidity()` is false **before** gas fee debit
- `compute_actual_deposit_amounts()` returns `(0, 0)` if either reserve is zero (belt-and-suspenders)

## Pre-merge checklist

### Code / consensus

- [ ] Review protocol gate names and activation heights (952500 / testnet / testnet4 / signet)
- [ ] Confirm intentional: post-gate invalid sweeps appear in `sweeps` + journal
- [ ] Confirm intentional: post-gate fairminter `fee_paid` is integer in bindings JSON
- [ ] Confirm intentional: post-gate dispense skips (not halts) on non-positive oracle price
- [ ] Confirm intentional: post-gate broadcast/issuance mark crafted bytes invalid instead of halting

### Tests (CI)

- [ ] Unit: `pooldeposit_test` depleted reserve cases
- [ ] Unit: `replay_safe_gates_test`, `assetnames_test` expand cap gate
- [ ] Fuzz: `pooldeposit` / `poolwithdraw` added to `fuzz_parse_test.py`
- [ ] Full unit matrix (Python 3.10–3.13)
- [ ] Regtest scenarios (`scenario_26_pools`, `scenario_28_indefinite_orders`)

### Replay / ops (recommended before mainnet activation)

- [ ] Re-index a mainnet snapshot **before** and **after** this branch; compare `messages_hash` per block for `block_index < 952500` (should match prior v11.1 develop indexing)
- [ ] Spot-check blocks `>= 952500` on testnet4/signet with pool + indefinite order scenarios
- [ ] Optional SQL scans (pre-952500 only): oversized subasset compact payloads, invalid sweeps count, oracle dispense with `last_price <= 0`

### Documentation

- [ ] Add release-note bullets for new gates (if merging into v11.1.0 release notes)

## Test plan

```bash
cd counterparty-core
pytest counterpartycore/test/units/messages/pooldeposit_test.py -k depleted
pytest counterpartycore/test/units/messages/replay_safe_gates_test.py
pytest counterpartycore/test/units/utils/assetnames_test.py -k expand_subasset
pytest counterpartycore/test/units/messages/fuzz_parse_test.py -k pool
```