### PR TITLE
Normalize null BTC amounts in transaction responses

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/queries.py
+++ b/counterparty-core/counterpartycore/lib/api/queries.py
@@ -182,6 +182,12 @@ class QueryResult:
         self.table = table
 
 
+def normalize_transaction_rows(result):
+    for row in result:
+        if "btc_amount" in row and row["btc_amount"] is None:
+            row["btc_amount"] = 0
+
+
 def select_rows(
     db,
     table,
@@ -365,6 +371,9 @@ def select_rows(
             if "params" not in row:
                 break
             row["params"] = json.loads(row["params"])
+
+    if table in ["all_transactions_with_status", "transactions_with_status"]:
+        normalize_transaction_rows(result)
 
     if table == "all_transactions_with_status":
         for row in result:

--- a/counterparty-core/counterpartycore/test/units/api/queries_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/queries_test.py
@@ -227,6 +227,53 @@ def test_get_transactions_by_addresses_with_valid_filter(ledger_db, defaults):
     assert result is not None
 
 
+def test_transaction_queries_return_zero_btc_amount_for_null(ledger_db, current_block_index):
+    """Test transaction endpoints do not expose null btc_amount values."""
+    block = ledger_db.execute(
+        "SELECT block_hash, block_time FROM blocks WHERE block_index = ?",
+        (current_block_index,),
+    ).fetchone()
+    tx_index = (
+        ledger_db.execute("SELECT MAX(tx_index) AS tx_index FROM transactions").fetchone()[
+            "tx_index"
+        ]
+        + 1
+    )
+    tx_hash = "ab" * 32
+    ledger_db.execute(
+        """INSERT INTO transactions(
+            tx_index, tx_hash, block_index, block_hash, block_time, source, destination,
+            btc_amount, fee, data, supported, utxos_info, transaction_type
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            tx_index,
+            tx_hash,
+            current_block_index,
+            block["block_hash"],
+            block["block_time"],
+            "",
+            "",
+            None,
+            None,
+            None,
+            True,
+            "",
+            "utxomove",
+        ),
+    )
+    ledger_db.execute(
+        "INSERT INTO transactions_status(tx_index, valid) VALUES(?, ?)",
+        (tx_index, True),
+    )
+
+    query_result = queries.get_transaction_by_hash(ledger_db, tx_hash)
+    assert query_result.result["btc_amount"] == 0
+
+    query_result = queries.get_transactions(ledger_db, type="utxomove", limit=1)
+    assert query_result.result[0]["tx_hash"] == tx_hash
+    assert query_result.result[0]["btc_amount"] == 0
+
+
 # =============================================================================
 # Tests for event queries
 # =============================================================================


### PR DESCRIPTION
## Summary
- normalize null `btc_amount` values to `0` for transaction query responses
- keep the change scoped to `transactions_with_status` and `all_transactions_with_status` results
- add a regression test for single-transaction and list transaction query paths

Fixes #2825

## Tests
- `.venv/bin/python -m ruff format --check counterpartycore/lib/api/queries.py counterpartycore/test/units/api/queries_test.py`
- `.venv/bin/python -m ruff check counterpartycore/lib/api/queries.py counterpartycore/test/units/api/queries_test.py`
- `.venv/bin/pytest counterpartycore/test/units/api/queries_test.py::test_transaction_queries_return_zero_btc_amount_for_null`
- `.venv/bin/pytest counterpartycore/test/units/api/queries_test.py`
- `.venv/bin/pytest counterpartycore/test/units/api/apiserver_test.py::test_get_transactions counterpartycore/test/units/api/apiserver_test.py::test_get_all_transactions_verbose counterpartycore/test/units/api/apiserver_test.py::test_show_unconfirmed counterpartycore/test/units/api/apiserver_test.py::test_get_transactions_valid`
- `git diff --check`

BTC payout address, if applicable: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`