### PR TITLE
Validate minimum fairminter commission

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/fairminter.py
+++ b/counterparty-core/counterpartycore/lib/messages/fairminter.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(config.LOGGER_NAME)
 D = decimal.Decimal
 
 ID = 90
+MIN_MINTED_ASSET_COMMISSION = D("0.0000001")
 
 
 def validate(
@@ -83,6 +84,11 @@ def validate(
             problems.append(
                 "`minted_asset_commission` must be less than 0 or greater than or equal to 1"
             )
+        elif (
+            protocol.enabled("fix_fairminter_commission_minimum", block_index=block_index)
+            and 0 < D(str(minted_asset_commission)) <= MIN_MINTED_ASSET_COMMISSION
+        ):
+            problems.append("minted_asset_commission must be 0 or greater than 0.0000001")
 
     if max_mint_per_tx > max_mint_per_address > 0:
         problems.append("max_mint_per_tx must be <= max_mint_per_address.")

--- a/counterparty-core/counterpartycore/protocol_changes.json
+++ b/counterparty-core/counterpartycore/protocol_changes.json
@@ -1410,5 +1410,14 @@
         "testnet3_block_index": 4961300,
         "testnet4_block_index": 136300,
         "signet_block_index": 310300
+    },
+    "fix_fairminter_commission_minimum": {
+        "minimum_version_major": 11,
+        "minimum_version_minor": 1,
+        "minimum_version_revision": 0,
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     }
 }

--- a/counterparty-core/counterpartycore/test/units/messages/fairminter_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/fairminter_test.py
@@ -23,6 +23,37 @@ def test_validate(ledger_db, defaults):
 
     assert fairminter.validate(
         ledger_db,
+        defaults["addresses"][1],
+        "FAIRMINTED",
+        max_mint_per_tx=10,
+        minted_asset_commission=0.0000001,
+    ) == ["minted_asset_commission must be 0 or greater than 0.0000001"]
+
+    with ProtocolChangesDisabled(["fix_fairminter_commission_minimum"]):
+        assert (
+            fairminter.validate(
+                ledger_db,
+                defaults["addresses"][1],
+                "FAIRMINTED",
+                max_mint_per_tx=10,
+                minted_asset_commission=0.0000001,
+            )
+            == []
+        )
+
+    assert (
+        fairminter.validate(
+            ledger_db,
+            defaults["addresses"][1],
+            "FAIRMINTED",
+            max_mint_per_tx=10,
+            minted_asset_commission=0.0000002,
+        )
+        == []
+    )
+
+    assert fairminter.validate(
+        ledger_db,
         defaults["addresses"][1],  # source
         "XCP",  # asset
         "",  # asset_parent,


### PR DESCRIPTION
Summary
- Fixes #3134.
- Reject positive fairminter `minted_asset_commission` values at or below `0.0000001`, while keeping `0` as the no-commission value.
- Add validation coverage for the rejected boundary and an accepted value above it.

Tests
- `.venv/bin/pytest counterpartycore/test/units/messages/fairminter_test.py::test_validate -q`
- `.venv/bin/pytest counterpartycore/test/units/messages/fairminter_test.py -q`
- `.venv/bin/ruff format counterpartycore/lib/messages/fairminter.py counterpartycore/test/units/messages/fairminter_test.py --check`
- `.venv/bin/ruff check counterpartycore/lib/messages/fairminter.py counterpartycore/test/units/messages/fairminter_test.py`
- `git diff --check`

Bounty payout address
- BTC: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`