### PR TITLE
Add API error context to Sentry reports

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/apiserver.py
+++ b/counterparty-core/counterpartycore/lib/api/apiserver.py
@@ -132,6 +132,19 @@ def set_cors_headers(response):
         response.headers["Access-Control-Allow-Methods"] = "*"
 
 
+def set_sentry_api_response_context(http_code, error):
+    with configure_sentry_scope() as scope:
+        scope.set_context(
+            "api_response",
+            {
+                "status_code": http_code,
+                "error": str(error),
+                "method": request.method,
+                "path": request.path,
+            },
+        )
+
+
 def return_result(
     http_code,
     result=None,
@@ -366,11 +379,11 @@ def handle_route(**kwargs):
         except Exception as e:  # pylint: disable=broad-except
             # import traceback
             # print(traceback.format_exc())
+            error = "Unknown error"
+            set_sentry_api_response_context(503, error)
             capture_exception(e)
             logger.error("Error in API: %s", e)
-            return return_result(
-                503, error="Unknown error", start_time=start_time, query_args=query_args
-            )
+            return return_result(503, error=error, start_time=start_time, query_args=query_args)
 
         if isinstance(result, requests.Response):
             message = f"API Request - {request.remote_addr} {request.method} {request.url}"
@@ -416,9 +429,11 @@ def handle_route(**kwargs):
     except Exception as e:  # pylint: disable=broad-except
         # import traceback
         # print(traceback.format_exc())
+        error = "Internal server error"
+        set_sentry_api_response_context(500, error)
         capture_exception(e)
         logger.error("Error in API: %s", e)
-        return return_result(500, error="Internal server error")
+        return return_result(500, error=error)
 
 
 def handle_not_found(_error):

--- a/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
@@ -413,6 +413,50 @@ def test_get_transactions(apiv2_client, monkeypatch):
     assert result[0]["unpacked_data"]["error"] == "Could not unpack data"
 
 
+def test_sentry_context_includes_http_error_returned_to_user(apiv2_client, monkeypatch):
+    class FakeSentryScope:
+        def __init__(self):
+            self.contexts = {}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, _exc_type, _exc_value, _traceback):
+            return False
+
+        def set_transaction_name(self, _name):
+            pass
+
+        def set_context(self, name, data):
+            self.contexts[name] = data
+
+    scope = FakeSentryScope()
+    captured = []
+
+    def execute_api_function_mock(_rule, _route, _function_args):
+        raise RuntimeError("boom")
+
+    def capture_exception_mock(error):
+        captured.append(error)
+        assert scope.contexts["api_response"] == {
+            "status_code": 503,
+            "error": "Unknown error",
+            "method": "GET",
+            "path": "/v2/transactions",
+        }
+
+    monkeypatch.setattr(apiserver, "configure_sentry_scope", lambda: scope)
+    monkeypatch.setattr(apiserver, "execute_api_function", execute_api_function_mock)
+    monkeypatch.setattr(apiserver, "capture_exception", capture_exception_mock)
+
+    response = apiv2_client.get("/v2/transactions?limit=1")
+
+    assert response.status_code == 503
+    assert response.json["error"] == "Unknown error"
+    assert len(captured) == 1
+    assert isinstance(captured[0], RuntimeError)
+
+
 def test_get_all_transactions_verbose(apiv2_client):
     url = "/v2/transactions?verbose=true&show_unconfirmed=true"
     result = apiv2_client.get(url).json["result"]


### PR DESCRIPTION
Fixes #3085.

This adds the HTTP error returned by the v2 API to the Sentry scope before captured API exceptions are sent. The context includes the response status, error message, request method, and path, so Sentry reports show the same API error the user saw without changing the response body or status code.

Covered paths:
- API function exceptions returning `503` / `Unknown error`
- outer API handler exceptions returning `500` / `Internal server error`

Tests:
- `.venv/bin/ruff format counterpartycore/lib/api/apiserver.py counterpartycore/test/units/api/apiserver_test.py`
- `.venv/bin/ruff check counterpartycore/lib/api/apiserver.py counterpartycore/test/units/api/apiserver_test.py`
- `.venv/bin/pytest counterpartycore/test/units/api/apiserver_test.py::test_sentry_context_includes_http_error_returned_to_user`
- `.venv/bin/pytest counterpartycore/test/units/api/apiserver_test.py`
- `git diff --check`

BTC payout address, if applicable: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`