### PR TITLE
Validate sweep flags before memo bit check

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/sweep.py
+++ b/counterparty-core/counterpartycore/lib/messages/sweep.py
@@ -80,9 +80,10 @@ def validate(db, source, destination, flags, memo, block_index):
 def compose(
     db, source: str, destination: str, flags: int, memo: str, skip_validation: bool = False
 ):
+    flags_is_int = isinstance(flags, int) and not isinstance(flags, bool)
     if memo is None:
         memo_bytes = b""
-    elif flags & FLAG_BINARY_MEMO:
+    elif flags_is_int and flags & FLAG_BINARY_MEMO:
         memo_bytes = bytes.fromhex(memo)
     else:
         memo_bytes = memo.encode("utf-8")

--- a/counterparty-core/counterpartycore/test/units/messages/sweep_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/sweep_test.py
@@ -121,6 +121,11 @@ def test_compose(ledger_db, defaults, monkeypatch):
             (sweep.compose(ledger_db, defaults["addresses"][8], defaults["addresses"][5], 1, None),)
 
 
+def test_compose_rejects_non_integer_flags_with_memo(ledger_db, defaults):
+    with pytest.raises(exceptions.ComposeError, match="flags must be an int"):
+        sweep.compose(ledger_db, defaults["addresses"][6], defaults["addresses"][5], "1", "memo")
+
+
 def test_compose_2(ledger_db, defaults):
     assert sweep.compose(
         ledger_db, defaults["addresses"][0], defaults["addresses"][1], 1, None, False


### PR DESCRIPTION
Summary
- Avoid applying the binary memo bit check when sweep compose receives non-integer flags.
- Let the existing compose validation return the user-facing `flags must be an int` error instead of leaking a TypeError.
- Add a regression test for non-integer flags with a memo.

Tests
- `.venv/bin/pytest counterpartycore/test/units/messages/sweep_test.py::test_compose_rejects_non_integer_flags_with_memo -q`
- `.venv/bin/pytest counterpartycore/test/units/messages/sweep_test.py -q`
- `.venv/bin/ruff format counterpartycore/lib/messages/sweep.py counterpartycore/test/units/messages/sweep_test.py --check`
- `.venv/bin/ruff check counterpartycore/lib/messages/sweep.py counterpartycore/test/units/messages/sweep_test.py`
- `git diff --check`

Bounty payout address
- BTC: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`