### PR TITLE
Validate broadcast compose numeric fields

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/broadcast.py
+++ b/counterparty-core/counterpartycore/lib/messages/broadcast.py
@@ -21,6 +21,7 @@ because it is stored as a four‐byte integer, it may not be greater than about
 
 import decimal
 import logging
+import math
 import struct
 from fractions import Fraction
 
@@ -46,6 +47,7 @@ FORMAT = ">IdI"
 LENGTH = 4 + 8 + 4
 ID = 30
 BET_TYPE_ID = {"BullCFD": 0, "BearCFD": 1, "Equal": 2, "NotEqual": 3}
+UINT32_MAX = 2**32 - 1
 
 # NOTE: Pascal strings are used for storing texts for backwards‐compatibility.
 
@@ -70,6 +72,33 @@ def validate_address_options(options):
         raise exceptions.OptionsError("options out of range")
     if not helpers.active_options(config.ADDRESS_OPTION_MAX_VALUE, options):
         raise exceptions.OptionsError("options not possible")
+
+
+def is_finite_number(value):
+    try:
+        return math.isfinite(value)
+    except (TypeError, ValueError):
+        return False
+
+
+def validate_compose_fields(timestamp, value, fee_fraction):
+    problems = []
+
+    if not isinstance(timestamp, int) or timestamp < 0 or timestamp > UINT32_MAX:
+        problems.append("timestamp must be a 32-bit unsigned integer")
+
+    if not is_finite_number(value):
+        problems.append("value must be finite")
+
+    if not is_finite_number(fee_fraction):
+        problems.append("fee fraction must be finite")
+        fee_fraction_int = None
+    else:
+        fee_fraction_int = int(fee_fraction * 1e8)
+        if fee_fraction_int < 0 or fee_fraction_int > UINT32_MAX:
+            problems.append("fee fraction must fit in a 32-bit unsigned integer")
+
+    return problems, fee_fraction_int
 
 
 def validate(db, source, timestamp, value, fee_fraction_int, text, mime_type, block_index=None):
@@ -130,14 +159,18 @@ def compose(
     skip_validation: bool = False,
 ):
     # Store the fee fraction as an integer.
-    fee_fraction_int = int(fee_fraction * 1e8)
-
     broadcast_timestamp = timestamp
     if timestamp == 0:
         broadcasts = ledger.other.get_broadcasts_by_source(db, source, "valid", order_by="ASC")
         if broadcasts:
             last_broadcast = broadcasts[-1]
             broadcast_timestamp = last_broadcast["timestamp"] + 1
+
+    field_problems, fee_fraction_int = validate_compose_fields(
+        broadcast_timestamp, value, fee_fraction
+    )
+    if field_problems:
+        raise exceptions.ComposeError(field_problems)
 
     problems = validate(
         db,

--- a/counterparty-core/counterpartycore/test/units/messages/broadcast_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/broadcast_test.py
@@ -3,7 +3,7 @@ import struct
 import cbor2
 import pytest
 from bitcoin.core import VarIntSerializer
-from counterpartycore.lib import config
+from counterpartycore.lib import config, exceptions
 from counterpartycore.lib.messages import broadcast
 from counterpartycore.test.mocks.counterpartydbs import ProtocolChangesDisabled
 
@@ -293,6 +293,51 @@ def test_compose(ledger_db, defaults):
             defaults["addresses"][1],
             [],
             b"\x1e\x85\x1aR\xbb3d\x1a\x02\xfa\xf0\x80\x00`FBARFOO",
+        )
+
+
+def test_compose_rejects_unencodable_numeric_fields(ledger_db, defaults):
+    with pytest.raises(exceptions.ComposeError, match="timestamp must be"):
+        broadcast.compose(
+            ledger_db,
+            defaults["addresses"][0],
+            2**32,
+            1,
+            0,
+            "Unit Test",
+            skip_validation=True,
+        )
+
+    with pytest.raises(exceptions.ComposeError, match="value must be finite"):
+        broadcast.compose(
+            ledger_db,
+            defaults["addresses"][0],
+            1588000000,
+            float("nan"),
+            0,
+            "Unit Test",
+        )
+
+    with pytest.raises(exceptions.ComposeError, match="fee fraction must fit"):
+        broadcast.compose(
+            ledger_db,
+            defaults["addresses"][0],
+            1588000000,
+            1,
+            -0.01,
+            "Unit Test",
+            skip_validation=True,
+        )
+
+    with pytest.raises(exceptions.ComposeError, match="fee fraction must be finite"):
+        broadcast.compose(
+            ledger_db,
+            defaults["addresses"][0],
+            1588000000,
+            1,
+            float("inf"),
+            "Unit Test",
+            skip_validation=True,
         )
 
 


### PR DESCRIPTION
Summary:
- Reject broadcast compose timestamps that cannot fit the legacy 32-bit wire field before packing.
- Reject non-finite broadcast values and non-finite or out-of-range fee fractions before data construction.
- Add unit coverage for these compose-time guards, including validate=false cases that previously reached packing errors.

Why:
Malformed compose inputs such as timestamp=4294967296 or a negative fee_fraction with validate=false can reach struct.pack and surface as an internal server error instead of a normal compose validation error. Non-finite values such as NaN are also not meaningful broadcast payloads and should not be emitted by the composer.

Tests:
- ./.venv/bin/pytest -q counterparty-core/counterpartycore/test/units/messages/broadcast_test.py
- ./.venv/bin/pytest -q counterparty-core/counterpartycore/test/units/messages/broadcast_test.py counterparty-core/counterpartycore/test/units/api/composer_test.py -k broadcast
- ./.venv/bin/pytest -q counterparty-core/counterpartycore/test/units/api/compose_test.py
- git diff --check

Bounty claim:
If this qualifies under the Counterparty bug bounty, please pay the BTC portion to: bc1qa5acxqc3wldzxwjhe8a65gjp6n7dxmafm6qs4j