### PR TITLE
Validate enhanced send hex memo before composing

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/versions/enhancedsend.py
+++ b/counterparty-core/counterpartycore/lib/messages/versions/enhancedsend.py
@@ -164,7 +164,10 @@ def compose(
     if memo is None:
         memo_bytes = b""
     elif memo_is_hex:
-        memo_bytes = bytes.fromhex(memo)
+        try:
+            memo_bytes = bytes.fromhex(memo)
+        except ValueError as exc:
+            raise exceptions.ComposeError(["invalid memo hex"]) from exc
     else:
         memo_bytes = memo.encode("utf-8")
         memo_bytes = struct.pack(f">{len(memo_bytes)}s", memo_bytes)

--- a/counterparty-core/counterpartycore/test/units/messages/versions/enhancedsend_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/versions/enhancedsend_test.py
@@ -106,6 +106,20 @@ def test_compose_rejects_overflow_btc_quantity(ledger_db, defaults):
         )
 
 
+def test_compose_rejects_invalid_hex_memo(ledger_db, defaults):
+    with pytest.raises(exceptions.ComposeError, match="invalid memo hex"):
+        enhancedsend.compose(
+            ledger_db,
+            defaults["addresses"][0],
+            defaults["addresses"][1],
+            "XCP",
+            1000,
+            "not-hex",
+            True,
+            True,  # skip validation
+        )
+
+
 def test_unpack(ledger_db, defaults):
     assert enhancedsend.unpack(
         b"\x84\x01\x19\x03\xe8U\x01\x8dj\xe8\xa3\xb3\x81f1\x18\xb4\xe1\xef\xf4\xcf\xc7\xd0\x95M\xd6\xecDmemo"


### PR DESCRIPTION
### Summary

`enhancedsend.compose()` currently converts public `memo` input with `bytes.fromhex(memo)` whenever `memo_is_hex` is true. Malformed hex therefore raises a raw `ValueError` before the normal compose validation path can return a `ComposeError`.

This patch catches malformed hex memos and raises `ComposeError(["invalid memo hex"])` instead, matching the API-facing validation style used by compose callers.

### Verification

- `python3 -m py_compile counterparty-core/counterpartycore/lib/messages/versions/enhancedsend.py counterparty-core/counterpartycore/test/units/messages/versions/enhancedsend_test.py`
- `. .test-venv/bin/activate && pytest counterparty-core/counterpartycore/test/units/messages/versions/enhancedsend_test.py -q` (`15 passed`)
- `. .test-venv/bin/activate && pytest counterparty-core/counterpartycore/test/units/api/compose_test.py -q` (`60 passed`)
- `. .test-venv/bin/activate && pytest counterparty-core/counterpartycore/test/units/messages/send_test.py -q` (`15 passed`; rerun serially after an initial parallel run hit sqlite database locking)

Bounty address: `15Dxp7sLdrjcao5gydZiVBitKSaTStRxva`

AI assistance disclosure: I used Codex to inspect compose paths, implement the focused patch, and run the regression tests.