### PR TITLE
Default missing bet target value to zero

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/bet.py
+++ b/counterparty-core/counterpartycore/lib/messages/bet.py
@@ -208,6 +208,9 @@ def compose(
     expiration: int,
     skip_validation: bool = False,
 ):
+    if target_value is None:
+        target_value = 0.0
+
     if ledger.balances.get_balance(db, source, config.XCP) < wager_quantity:
         raise exceptions.ComposeError("insufficient funds")
 

--- a/counterparty-core/counterpartycore/test/units/messages/bet_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/bet_test.py
@@ -365,6 +365,20 @@ def test_compose(ledger_db, defaults):
         b"(\x00\x00X\xb1\x14d\x00\x00\x00\x00\x02\xfa\xf0\x80\x00\x00\x00\x00\x02\xfa\xf0\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00;\x10\x00\x00\x00\n",
     )
 
+    _source, _destination, data = bet.compose(
+        ledger_db,
+        defaults["addresses"][1],
+        defaults["addresses"][0],
+        2,
+        1488000100,
+        defaults["small"],
+        defaults["small"],
+        None,
+        5040,
+        defaults["expiration"],
+    )
+    assert bet.unpack(data[1:], return_dict=True)["target_value"] == 0.0
+
     assert bet.compose(
         ledger_db,
         defaults["p2sh_addresses"][0],


### PR DESCRIPTION
Summary
- Fixes #3102.
- Normalize a missing bet `target_value` to `0.0` before packing the bet message.
- Add a regression test for composing a bet with `target_value=None`, matching the API default path.

Tests
- `.venv/bin/pytest counterpartycore/test/units/messages/bet_test.py::test_compose -q`
- `.venv/bin/pytest counterpartycore/test/units/messages/bet_test.py -q`
- `.venv/bin/ruff format counterpartycore/lib/messages/bet.py counterpartycore/test/units/messages/bet_test.py --check`
- `.venv/bin/ruff check counterpartycore/lib/messages/bet.py counterpartycore/test/units/messages/bet_test.py`
- `git diff --check`

Bounty payout address
- BTC: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`