### PR TITLE
Fix connection_count leak in APSWConnectionPool from short-lived threads

### DIFF
--- a/counterparty-core/counterpartycore/lib/utils/database.py
+++ b/counterparty-core/counterpartycore/lib/utils/database.py
@@ -2,6 +2,7 @@ import logging
 import os
 import threading
 import time
+import weakref
 from contextlib import contextmanager
 
 import apsw
@@ -100,6 +101,39 @@ def get_connection(read_only=True, check_wal=True):
     return get_db_connection(config.DATABASE, read_only=read_only, check_wal=check_wal)
 
 
+class _ThreadLocalConnections:
+    """
+    Per-thread connection cache. When CPython GCs this object (on thread exit),
+    __del__ closes any cached connections and decrements the pool counter,
+    preventing the connection_count leak caused by short-lived per-request
+    threads (e.g. Werkzeug threaded=True spawns one thread per HTTP request).
+    """
+
+    __slots__ = ("connections", "_pool_ref")
+
+    def __init__(self, pool):
+        self.connections = []
+        self._pool_ref = weakref.ref(pool)
+
+    def __del__(self):
+        pool = self._pool_ref()
+        if pool is None or not self.connections:
+            return
+        n = len(self.connections)
+        for db in self.connections:
+            try:
+                db.close()
+            except Exception:  # noqa: BLE001
+                pass
+        self.connections = []
+        if pool.closed:
+            return
+        with pool.connection_available:
+            pool.connection_count -= n
+            if n > 0:
+                pool.connection_available.notify_all()
+
+
 class APSWConnectionPool:
     def __init__(self, db_file, name):
         self.db_file = db_file
@@ -177,8 +211,8 @@ class APSWConnectionPool:
     @contextmanager
     def connection(self):
         # Fast path: initialize thread-local storage if needed
-        if not hasattr(self.thread_local, "connections"):
-            self.thread_local.connections = []
+        if not hasattr(self.thread_local, "state"):
+            self.thread_local.state = _ThreadLocalConnections(self)
 
         # Quick check without acquiring lock
         if self.closed:
@@ -190,20 +224,23 @@ class APSWConnectionPool:
                 db.close()
             return
 
+        thread_connections = self.thread_local.state.connections
+
         # Get or create a connection
-        if self.thread_local.connections:
+        if thread_connections:
             # Reuse existing connection - fast path without locking
-            db = self.thread_local.connections.pop()
+            db = thread_connections.pop()
             try:
                 # Minimal validation - use a cheap operation
                 cursor = db.execute("SELECT 1")
                 cursor.fetchone()
             except (apsw.ThreadingViolationError, apsw.BusyError):
-                # Close the bad connection before creating a new one
+                # Release the slot for the bad connection before acquiring a new one
                 try:
                     db.close()
                 except apsw.Error:  # noqa: S110
                     pass  # Connection may already be closed or in bad state
+                self._release_connection()
                 db = self._create_connection_with_limit()
         else:
             db = self._create_connection_with_limit()
@@ -217,8 +254,8 @@ class APSWConnectionPool:
                 self._release_connection()
             else:
                 # Fast path: return to local pool without locking
-                if len(self.thread_local.connections) < config.DB_CONNECTION_POOL_SIZE:
-                    self.thread_local.connections.append(db)
+                if len(thread_connections) < config.DB_CONNECTION_POOL_SIZE:
+                    thread_connections.append(db)
                 else:
                     # Close connection and notify waiters
                     db.close()
@@ -236,14 +273,14 @@ class APSWConnectionPool:
             self.connection_available.notify_all()
 
         # Close connections in current thread
-        if hasattr(self.thread_local, "connections"):
-            for db in self.thread_local.connections:
+        if hasattr(self.thread_local, "state"):
+            for db in self.thread_local.state.connections:
                 try:
                     db.close()
                 except apsw.ThreadingViolationError:
                     logger.trace("ThreadingViolationError occurred while closing connection.")
             # Clear thread local connections
-            self.thread_local.connections = []
+            self.thread_local.state.connections = []
 
     def get_stats(self):
         """Get current connection pool statistics."""

--- a/counterparty-core/counterpartycore/lib/utils/database.py
+++ b/counterparty-core/counterpartycore/lib/utils/database.py
@@ -123,8 +123,8 @@ class _ThreadLocalConnections:
         for db in self.connections:
             try:
                 db.close()
-            except Exception:  # noqa: BLE001
-                pass
+            except Exception as e:  # noqa: BLE001
+                logger.debug("Error closing connection: %s", e)
         self.connections = []
         if pool.closed:
             return

--- a/counterparty-core/counterpartycore/test/units/utils/database_test.py
+++ b/counterparty-core/counterpartycore/test/units/utils/database_test.py
@@ -107,8 +107,8 @@ def test_basic_connection(connection_pool, temp_db_file):
         assert result == {"1": 1}
 
     # The connection should be in the pool
-    assert hasattr(connection_pool.thread_local, "connections")
-    assert len(connection_pool.thread_local.connections) == 1
+    assert hasattr(connection_pool.thread_local, "state")
+    assert len(connection_pool.thread_local.state.connections) == 1
     assert connection_pool.connection_count == 1
 
 
@@ -126,7 +126,7 @@ def test_connection_reuse(connection_pool):
     assert conn1_id == conn2_id
 
     # The connection should be back in the pool
-    assert len(connection_pool.thread_local.connections) == 1
+    assert len(connection_pool.thread_local.state.connections) == 1
     assert connection_pool.connection_count == 1
 
 
@@ -141,7 +141,7 @@ def test_pool_full(connection_pool, monkeypatch):
             connections_created.append(id(conn))
 
     # Verify that we have at least one connection in the pool
-    assert len(connection_pool.thread_local.connections) == 1
+    assert len(connection_pool.thread_local.state.connections) == 1
 
     # Verify the connection count is correct
     assert connection_pool.connection_count == 1
@@ -159,7 +159,7 @@ def test_closed_pool(connection_pool):
         assert result == {"1": 1}
 
     # The connection should be closed, not added to the pool
-    assert len(getattr(connection_pool.thread_local, "connections", [])) == 0
+    assert len(connection_pool.thread_local.state.connections) == 0
     # The connection count should not have changed (the temporary connection is not counted)
     assert connection_pool.connection_count == 0
 
@@ -206,9 +206,40 @@ def test_multithreaded_use(connection_pool):
 
     assert not failures, f"Thread failures: {failures}"
 
-    # The total number of connections should be greater than 0
-    # We can't predict the exact number because of thread timing
-    assert connection_pool.connection_count > 0
+    # After all threads exit, _ThreadLocalConnections.__del__ releases their
+    # cached connections, so the pool count returns to 0 (no leak).
+    assert connection_pool.connection_count == 0
+
+
+def test_thread_exit_releases_connections(connection_pool):
+    """Regression test: connection_count must return to 0 when short-lived threads exit.
+
+    This guards against the v1 API leak where Werkzeug's threaded=True spawns a
+    new thread per request and each thread left its cached connections counted
+    permanently in connection_count.
+    """
+    import gc
+
+    def use_pool():
+        with connection_pool.connection():
+            pass  # acquire then release to thread-local cache
+
+    num_threads = 10
+    threads = []
+    for _ in range(num_threads):
+        t = threading.Thread(target=use_pool)
+        threads.append(t)
+        t.start()
+
+    for t in threads:
+        t.join()
+
+    # Force GC so __del__ fires on any lingering _ThreadLocalConnections objects
+    gc.collect()
+
+    assert connection_pool.connection_count == 0, (
+        f"connection_count leaked to {connection_pool.connection_count} after threads exited"
+    )
 
 
 def test_close_with_active_connections(connection_pool):
@@ -225,7 +256,7 @@ def test_close_with_active_connections(connection_pool):
         assert result == {"1": 1}
 
     # The connection should have been closed, not returned to the pool
-    assert len(getattr(connection_pool.thread_local, "connections", [])) == 0
+    assert len(connection_pool.thread_local.state.connections) == 0
     # The connection count should be 0 as it is decremented after use
     assert connection_pool.connection_count == 0
 
@@ -241,7 +272,7 @@ def test_connection_exception(connection_pool):
         assert str(e) == str(expected_error)
 
     # The connection should still be in the pool
-    assert len(connection_pool.thread_local.connections) == 1
+    assert len(connection_pool.thread_local.state.connections) == 1
     assert connection_pool.connection_count == 1
 
 
@@ -296,7 +327,8 @@ def test_concurrent_close(connection_pool):
     assert len(connections_made) == 5
 
     # All connections should be closed
-    assert len(getattr(connection_pool.thread_local, "connections", [])) == 0
+    state = getattr(connection_pool.thread_local, "state", None)
+    assert state is None or len(state.connections) == 0
 
 
 # Handle connection validation errors with a different approach
@@ -307,7 +339,7 @@ def test_threading_violation_error(connection_pool):
         pass
 
     # Now we have a connection in the pool - retrieve it
-    original_connection = connection_pool.thread_local.connections[0]
+    original_connection = connection_pool.thread_local.state.connections[0]
 
     # Create a wrapper for the original connection that will fail validation
     class ValidationFailingConnection:
@@ -326,7 +358,7 @@ def test_threading_violation_error(connection_pool):
             return getattr(self.real_conn, name)
 
     # Replace the real connection with our failing connection
-    connection_pool.thread_local.connections[0] = ValidationFailingConnection(original_connection)
+    connection_pool.thread_local.state.connections[0] = ValidationFailingConnection(original_connection)
 
     # Get a connection from the pool - should trigger validation failure
     with connection_pool.connection() as conn:
@@ -336,9 +368,8 @@ def test_threading_violation_error(connection_pool):
         result = cursor.fetchone()
         assert result == {"1": 1}
 
-    # The connection count should have increased because a new connection
-    # should have been created when validation failed
-    assert connection_pool.connection_count > 1
+    # The bad connection slot is released and a new one created: net count stays at 1
+    assert connection_pool.connection_count == 1
 
 
 def test_busy_error(connection_pool):
@@ -348,7 +379,7 @@ def test_busy_error(connection_pool):
         pass
 
     # Now we have a connection in the pool - retrieve it
-    original_connection = connection_pool.thread_local.connections[0]
+    original_connection = connection_pool.thread_local.state.connections[0]
 
     # Create a wrapper for the original connection that will fail validation
     class ValidationFailingConnection:
@@ -367,7 +398,7 @@ def test_busy_error(connection_pool):
             return getattr(self.real_conn, name)
 
     # Replace the real connection with our failing connection
-    connection_pool.thread_local.connections[0] = ValidationFailingConnection(original_connection)
+    connection_pool.thread_local.state.connections[0] = ValidationFailingConnection(original_connection)
 
     # Get a connection from the pool - should trigger validation failure
     with connection_pool.connection() as conn:
@@ -377,9 +408,8 @@ def test_busy_error(connection_pool):
         result = cursor.fetchone()
         assert result == {"1": 1}
 
-    # The connection count should have increased because a new connection
-    # should have been created when validation failed
-    assert connection_pool.connection_count > 1
+    # The bad connection slot is released and a new one created: net count stays at 1
+    assert connection_pool.connection_count == 1
 
 
 def test_connection_count_increment(connection_pool):
@@ -422,7 +452,7 @@ def test_pool_close(connection_pool):
         pass
 
     # Verify that there is a connection in the pool
-    assert len(connection_pool.thread_local.connections) == 1
+    assert len(connection_pool.thread_local.state.connections) == 1
 
     # Close the pool
     connection_pool.close()
@@ -431,7 +461,7 @@ def test_pool_close(connection_pool):
     assert connection_pool.closed
 
     # Verify that the connections list is empty
-    assert len(connection_pool.thread_local.connections) == 0
+    assert len(connection_pool.thread_local.state.connections) == 0
 
 
 def test_close_with_threading_violation(connection_pool):
@@ -465,9 +495,9 @@ def test_close_with_threading_violation(connection_pool):
             return getattr(self.real_conn, name)
 
     # Replace connections with our wrapper
-    original_connections = connection_pool.thread_local.connections.copy()
+    original_connections = connection_pool.thread_local.state.connections.copy()
     wrapped_connections = [ConnectionCloseRaiser(conn) for conn in original_connections]
-    connection_pool.thread_local.connections = wrapped_connections
+    connection_pool.thread_local.state.connections = wrapped_connections
 
     # Patch logger.trace
     with patch("counterpartycore.lib.utils.database.logger.trace", mock_trace):
@@ -485,19 +515,19 @@ def test_multithreaded_init(temp_db_file):
 
     def worker():
         try:
-            # Verify that thread_local.connections does not yet exist
-            assert not hasattr(pool.thread_local, "connections")
+            # Verify that thread_local.state does not yet exist
+            assert not hasattr(pool.thread_local, "state")
 
-            # Get a connection that will initialize thread_local.connections
+            # Get a connection that will initialize thread_local.state
             with pool.connection() as conn:
                 cursor = conn.cursor()
                 cursor.execute("SELECT 1")
                 result = cursor.fetchone()
                 assert result == {"1": 1}
 
-            # Verify that thread_local.connections is initialized
-            assert hasattr(pool.thread_local, "connections")
-            assert len(pool.thread_local.connections) == 1
+            # Verify that thread_local.state is initialized
+            assert hasattr(pool.thread_local, "state")
+            assert len(pool.thread_local.state.connections) == 1
 
             results.put(True)
         except Exception as e:
@@ -577,7 +607,7 @@ def test_edge_case_config_pool_size_zero(monkeypatch):
 
         # All connections should be closed after use
         # because the pool size is 0
-        assert len(getattr(pool.thread_local, "connections", [])) == 0
+        assert len(pool.thread_local.state.connections) == 0
 
         # Clean up
         pool.close()

--- a/counterparty-core/counterpartycore/test/units/utils/database_test.py
+++ b/counterparty-core/counterpartycore/test/units/utils/database_test.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import queue
 import tempfile
@@ -218,7 +219,6 @@ def test_thread_exit_releases_connections(connection_pool):
     new thread per request and each thread left its cached connections counted
     permanently in connection_count.
     """
-    import gc
 
     def use_pool():
         with connection_pool.connection():
@@ -358,7 +358,9 @@ def test_threading_violation_error(connection_pool):
             return getattr(self.real_conn, name)
 
     # Replace the real connection with our failing connection
-    connection_pool.thread_local.state.connections[0] = ValidationFailingConnection(original_connection)
+    connection_pool.thread_local.state.connections[0] = ValidationFailingConnection(
+        original_connection
+    )
 
     # Get a connection from the pool - should trigger validation failure
     with connection_pool.connection() as conn:
@@ -398,7 +400,9 @@ def test_busy_error(connection_pool):
             return getattr(self.real_conn, name)
 
     # Replace the real connection with our failing connection
-    connection_pool.thread_local.state.connections[0] = ValidationFailingConnection(original_connection)
+    connection_pool.thread_local.state.connections[0] = ValidationFailingConnection(
+        original_connection
+    )
 
     # Get a connection from the pool - should trigger validation failure
     with connection_pool.connection() as conn:

--- a/release-notes/release-notes-v11.1.1.md
+++ b/release-notes/release-notes-v11.1.1.md
@@ -35,6 +35,8 @@ counterparty-server start
 
 ## Bugfixes
 
+- Fix `connection_count` leak in `APSWConnectionPool` causing `MAINPROCESS_POOL` to exhaust over time (per-request threads in APIv1 left cached connections counted forever)
+
 ## API
 
 ## Codebase


### PR DESCRIPTION
Werkzeug's `make_server(..., threaded=True)` in APIv1 spawns one thread per HTTP request. Each thread acquired connections via the singleton pool, cached them in `thread_local.connections`, then died — leaving `connection_count` permanently incremented while the cached connections were dropped on the floor. Over time MAINPROCESS_POOL climbed to its max (e.g. 4237/5000) and new requests timed out with `Timeout waiting for database connection`.

Wrap the per-thread cache in a `_ThreadLocalConnections` object whose `__del__` closes the cached connections and decrements the pool counter when the thread exits. Uses `weakref.ref(pool)` to avoid pinning the pool.

Also release the slot in the validation-failure path (ThreadingViolationError / BusyError) before creating the replacement connection — previously this path also leaked one slot per failure.

----------------


* [x] Double-check the spelling and grammar of all strings, code comments, etc.
* [x] Double-check that all code is deterministic that needs to be
* [x] Add tests to cover any new or revised logic
* [x] Ensure that the test suite passes
* [x] Update the project [release notes](release-notes/)
* [x] Update the project documentation, as appropriate, with a corresponding Pull Request in the [Documentation repository](https://github.com/CounterpartyXCP/Documentation)
