### PR TITLE
Allow valid large pool deposits (gated)

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/pooldeposit.py
+++ b/counterparty-core/counterpartycore/lib/messages/pooldeposit.py
@@ -6,7 +6,7 @@ import struct
 from counterpartycore.lib import config, exceptions, ledger
 from counterpartycore.lib.ledger.currentstate import CurrentState
 from counterpartycore.lib.messages import gas
-from counterpartycore.lib.parser import messagetype
+from counterpartycore.lib.parser import messagetype, protocol
 from counterpartycore.lib.utils import assetnames
 
 logger = logging.getLogger(config.LOGGER_NAME)
@@ -64,7 +64,18 @@ def validate(
     elif min_lp_quantity > config.MAX_INT:
         problems.append("min_lp_quantity exceeds maximum value")
 
-    if not problems and quantity_a > 0 and quantity_b > config.MAX_INT // quantity_a:
+    # The product quantity_a * quantity_b is only ever consumed by arbitrary-precision
+    # Python integer arithmetic (math.isqrt) and is never stored, so it cannot overflow
+    # any persisted value: with both quantities <= MAX_INT, isqrt(quantity_a * quantity_b)
+    # <= MAX_INT, and quantity_minted is bounded separately below. The original check
+    # therefore rejected otherwise valid deposits (capping balanced divisible deposits at
+    # ~30.37 units/side). It is retained, gated, for pre-activation consensus compatibility.
+    if (
+        not protocol.enabled("fix_pool_deposit_product_overflow", block_index)
+        and not problems
+        and quantity_a > 0
+        and quantity_b > config.MAX_INT // quantity_a
+    ):
         problems.append("quantity_a * quantity_b exceeds maximum value")
 
     if problems:

--- a/counterparty-core/counterpartycore/protocol_changes.json
+++ b/counterparty-core/counterpartycore/protocol_changes.json
@@ -1410,5 +1410,14 @@
         "testnet3_block_index": 4961300,
         "testnet4_block_index": 136300,
         "signet_block_index": 310300
+    },
+    "fix_pool_deposit_product_overflow": {
+        "minimum_version_major": 11,
+        "minimum_version_minor": 1,
+        "minimum_version_revision": 1,
+        "block_index": 99999999,
+        "testnet3_block_index": 99999999,
+        "testnet4_block_index": 99999999,
+        "signet_block_index": 99999999
     }
 }

--- a/counterparty-core/counterpartycore/test/units/messages/pooldeposit_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/pooldeposit_test.py
@@ -90,21 +90,26 @@ def test_validate_overflow_quantity(ledger_db, defaults):
     assert any("exceeds maximum" in p for p in problems)
 
 
-def test_validate_product_overflow(ledger_db, defaults):
-    quantity = config.MAX_INT // 2 + 1
+def test_validate_large_product_with_individually_valid_quantities(ledger_db, defaults):
+    # Once fix_pool_deposit_product_overflow is active (always on regtest), a deposit
+    # whose quantity_a * quantity_b exceeds MAX_INT is accepted as long as each quantity
+    # and the resulting LP quantity are individually valid. 100 units per side has a
+    # product of 1e20 (> MAX_INT) but isqrt(product) == 1e10 (< MAX_INT).
+    quantity = 10_000_000_000
     problems = pooldeposit.validate(
         ledger_db,
         defaults["addresses"][0],
         "XCP",
         "DIVISIBLE",
         quantity,
-        3,
+        quantity,
+        lp_asset="A99999999999999999",
     )
-    assert any("quantity_a * quantity_b exceeds" in p for p in problems)
+    assert problems == []
 
 
 def test_validate_insufficient_balance(ledger_db, defaults):
-    # Large enough to exceed balance, small enough that product fits MAX_INT
+    # Large enough to exceed the fixture balance.
     huge = config.MAX_INT // 2
     problems = pooldeposit.validate(
         ledger_db,


### PR DESCRIPTION
## Summary

Removes a redundant product-overflow validation in `pooldeposit.validate()` that rejects otherwise valid AMM pool deposits, gated behind a new protocol change so it is replay-safe after the AMM activates.

The check `quantity_a * quantity_b > config.MAX_INT` rejected every deposit whose product exceeds `MAX_INT`, even when both quantities, the resulting LP quantity, balances, and stored reserves are individually valid. For balanced divisible assets it caps each side at `floor(sqrt(MAX_INT)) = 3,037,000,499` raw units (30.37000499 divisible units) — so a normal 100-unit-per-side deposit (`10,000,000,000` each) is rejected.

The product is only consumed by arbitrary-precision Python integer arithmetic (`math.isqrt`) and is never persisted. With both quantities `<= MAX_INT`, `isqrt(quantity_a * quantity_b) <= MAX_INT`, and `quantity_minted` is bounded separately. The check protects no stored value.

## Consensus safety

The AMM activates at mainnet block **952800**. This fix lands in a later release, i.e. **after** the feature is live, so the removal is gated behind the new `fix_pool_deposit_product_overflow` protocol change. Pre-activation consensus is unchanged.

> [!IMPORTANT]
> The activation heights in `protocol_changes.json` are placeholders (`99999999`) and **must be set to the real release heights before merge**. As shipped (far-future), the fix stays disabled — safe default, no accidental fork.

## Changes

- gate the `quantity_a * quantity_b` check behind `fix_pool_deposit_product_overflow`
- add the `protocol_changes.json` entry (placeholder heights)
- replace the product-overflow regression test with one asserting individually valid large quantities are accepted

## Validation

- `pooldeposit_test.py`: 49 passed
- `ruff check` on changed Python: clean
- independently verified `isqrt(quantity_a*quantity_b) <= MAX_INT` for both `<= MAX_INT`

Bug reported by GioLealhmx.
