### PR TITLE
Report empty sweep sources clearly

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/sweep.py
+++ b/counterparty-core/counterpartycore/lib/messages/sweep.py
@@ -77,6 +77,45 @@ def validate(db, source, destination, flags, memo, block_index):
     return problems, total_fee
 
 
+def has_asset_ownership_to_sweep(db, source, block_index):
+    for asset_issued in ledger.issuances.get_asset_issued(db, source):
+        issuances = ledger.issuances.get_issuances(
+            db,
+            asset=asset_issued["asset"],
+            status="valid",
+            first=True,
+            current_block_index=block_index,
+        )
+        if issuances and issuances[-1]["issuer"] == source:
+            return True
+    return False
+
+
+def empty_sweep_problem(db, source, flags, block_index):
+    if not isinstance(flags, int) or isinstance(flags, bool):
+        return None
+
+    requested = []
+    has_sweepable_content = False
+
+    if flags & FLAG_BALANCES:
+        requested.append("balances")
+        balances = ledger.balances.get_address_balances(db, source)
+        has_sweepable_content = any(balance["quantity"] > 0 for balance in balances)
+
+    if flags & FLAG_OWNERSHIP:
+        requested.append("asset ownerships")
+        has_sweepable_content = has_sweepable_content or has_asset_ownership_to_sweep(
+            db, source, block_index
+        )
+
+    if has_sweepable_content or not requested:
+        return None
+    if len(requested) == 1:
+        return f"address has no {requested[0]} to sweep"
+    return "address has no balances or asset ownerships to sweep"
+
+
 def compose(
     db, source: str, destination: str, flags: int, memo: str, skip_validation: bool = False
 ):
@@ -90,6 +129,10 @@ def compose(
 
     block_index = CurrentState().current_block_index()
     problems, _total_fee = validate(db, source, destination, flags, memo_bytes, block_index)
+    if not problems:
+        empty_problem = empty_sweep_problem(db, source, flags, block_index)
+        if empty_problem:
+            problems.append(empty_problem)
     if problems and not skip_validation:
         raise exceptions.ComposeError(problems)
 

--- a/counterparty-core/counterpartycore/test/units/api/compose_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/compose_test.py
@@ -208,6 +208,18 @@ def test_compose_sweep(apiv2_client, defaults):
     assert response.status_code in [200, 400]
 
 
+def test_compose_sweep_empty_address_error(apiv2_client, defaults):
+    """Test compose_sweep returns a useful error for an empty source address."""
+    address = defaults["addresses"][7]
+    destination = defaults["addresses"][1]
+    response = apiv2_client.get(
+        f"/v2/addresses/{address}/compose/sweep?destination={destination}&flags=3&memo="
+    )
+
+    assert response.status_code == 400
+    assert "address has no balances or asset ownerships to sweep" in response.json["error"]
+
+
 def test_get_sweep_estimate_xcp_fee(apiv2_client, defaults):
     """Test get_sweep_estimate_xcp_fee function via API."""
     address = defaults["addresses"][0]

--- a/counterparty-core/counterpartycore/test/units/messages/sweep_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/sweep_test.py
@@ -147,6 +147,19 @@ def test_compose_2(ledger_db, defaults):
     )
 
 
+def test_compose_empty_address_reports_no_sweepable_content(ledger_db, defaults):
+    with pytest.raises(
+        exceptions.ComposeError, match="address has no balances or asset ownerships to sweep"
+    ):
+        sweep.compose(
+            ledger_db,
+            defaults["addresses"][7],
+            defaults["addresses"][5],
+            sweep.FLAG_BALANCES | sweep.FLAG_OWNERSHIP,
+            None,
+        )
+
+
 def test_new_unpack(defaults):
     assert sweep.unpack(
         b"\x83U\x01\x8dj\xe8\xa3\xb3\x81f1\x18\xb4\xe1\xef\xf4\xcf\xc7\xd0\x95M\xd6\xec\x01@"


### PR DESCRIPTION
Fixes #1397.

This improves the compose/API error for sweeps from an address that has nothing selected to sweep. Instead of continuing into later transaction construction, compose now reports when the requested sweep has no balances and/or asset ownerships available.

The check is compose-only and does not change sweep parsing or protocol validity for already-broadcast transactions. For ownership sweeps, it verifies current ownership by checking the latest valid issuance for each asset, matching the parse-side ownership transfer logic.

Tests:
- `.venv/bin/ruff format counterpartycore/lib/messages/sweep.py counterpartycore/test/units/messages/sweep_test.py counterpartycore/test/units/api/compose_test.py`
- `.venv/bin/ruff check counterpartycore/lib/messages/sweep.py counterpartycore/test/units/messages/sweep_test.py counterpartycore/test/units/api/compose_test.py`
- `.venv/bin/pytest counterpartycore/test/units/messages/sweep_test.py::test_compose_empty_address_reports_no_sweepable_content counterpartycore/test/units/api/compose_test.py::test_compose_sweep_empty_address_error`
- `.venv/bin/pytest counterpartycore/test/units/messages/sweep_test.py counterpartycore/test/units/api/compose_test.py` — 75 passed
- `git diff --check`

BTC payout address, if applicable: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`