### PR TITLE
Wrap invalid hex memo compose errors

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/sweep.py
+++ b/counterparty-core/counterpartycore/lib/messages/sweep.py
@@ -83,7 +83,10 @@ def compose(
     if memo is None:
         memo_bytes = b""
     elif flags & FLAG_BINARY_MEMO:
-        memo_bytes = bytes.fromhex(memo)
+        try:
+            memo_bytes = bytes.fromhex(memo)
+        except (TypeError, ValueError) as e:
+            raise exceptions.ComposeError("memo must be valid hexadecimal") from e
     else:
         memo_bytes = memo.encode("utf-8")
         memo_bytes = struct.pack(f">{len(memo_bytes)}s", memo_bytes)

--- a/counterparty-core/counterpartycore/lib/messages/versions/enhancedsend.py
+++ b/counterparty-core/counterpartycore/lib/messages/versions/enhancedsend.py
@@ -164,7 +164,10 @@ def compose(
     if memo is None:
         memo_bytes = b""
     elif memo_is_hex:
-        memo_bytes = bytes.fromhex(memo)
+        try:
+            memo_bytes = bytes.fromhex(memo)
+        except (TypeError, ValueError) as e:
+            raise exceptions.ComposeError("memo must be valid hexadecimal") from e
     else:
         memo_bytes = memo.encode("utf-8")
         memo_bytes = struct.pack(f">{len(memo_bytes)}s", memo_bytes)

--- a/counterparty-core/counterpartycore/test/units/messages/sweep_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/sweep_test.py
@@ -121,6 +121,11 @@ def test_compose(ledger_db, defaults, monkeypatch):
             (sweep.compose(ledger_db, defaults["addresses"][8], defaults["addresses"][5], 1, None),)
 
 
+def test_compose_rejects_invalid_hex_memo(ledger_db, defaults):
+    with pytest.raises(exceptions.ComposeError, match="memo must be valid hexadecimal"):
+        sweep.compose(ledger_db, defaults["addresses"][6], defaults["addresses"][5], 7, "not hex")
+
+
 def test_compose_2(ledger_db, defaults):
     assert sweep.compose(
         ledger_db, defaults["addresses"][0], defaults["addresses"][1], 1, None, False

--- a/counterparty-core/counterpartycore/test/units/messages/versions/enhancedsend_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/versions/enhancedsend_test.py
@@ -106,6 +106,19 @@ def test_compose_rejects_overflow_btc_quantity(ledger_db, defaults):
         )
 
 
+def test_compose_rejects_invalid_hex_memo(ledger_db, defaults):
+    with pytest.raises(exceptions.ComposeError, match="memo must be valid hexadecimal"):
+        enhancedsend.compose(
+            ledger_db,
+            defaults["addresses"][0],
+            defaults["addresses"][1],
+            "XCP",
+            1000,
+            "not hex",
+            True,
+        )
+
+
 def test_unpack(ledger_db, defaults):
     assert enhancedsend.unpack(
         b"\x84\x01\x19\x03\xe8U\x01\x8dj\xe8\xa3\xb3\x81f1\x18\xb4\xe1\xef\xf4\xcf\xc7\xd0\x95M\xd6\xecDmemo"


### PR DESCRIPTION
## Summary
- convert invalid hex memo input in enhanced send compose into `ComposeError`
- do the same for sweep binary memo compose
- add regression coverage so these compose APIs do not leak Python `ValueError` for user input

## Tests
- `.venv/bin/pytest counterpartycore/test/units/messages/versions/enhancedsend_test.py::test_compose_rejects_invalid_hex_memo counterpartycore/test/units/messages/sweep_test.py::test_compose_rejects_invalid_hex_memo -q`
- `.venv/bin/pytest counterpartycore/test/units/messages/versions/enhancedsend_test.py counterpartycore/test/units/messages/sweep_test.py -q`
- `.venv/bin/ruff format --check counterpartycore/lib/messages/versions/enhancedsend.py counterpartycore/lib/messages/sweep.py counterpartycore/test/units/messages/versions/enhancedsend_test.py counterpartycore/test/units/messages/sweep_test.py`
- `.venv/bin/ruff check counterpartycore/lib/messages/versions/enhancedsend.py counterpartycore/lib/messages/sweep.py counterpartycore/test/units/messages/versions/enhancedsend_test.py counterpartycore/test/units/messages/sweep_test.py`
- `git diff --check`

## Bounty / payout
Submitting this as a candidate for the Counterparty bug bounty program if maintainers classify it as eligible.

BTC payout address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`