### PR TITLE
Validate malformed compose inputs

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/btcpay.py
+++ b/counterparty-core/counterpartycore/lib/messages/btcpay.py
@@ -65,12 +65,31 @@ def validate(db, source, order_match_id, block_index):  # pylint: disable=unused
     return destination, btc_quantity, escrowed_asset, escrowed_quantity, order_match, problems
 
 
-def compose(db, source: str, order_match_id: str, skip_validation: bool = False):
-    assert order_match_id[64] == "_"
+def _decode_order_match_id(order_match_id: str):
+    if (
+        not isinstance(order_match_id, str)
+        or len(order_match_id) != 129
+        or order_match_id[64] != "_"
+    ):
+        raise exceptions.ComposeError(["invalid order match id"])
+
     tx0_hash, tx1_hash = (
         order_match_id[:64],
         order_match_id[65:],
     )  # UTF-8 encoding means that the indices are doubled.
+    try:
+        tx0_hash_bytes, tx1_hash_bytes = (
+            binascii.unhexlify(bytes(tx0_hash, "utf-8")),
+            binascii.unhexlify(bytes(tx1_hash, "utf-8")),
+        )
+    except binascii.Error as exc:
+        raise exceptions.ComposeError(["invalid order match id"]) from exc
+
+    return tx0_hash, tx1_hash, tx0_hash_bytes, tx1_hash_bytes
+
+
+def compose(db, source: str, order_match_id: str, skip_validation: bool = False):
+    tx0_hash, tx1_hash, tx0_hash_bytes, tx1_hash_bytes = _decode_order_match_id(order_match_id)
 
     destination, btc_quantity, _escrowed_asset, _escrowed_quantity, order_match, problems = (
         validate(db, source, order_match_id, CurrentState().current_block_index())
@@ -88,10 +107,6 @@ def compose(db, source: str, order_match_id: str, skip_validation: bool = False)
     if 10 - time_left < 4:
         logger.warning("Order match has only %s confirmation(s).", 10 - time_left)
 
-    tx0_hash_bytes, tx1_hash_bytes = (
-        binascii.unhexlify(bytes(tx0_hash, "utf-8")),
-        binascii.unhexlify(bytes(tx1_hash, "utf-8")),
-    )
     data = messagetype.pack(ID)
     data += struct.pack(FORMAT, tx0_hash_bytes, tx1_hash_bytes)
     return (source, [(destination, btc_quantity)], data)

--- a/counterparty-core/counterpartycore/lib/messages/cancel.py
+++ b/counterparty-core/counterpartycore/lib/messages/cancel.py
@@ -49,7 +49,14 @@ def compose(db, source: str, offer_hash: str, skip_validation: bool = False):
     if problems and not skip_validation:
         raise exceptions.ComposeError(problems)
 
-    offer_hash_bytes = binascii.unhexlify(bytes(offer_hash, "utf-8"))
+    if len(offer_hash) != 64:
+        raise exceptions.ComposeError(["invalid offer hash"])
+
+    try:
+        offer_hash_bytes = binascii.unhexlify(bytes(offer_hash, "utf-8"))
+    except binascii.Error as exc:
+        raise exceptions.ComposeError(["invalid offer hash"]) from exc
+
     data = messagetype.pack(ID)
     data += struct.pack(FORMAT, offer_hash_bytes)
     return (source, [], data)

--- a/counterparty-core/counterpartycore/lib/messages/sweep.py
+++ b/counterparty-core/counterpartycore/lib/messages/sweep.py
@@ -83,7 +83,10 @@ def compose(
     if memo is None:
         memo_bytes = b""
     elif flags & FLAG_BINARY_MEMO:
-        memo_bytes = bytes.fromhex(memo)
+        try:
+            memo_bytes = bytes.fromhex(memo)
+        except (TypeError, ValueError) as exc:
+            raise exceptions.ComposeError(["invalid memo hex"]) from exc
     else:
         memo_bytes = memo.encode("utf-8")
         memo_bytes = struct.pack(f">{len(memo_bytes)}s", memo_bytes)

--- a/counterparty-core/counterpartycore/lib/messages/versions/enhancedsend.py
+++ b/counterparty-core/counterpartycore/lib/messages/versions/enhancedsend.py
@@ -164,7 +164,10 @@ def compose(
     if memo is None:
         memo_bytes = b""
     elif memo_is_hex:
-        memo_bytes = bytes.fromhex(memo)
+        try:
+            memo_bytes = bytes.fromhex(memo)
+        except ValueError as exc:
+            raise exceptions.ComposeError(["invalid memo hex"]) from exc
     else:
         memo_bytes = memo.encode("utf-8")
         memo_bytes = struct.pack(f">{len(memo_bytes)}s", memo_bytes)

--- a/counterparty-core/counterpartycore/test/units/messages/btcpay_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/btcpay_test.py
@@ -83,6 +83,20 @@ def test_validate_no_order_match(ledger_db):
     assert "no such order match" in problems[0]
 
 
+@pytest.mark.parametrize(
+    "order_match_id",
+    [
+        "",
+        "short",
+        "0" * 64 + "-" + "1" * 64,
+        "0" * 64 + "_" + "g" * 64,
+    ],
+)
+def test_compose_rejects_malformed_order_match_id(ledger_db, defaults, order_match_id):
+    with pytest.raises(exceptions.ComposeError, match="invalid order match id"):
+        btcpay.compose(ledger_db, defaults["addresses"][0], order_match_id)
+
+
 def test_validate_expired_order_match(ledger_db, defaults, monkeypatch):
     """Test btcpay validate with an expired order match."""
     fake_order_match_id = "abc_def"

--- a/counterparty-core/counterpartycore/test/units/messages/cancel_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/cancel_test.py
@@ -37,6 +37,14 @@ def test_compose(ledger_db, defaults):
         cancel.compose(ledger_db, closed_bet["source"], closed_bet["tx_hash"])
 
 
+def test_compose_rejects_invalid_offer_hash_with_skip_validation(ledger_db, defaults):
+    with pytest.raises(exceptions.ComposeError, match="invalid offer hash"):
+        cancel.compose(ledger_db, defaults["addresses"][0], "not-hex", skip_validation=True)
+
+    with pytest.raises(exceptions.ComposeError, match="invalid offer hash"):
+        cancel.compose(ledger_db, defaults["addresses"][0], "z" * 64, skip_validation=True)
+
+
 def test_unpack_invalid_length():
     offer_hash, status = cancel.unpack(b"short")
     assert offer_hash is None

--- a/counterparty-core/counterpartycore/test/units/messages/sweep_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/sweep_test.py
@@ -109,6 +109,9 @@ def test_compose(ledger_db, defaults, monkeypatch):
             b"\x04o\x9c\x8d\x1fT\x05E\x1d\xe6\x07\x0b\xf1\xdb\x86\xabj\xcc\xb4\x95\xb6%\x07\xca\xfe\xba\xbe",
         )
 
+        with pytest.raises(exceptions.ComposeError, match="invalid memo hex"):
+            sweep.compose(ledger_db, defaults["addresses"][6], defaults["addresses"][5], 7, "Z")
+
         monkeypatch.setattr(
             "counterpartycore.lib.messages.sweep.get_total_fee",
             lambda db, source, block_index: 1000000000000,

--- a/counterparty-core/counterpartycore/test/units/messages/versions/enhancedsend_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/versions/enhancedsend_test.py
@@ -106,6 +106,20 @@ def test_compose_rejects_overflow_btc_quantity(ledger_db, defaults):
         )
 
 
+def test_compose_rejects_invalid_hex_memo(ledger_db, defaults):
+    with pytest.raises(exceptions.ComposeError, match="invalid memo hex"):
+        enhancedsend.compose(
+            ledger_db,
+            defaults["addresses"][0],
+            defaults["addresses"][1],
+            "XCP",
+            1000,
+            "not-hex",
+            True,
+            True,  # skip validation
+        )
+
+
 def test_unpack(ledger_db, defaults):
     assert enhancedsend.unpack(
         b"\x84\x01\x19\x03\xe8U\x01\x8dj\xe8\xa3\xb3\x81f1\x18\xb4\xe1\xef\xf4\xcf\xc7\xd0\x95M\xd6\xecDmemo"


### PR DESCRIPTION
## Summary
- validate malformed compose inputs in `btcpay`, `sweep`, `enhancedsend`, and `cancel` before indexing or decoding user-provided strings
- raise normal `ComposeError` validation failures instead of leaking raw Python exceptions such as `IndexError`, `AssertionError`, or `binascii.Error`
- consolidate the four focused fixes requested by maintainers into one PR targeting `develop`

## Covered cases
- `btcpay.compose()` malformed `order_match_id`
- `sweep.compose()` malformed binary memo hex
- `enhancedsend.compose()` malformed memo hex
- `cancel.compose(validate=false)` malformed offer hash

## Tests
- `python3 -m py_compile counterparty-core/counterpartycore/lib/messages/btcpay.py counterparty-core/counterpartycore/lib/messages/sweep.py counterparty-core/counterpartycore/lib/messages/versions/enhancedsend.py counterparty-core/counterpartycore/lib/messages/cancel.py counterparty-core/counterpartycore/test/units/messages/btcpay_test.py counterparty-core/counterpartycore/test/units/messages/sweep_test.py counterparty-core/counterpartycore/test/units/messages/versions/enhancedsend_test.py counterparty-core/counterpartycore/test/units/messages/cancel_test.py`
- `pytest counterparty-core/counterpartycore/test/units/messages/btcpay_test.py counterparty-core/counterpartycore/test/units/messages/sweep_test.py counterparty-core/counterpartycore/test/units/messages/versions/enhancedsend_test.py counterparty-core/counterpartycore/test/units/messages/cancel_test.py -q`

## Bounty
If this qualifies under the Counterparty bug bounty program, bounty address: `15Dxp7sLdrjcao5gydZiVBitKSaTStRxva`

Supersedes #3315, #3316, #3317, and #3318.
