### PR TITLE
Handle missing MPMA compose destinations

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/versions/mpma.py
+++ b/counterparty-core/counterpartycore/lib/messages/versions/mpma.py
@@ -122,6 +122,10 @@ def compose(
     :param memo: optional memo for the entire send
     :param memo_is_hex: optional boolean indicating if the memo is in hex format
     """
+    for send in asset_dest_quant_list:
+        if not send[1] and not skip_validation:
+            raise exceptions.ComposeError([f"destination is required for {send[0]}"])
+
     cursor = db.cursor()
 
     for send in asset_dest_quant_list:

--- a/counterparty-core/counterpartycore/test/units/messages/versions/mpma_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/versions/mpma_test.py
@@ -432,6 +432,21 @@ def test_compose_invalid(ledger_db, defaults):
             None,
         )
 
+    with pytest.raises(
+        exceptions.ComposeError,
+        match=re.escape("destination is required for XCP"),
+    ):
+        mpma.compose(
+            ledger_db,
+            defaults["addresses"][0],
+            [
+                ("XCP", None, defaults["quantity"]),
+                ("DIVISIBLE", defaults["addresses"][1], defaults["quantity"]),
+            ],
+            None,
+            None,
+        )
+
     with pytest.raises(exceptions.ComposeError, match="`memo` must be a string"):
         mpma.compose(
             ledger_db,


### PR DESCRIPTION
## Summary
- raise a compose-level error before MPMA tries to pack a missing destination address
- keep existing unsupported-address handling for non-empty destinations
- add a regression test covering mixed MPMA sends where one destination is missing

## Tests
- `.venv/bin/pytest counterpartycore/test/units/messages/versions/mpma_test.py -q`
- `.venv/bin/ruff format --check counterpartycore/lib/messages/versions/mpma.py counterpartycore/test/units/messages/versions/mpma_test.py`
- `.venv/bin/ruff check counterpartycore/lib/messages/versions/mpma.py counterpartycore/test/units/messages/versions/mpma_test.py`

## Bounty / payout
Submitting this as a candidate for the Counterparty bug bounty program if maintainers classify it as eligible.

BTC payout address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`