### PR TITLE
Reject duplicate MPMA compose destinations

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/versions/mpma.py
+++ b/counterparty-core/counterpartycore/lib/messages/versions/mpma.py
@@ -106,6 +106,20 @@ def validate(db, asset_dest_quant_list):
     return problems
 
 
+def validate_compose(db, asset_dest_quant_list):
+    problems = validate(db, asset_dest_quant_list)
+    seen = set()
+    duplicate_problem = "cannot specify more than once a destination per asset"
+    for send in asset_dest_quant_list:
+        send_key = (send[0], send[1])
+        if send_key in seen and duplicate_problem not in problems:
+            problems.append(duplicate_problem)
+            break
+        seen.add(send_key)
+
+    return problems
+
+
 def compose(
     db,
     source: str,
@@ -150,7 +164,7 @@ def compose(
 
     cursor.close()
 
-    problems = validate(db, asset_dest_quant_list)
+    problems = validate_compose(db, asset_dest_quant_list)
     if problems and not skip_validation:
         raise exceptions.ComposeError(problems)
 

--- a/counterparty-core/counterpartycore/test/units/messages/versions/mpma_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/versions/mpma_test.py
@@ -432,6 +432,22 @@ def test_compose_invalid(ledger_db, defaults):
             None,
         )
 
+    with pytest.raises(
+        exceptions.ComposeError,
+        match=re.escape("cannot specify more than once a destination per asset"),
+    ):
+        mpma.compose(
+            ledger_db,
+            defaults["addresses"][0],
+            [
+                ("XCP", defaults["addresses"][2], defaults["quantity"]),
+                ("DIVISIBLE", defaults["addresses"][1], defaults["quantity"]),
+                ("XCP", defaults["addresses"][2], defaults["quantity"]),
+            ],
+            None,
+            None,
+        )
+
     with pytest.raises(exceptions.ComposeError, match="`memo` must be a string"):
         mpma.compose(
             ledger_db,


### PR DESCRIPTION
## Summary

This adds a compose-only MPMA validation check for duplicate `(asset, destination)` pairs even when the duplicate entries are not adjacent in the input list.

`validate()` currently detects adjacent duplicate destination/asset pairs via `groupby()`. That path is also used by `parse()`, so this PR intentionally leaves `validate()` unchanged to avoid changing historical transaction parsing behavior. Instead, `compose()` now calls `validate_compose()`, which wraps the existing validation and adds a full input scan before encoding a new MPMA transaction.

## Why it matters

The existing adjacent-duplicate check catches this:

```python
[
    ("XCP", destination_a, 100),
    ("XCP", destination_a, 100),
]
```

but misses this because the duplicate pair is separated by another asset:

```python
[
    ("XCP", destination_a, 100),
    ("DIVISIBLE", destination_b, 1),
    ("XCP", destination_a, 100),
]
```

The composer should reject both forms consistently with the existing `"cannot specify more than once a destination per asset"` validation rule.

## Tests

- `.venv/bin/pytest counterpartycore/test/units/messages/versions/mpma_test.py::test_compose_invalid counterpartycore/test/units/messages/versions/mpma_test.py::test_compose_valid -q`
- `.venv/bin/pytest counterpartycore/test/units/messages/versions/mpma_test.py -q` — 7 passed
- `.venv/bin/ruff format --check counterpartycore/lib/messages/versions/mpma.py counterpartycore/test/units/messages/versions/mpma_test.py`
- `.venv/bin/ruff check counterpartycore/lib/messages/versions/mpma.py counterpartycore/test/units/messages/versions/mpma_test.py`
- `git diff --check`

If this qualifies for the project bounty program, BTC payout address:

`bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
