### PR TITLE
Validate sweep binary memo hex before composing

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/sweep.py
+++ b/counterparty-core/counterpartycore/lib/messages/sweep.py
@@ -83,7 +83,10 @@ def compose(
     if memo is None:
         memo_bytes = b""
     elif flags & FLAG_BINARY_MEMO:
-        memo_bytes = bytes.fromhex(memo)
+        try:
+            memo_bytes = bytes.fromhex(memo)
+        except (TypeError, ValueError) as exc:
+            raise exceptions.ComposeError(["invalid memo hex"]) from exc
     else:
         memo_bytes = memo.encode("utf-8")
         memo_bytes = struct.pack(f">{len(memo_bytes)}s", memo_bytes)

--- a/counterparty-core/counterpartycore/test/units/messages/sweep_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/sweep_test.py
@@ -109,6 +109,9 @@ def test_compose(ledger_db, defaults, monkeypatch):
             b"\x04o\x9c\x8d\x1fT\x05E\x1d\xe6\x07\x0b\xf1\xdb\x86\xabj\xcc\xb4\x95\xb6%\x07\xca\xfe\xba\xbe",
         )
 
+        with pytest.raises(exceptions.ComposeError, match="invalid memo hex"):
+            sweep.compose(ledger_db, defaults["addresses"][6], defaults["addresses"][5], 7, "Z")
+
         monkeypatch.setattr(
             "counterpartycore.lib.messages.sweep.get_total_fee",
             lambda db, source, block_index: 1000000000000,


### PR DESCRIPTION
## Summary
- convert malformed binary sweep memo hex into a normal ComposeError
- add regression coverage for invalid `FLAG_BINARY_MEMO` compose input

## Bug
A public compose request for a sweep with `FLAG_BINARY_MEMO` set and malformed `memo` hex, for example `memo=Z`, reaches `bytes.fromhex(memo)` before validation and raises a raw Python `ValueError` instead of a normal compose validation error.

This is a separate compose/API validation issue from #3315: it is the `sweep` message, the public `memo` parameter, and the `bytes.fromhex` decoder path.

## Verification
- `python3 -m py_compile counterparty-core/counterpartycore/lib/messages/sweep.py counterparty-core/counterpartycore/test/units/messages/sweep_test.py`
- `. .test-venv/bin/activate && pytest counterparty-core/counterpartycore/test/units/messages/sweep_test.py -q` (`13 passed`)
- `. .test-venv/bin/activate && pytest counterparty-core/counterpartycore/test/units/api/compose_test.py -q` (`60 passed`)

Bounty address: 15Dxp7sLdrjcao5gydZiVBitKSaTStRxva