### PR TITLE
Fix MPMA balance accumulation

### DIFF
--- a/counterparty-core/counterpartycore/lib/utils/helpers.py
+++ b/counterparty-core/counterpartycore/lib/utils/helpers.py
@@ -1,13 +1,11 @@
 import binascii
 import decimal
 import hashlib
-import itertools
 import json
 import mimetypes
 import os
 import string
 import threading
-from operator import itemgetter
 from urllib.parse import urlparse
 
 import pygit2
@@ -27,9 +25,10 @@ def flat(z):
 
 
 def accumulate(l):  # noqa: E741
-    it = itertools.groupby(l, itemgetter(0))
-    for key, subiter in it:
-        yield key, sum(item[1] for item in subiter)
+    totals = {}
+    for key, value in l:
+        totals[key] = totals.get(key, 0) + value
+    yield from totals.items()
 
 
 def active_options(given_config, options):

--- a/counterparty-core/counterpartycore/test/units/messages/versions/mpma_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/versions/mpma_test.py
@@ -410,7 +410,7 @@ def test_compose_valid(ledger_db, defaults):
     )
 
 
-def test_compose_invalid(ledger_db, defaults):
+def test_compose_invalid(ledger_db, defaults, monkeypatch):
     with pytest.raises(exceptions.ComposeError, match="insufficient funds for XCP"):
         mpma.compose(
             ledger_db,
@@ -431,6 +431,25 @@ def test_compose_invalid(ledger_db, defaults):
             None,
             None,
         )
+
+    with monkeypatch.context() as m:
+        m.setattr(
+            mpma.ledger.balances,
+            "get_balance",
+            lambda db, source, asset: 150 if asset == "XCP" else 10_000,
+        )
+        with pytest.raises(exceptions.ComposeError, match="insufficient funds for XCP"):
+            mpma.compose(
+                ledger_db,
+                defaults["addresses"][0],
+                [
+                    ("XCP", defaults["addresses"][2], 100),
+                    ("DIVISIBLE", defaults["addresses"][1], 1),
+                    ("XCP", defaults["addresses"][3], 100),
+                ],
+                None,
+                None,
+            )
 
     with pytest.raises(exceptions.ComposeError, match="`memo` must be a string"):
         mpma.compose(

--- a/counterparty-core/counterpartycore/test/units/utils/helpers_test.py
+++ b/counterparty-core/counterpartycore/test/units/utils/helpers_test.py
@@ -29,7 +29,7 @@ def test_accumulate():
     """Test accumulate function."""
     data = [("a", 1), ("a", 2), ("b", 3), ("b", 4), ("a", 5)]
     result = list(helpers.accumulate(data))
-    assert result == [("a", 3), ("b", 7), ("a", 5)]
+    assert result == [("a", 8), ("b", 7)]
 
 
 def test_active_options():


### PR DESCRIPTION
## Summary

This fixes an order-dependent accumulation bug in `helpers.accumulate()`.

`accumulate()` used `itertools.groupby()` on the input order, so equal keys were only combined when they were adjacent. MPMA composition uses this helper to check the total outgoing quantity per asset before encoding a transaction. With non-adjacent sends of the same asset, compose could check each partial group separately and allow a transaction whose total outgoing amount for that asset exceeds the source balance.

The helper now accumulates by key globally while preserving first-seen key order.

## Why it matters

A compose input like this can under-check the total XCP amount when the repeated asset is separated by another asset:

```python
[
    ("XCP", destination_a, 100),
    ("DIVISIBLE", destination_b, 1),
    ("XCP", destination_c, 100),
]
```

If the source has 150 XCP, the previous implementation checks 100 and 100 separately. The fixed implementation checks the actual 200 XCP total and raises `ComposeError("insufficient funds for XCP")`.

## Tests

- `.venv/bin/pytest counterpartycore/test/units/utils/helpers_test.py::test_accumulate -q`
- `.venv/bin/pytest counterpartycore/test/units/messages/versions/mpma_test.py::test_compose_invalid counterpartycore/test/units/messages/versions/mpma_test.py::test_compose_valid -q`
- `.venv/bin/pytest counterpartycore/test/units/utils/helpers_test.py counterpartycore/test/units/messages/versions/mpma_test.py -q` — 42 passed
- `.venv/bin/ruff format --check counterpartycore/lib/utils/helpers.py counterpartycore/test/units/utils/helpers_test.py counterpartycore/test/units/messages/versions/mpma_test.py`
- `.venv/bin/ruff check counterpartycore/lib/utils/helpers.py counterpartycore/test/units/utils/helpers_test.py counterpartycore/test/units/messages/versions/mpma_test.py`
- `git diff --check`

If this qualifies for the project bounty program, BTC payout address:

`bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
