### PR TITLE
Validate cancel offer hashes before composing

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/cancel.py
+++ b/counterparty-core/counterpartycore/lib/messages/cancel.py
@@ -49,7 +49,14 @@ def compose(db, source: str, offer_hash: str, skip_validation: bool = False):
     if problems and not skip_validation:
         raise exceptions.ComposeError(problems)
 
-    offer_hash_bytes = binascii.unhexlify(bytes(offer_hash, "utf-8"))
+    if len(offer_hash) != 64:
+        raise exceptions.ComposeError(["invalid offer hash"])
+
+    try:
+        offer_hash_bytes = binascii.unhexlify(bytes(offer_hash, "utf-8"))
+    except binascii.Error as exc:
+        raise exceptions.ComposeError(["invalid offer hash"]) from exc
+
     data = messagetype.pack(ID)
     data += struct.pack(FORMAT, offer_hash_bytes)
     return (source, [], data)

--- a/counterparty-core/counterpartycore/test/units/messages/cancel_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/cancel_test.py
@@ -37,6 +37,14 @@ def test_compose(ledger_db, defaults):
         cancel.compose(ledger_db, closed_bet["source"], closed_bet["tx_hash"])
 
 
+def test_compose_rejects_invalid_offer_hash_with_skip_validation(ledger_db, defaults):
+    with pytest.raises(exceptions.ComposeError, match="invalid offer hash"):
+        cancel.compose(ledger_db, defaults["addresses"][0], "not-hex", skip_validation=True)
+
+    with pytest.raises(exceptions.ComposeError, match="invalid offer hash"):
+        cancel.compose(ledger_db, defaults["addresses"][0], "z" * 64, skip_validation=True)
+
+
 def test_unpack_invalid_length():
     offer_hash, status = cancel.unpack(b"short")
     assert offer_hash is None


### PR DESCRIPTION
### Summary

`cancel.compose()` normally reports unknown malformed offer hashes as a compose validation error. But when callers request `validate=false`, semantic validation is skipped and the function passes public `offer_hash` input directly into `binascii.unhexlify()`. Invalid hex or short hashes can therefore raise raw Python exceptions instead of a normal `ComposeError`.

This patch keeps the existing default validation behavior, then validates the 32-byte hex shape before packing the cancel payload.

### Verification

- `python3 -m py_compile counterparty-core/counterpartycore/lib/messages/cancel.py counterparty-core/counterpartycore/test/units/messages/cancel_test.py`
- `. .test-venv/bin/activate && pytest counterparty-core/counterpartycore/test/units/messages/cancel_test.py -q` (`5 passed`)
- `. .test-venv/bin/activate && pytest counterparty-core/counterpartycore/test/units/api/compose_test.py -q` (`60 passed`)

Bounty address: `15Dxp7sLdrjcao5gydZiVBitKSaTStRxva`

AI assistance disclosure: I used Codex to inspect compose paths, implement the focused patch, and run the regression tests.