### PR TITLE
Validate enhanced send memo hex flag

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/versions/enhancedsend.py
+++ b/counterparty-core/counterpartycore/lib/messages/versions/enhancedsend.py
@@ -145,6 +145,9 @@ def compose(
 ):
     send1.validate_compose_quantity(quantity)
 
+    if memo_is_hex and not isinstance(memo_is_hex, bool):
+        raise exceptions.ComposeError("`memo_is_hex` must be a boolean")
+
     cursor = db.cursor()
 
     # Just send BTC?

--- a/counterparty-core/counterpartycore/test/units/messages/versions/enhancedsend_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/versions/enhancedsend_test.py
@@ -106,6 +106,19 @@ def test_compose_rejects_overflow_btc_quantity(ledger_db, defaults):
         )
 
 
+def test_compose_rejects_non_boolean_memo_is_hex(ledger_db, defaults):
+    with pytest.raises(exceptions.ComposeError, match="`memo_is_hex` must be a boolean"):
+        enhancedsend.compose(
+            ledger_db,
+            defaults["addresses"][0],
+            defaults["addresses"][1],
+            "XCP",
+            1000,
+            "abcdef",
+            "true",
+        )
+
+
 def test_unpack(ledger_db, defaults):
     assert enhancedsend.unpack(
         b"\x84\x01\x19\x03\xe8U\x01\x8dj\xe8\xa3\xb3\x81f1\x18\xb4\xe1\xef\xf4\xcf\xc7\xd0\x95M\xd6\xecDmemo"


### PR DESCRIPTION
## Summary
- reject truthy non-boolean `memo_is_hex` values in enhanced send compose
- align enhanced send behavior with MPMA compose, which already validates this flag
- add regression coverage for a string `memo_is_hex` value that previously changed memo encoding instead of failing validation

## Tests
- `.venv/bin/pytest counterpartycore/test/units/messages/versions/enhancedsend_test.py::test_compose_rejects_non_boolean_memo_is_hex -q`
- `.venv/bin/pytest counterpartycore/test/units/messages/versions/enhancedsend_test.py -q`
- `.venv/bin/ruff format --check counterpartycore/lib/messages/versions/enhancedsend.py counterpartycore/test/units/messages/versions/enhancedsend_test.py`
- `.venv/bin/ruff check counterpartycore/lib/messages/versions/enhancedsend.py counterpartycore/test/units/messages/versions/enhancedsend_test.py`
- `git diff --check`

## Bounty / payout
Submitting this as a candidate for the Counterparty bug bounty program if maintainers classify it as eligible.

BTC payout address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`