### PR TITLE
Validate malformed btcpay order match IDs

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/btcpay.py
+++ b/counterparty-core/counterpartycore/lib/messages/btcpay.py
@@ -65,12 +65,31 @@ def validate(db, source, order_match_id, block_index):  # pylint: disable=unused
     return destination, btc_quantity, escrowed_asset, escrowed_quantity, order_match, problems
 
 
-def compose(db, source: str, order_match_id: str, skip_validation: bool = False):
-    assert order_match_id[64] == "_"
+def _decode_order_match_id(order_match_id: str):
+    if (
+        not isinstance(order_match_id, str)
+        or len(order_match_id) != 129
+        or order_match_id[64] != "_"
+    ):
+        raise exceptions.ComposeError(["invalid order match id"])
+
     tx0_hash, tx1_hash = (
         order_match_id[:64],
         order_match_id[65:],
     )  # UTF-8 encoding means that the indices are doubled.
+    try:
+        tx0_hash_bytes, tx1_hash_bytes = (
+            binascii.unhexlify(bytes(tx0_hash, "utf-8")),
+            binascii.unhexlify(bytes(tx1_hash, "utf-8")),
+        )
+    except binascii.Error as exc:
+        raise exceptions.ComposeError(["invalid order match id"]) from exc
+
+    return tx0_hash, tx1_hash, tx0_hash_bytes, tx1_hash_bytes
+
+
+def compose(db, source: str, order_match_id: str, skip_validation: bool = False):
+    tx0_hash, tx1_hash, tx0_hash_bytes, tx1_hash_bytes = _decode_order_match_id(order_match_id)
 
     destination, btc_quantity, _escrowed_asset, _escrowed_quantity, order_match, problems = (
         validate(db, source, order_match_id, CurrentState().current_block_index())
@@ -88,10 +107,6 @@ def compose(db, source: str, order_match_id: str, skip_validation: bool = False)
     if 10 - time_left < 4:
         logger.warning("Order match has only %s confirmation(s).", 10 - time_left)
 
-    tx0_hash_bytes, tx1_hash_bytes = (
-        binascii.unhexlify(bytes(tx0_hash, "utf-8")),
-        binascii.unhexlify(bytes(tx1_hash, "utf-8")),
-    )
     data = messagetype.pack(ID)
     data += struct.pack(FORMAT, tx0_hash_bytes, tx1_hash_bytes)
     return (source, [(destination, btc_quantity)], data)

--- a/counterparty-core/counterpartycore/test/units/messages/btcpay_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/btcpay_test.py
@@ -83,6 +83,20 @@ def test_validate_no_order_match(ledger_db):
     assert "no such order match" in problems[0]
 
 
+@pytest.mark.parametrize(
+    "order_match_id",
+    [
+        "",
+        "short",
+        "0" * 64 + "-" + "1" * 64,
+        "0" * 64 + "_" + "g" * 64,
+    ],
+)
+def test_compose_rejects_malformed_order_match_id(ledger_db, defaults, order_match_id):
+    with pytest.raises(exceptions.ComposeError, match="invalid order match id"):
+        btcpay.compose(ledger_db, defaults["addresses"][0], order_match_id)
+
+
 def test_validate_expired_order_match(ledger_db, defaults, monkeypatch):
     """Test btcpay validate with an expired order match."""
     fake_order_match_id = "abc_def"


### PR DESCRIPTION
## Summary
- validate `btcpay.compose()` order match IDs before indexing or hex decoding them
- raise `ComposeError(["invalid order match id"])` for malformed IDs instead of leaking raw `IndexError`, `AssertionError`, or `binascii.Error`
- add regression coverage for short IDs, wrong separators, and non-hex hash halves

## Reproducer
Before this change, callers could pass malformed `order_match_id` values through the compose path, for example `"short"` or `"0" * 64 + "-" + "1" * 64`, and get raw Python exceptions before normal compose validation.

## Tests
- `python3 -m py_compile counterparty-core/counterpartycore/lib/messages/btcpay.py counterparty-core/counterpartycore/test/units/messages/btcpay_test.py`
- `pytest counterparty-core/counterpartycore/test/units/messages/btcpay_test.py -q`
- `pytest counterparty-core/counterpartycore/test/units/api/compose_test.py -q`

## Bounty
If this qualifies under the Counterparty bug bounty program, bounty address: `15Dxp7sLdrjcao5gydZiVBitKSaTStRxva`
