### PR TITLE
Add pytest flag to skip slow tests

### DIFF
--- a/counterparty-core/conftest.py
+++ b/counterparty-core/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--skip-slow-tests",
+        action="store_true",
+        default=False,
+        help="Skip tests marked as slow.",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: marks tests as slow")
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--skip-slow-tests"):
+        return
+
+    skip_slow = pytest.mark.skip(reason="Skipped because --skip-slow-tests was set.")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/counterparty-core/counterpartycore/test/units/messages/fuzz_cbor_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/fuzz_cbor_test.py
@@ -29,6 +29,8 @@ from counterpartycore.lib.messages.versions import enhancedsend
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
+pytestmark = pytest.mark.slow
+
 # Generate values with mixed valid / adversarial types. CBOR can carry any
 # of these; struct format would have rejected most.
 any_scalar = st.one_of(

--- a/counterparty-core/counterpartycore/test/units/messages/fuzz_parse_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/fuzz_parse_test.py
@@ -39,6 +39,8 @@ from counterpartycore.test.mocks.counterpartydbs import ProtocolChangesDisabled
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
+pytestmark = pytest.mark.slow
+
 msg_bytes = st.binary(min_size=0, max_size=512)
 
 


### PR DESCRIPTION
Fixes #3072.

This adds a repository-level pytest option, `--skip-slow-tests`, and registers a `slow` marker. The default behavior is unchanged: slow tests still run unless the new flag is explicitly set.

The existing Hypothesis fuzz test modules are marked as slow so the flag has immediate effect for the currently expensive unit fuzz checks.

Tests:
- `.venv/bin/ruff format conftest.py counterpartycore/test/units/messages/fuzz_cbor_test.py counterpartycore/test/units/messages/fuzz_parse_test.py`
- `.venv/bin/ruff check conftest.py counterpartycore/test/units/messages/fuzz_cbor_test.py counterpartycore/test/units/messages/fuzz_parse_test.py`
- `.venv/bin/pytest --help | rg -- "--skip-slow-tests"`
- `.venv/bin/pytest --skip-slow-tests counterpartycore/test/units/messages/fuzz_cbor_test.py -q` — 5 skipped
- `.venv/bin/pytest counterpartycore/test/units/messages/fuzz_cbor_test.py::test_cbor_sweep_no_halt -q` — 1 passed
- `.venv/bin/pytest --markers | rg "slow:"`
- `.venv/bin/pytest --skip-slow-tests counterpartycore/test/units/messages/fuzz_parse_test.py -q` — 20 skipped
- `git diff --check`

BTC payout address, if applicable: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`