### PR TITLE
Validate compose memo types before encoding

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/sweep.py
+++ b/counterparty-core/counterpartycore/lib/messages/sweep.py
@@ -80,6 +80,9 @@ def validate(db, source, destination, flags, memo, block_index):
 def compose(
     db, source: str, destination: str, flags: int, memo: str, skip_validation: bool = False
 ):
+    if memo is not None and not isinstance(memo, str):
+        raise exceptions.ComposeError("memo must be a string")
+
     if memo is None:
         memo_bytes = b""
     elif flags & FLAG_BINARY_MEMO:

--- a/counterparty-core/counterpartycore/lib/messages/versions/enhancedsend.py
+++ b/counterparty-core/counterpartycore/lib/messages/versions/enhancedsend.py
@@ -160,6 +160,9 @@ def compose(
     if balance < quantity and not skip_validation:
         raise exceptions.ComposeError("insufficient funds")
 
+    if memo is not None and not isinstance(memo, str):
+        raise exceptions.ComposeError("memo must be a string")
+
     # convert memo to memo_bytes based on memo_is_hex setting
     if memo is None:
         memo_bytes = b""

--- a/counterparty-core/counterpartycore/test/units/messages/sweep_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/sweep_test.py
@@ -121,6 +121,11 @@ def test_compose(ledger_db, defaults, monkeypatch):
             (sweep.compose(ledger_db, defaults["addresses"][8], defaults["addresses"][5], 1, None),)
 
 
+def test_compose_rejects_non_string_memo(ledger_db, defaults):
+    with pytest.raises(exceptions.ComposeError, match="memo must be a string"):
+        sweep.compose(ledger_db, defaults["addresses"][6], defaults["addresses"][5], 1, ["memo"])
+
+
 def test_compose_2(ledger_db, defaults):
     assert sweep.compose(
         ledger_db, defaults["addresses"][0], defaults["addresses"][1], 1, None, False

--- a/counterparty-core/counterpartycore/test/units/messages/versions/enhancedsend_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/versions/enhancedsend_test.py
@@ -106,6 +106,19 @@ def test_compose_rejects_overflow_btc_quantity(ledger_db, defaults):
         )
 
 
+def test_compose_rejects_non_string_memo(ledger_db, defaults):
+    with pytest.raises(exceptions.ComposeError, match="memo must be a string"):
+        enhancedsend.compose(
+            ledger_db,
+            defaults["addresses"][0],
+            defaults["addresses"][1],
+            "XCP",
+            1000,
+            ["memo"],
+            False,
+        )
+
+
 def test_unpack(ledger_db, defaults):
     assert enhancedsend.unpack(
         b"\x84\x01\x19\x03\xe8U\x01\x8dj\xe8\xa3\xb3\x81f1\x18\xb4\xe1\xef\xf4\xcf\xc7\xd0\x95M\xd6\xecDmemo"


### PR DESCRIPTION
Summary
- Reject non-string memo values in enhanced send compose and sweep compose before encoding them.
- Return a compose-level `memo must be a string` error instead of leaking Python AttributeError/TypeError from `.encode()` or hex conversion.
- Add regression tests for both compose paths.

Tests
- `.venv/bin/pytest counterpartycore/test/units/messages/versions/enhancedsend_test.py::test_compose_rejects_non_string_memo counterpartycore/test/units/messages/sweep_test.py::test_compose_rejects_non_string_memo -q`
- `.venv/bin/pytest counterpartycore/test/units/messages/versions/enhancedsend_test.py counterpartycore/test/units/messages/sweep_test.py -q`
- `.venv/bin/ruff format counterpartycore/lib/messages/versions/enhancedsend.py counterpartycore/lib/messages/sweep.py counterpartycore/test/units/messages/versions/enhancedsend_test.py counterpartycore/test/units/messages/sweep_test.py --check`
- `.venv/bin/ruff check counterpartycore/lib/messages/versions/enhancedsend.py counterpartycore/lib/messages/sweep.py counterpartycore/test/units/messages/versions/enhancedsend_test.py counterpartycore/test/units/messages/sweep_test.py`
- `git diff --check`

Bounty payout address
- BTC: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`