### PR TITLE
Skip call price checks after callability parameter removal

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/issuance.py
+++ b/counterparty-core/counterpartycore/lib/messages/issuance.py
@@ -130,7 +130,7 @@ def validate(
             (not protocol.enabled("cip03", block_index)) or (not reset)
         ):
             problems.append("cannot change divisibility")
-        if not protocol.enabled("issuance_callability_parameters_removal", block_index):
+        if not protocol.enabled("issuance_callable_lock_fix", block_index):
             if bool(last_issuance["callable"]) != bool(callable_):
                 problems.append("cannot change callability")
             if last_issuance["call_date"] > call_date and (

--- a/counterparty-core/counterpartycore/lib/messages/issuance.py
+++ b/counterparty-core/counterpartycore/lib/messages/issuance.py
@@ -130,20 +130,19 @@ def validate(
             (not protocol.enabled("cip03", block_index)) or (not reset)
         ):
             problems.append("cannot change divisibility")
-        if (not protocol.enabled("issuance_callability_parameters_removal", block_index)) and bool(
-            last_issuance["callable"]
-        ) != bool(callable_):
-            problems.append("cannot change callability")
-        if last_issuance["call_date"] > call_date and (
-            call_date != 0
-            or (
-                not protocol.enabled("default_values_for_callable")
-                and not protocol.is_test_network()
-            )
-        ):
-            problems.append("cannot advance call date")
-        if last_issuance["call_price"] > call_price:
-            problems.append("cannot reduce call price")
+        if not protocol.enabled("issuance_callability_parameters_removal", block_index):
+            if bool(last_issuance["callable"]) != bool(callable_):
+                problems.append("cannot change callability")
+            if last_issuance["call_date"] > call_date and (
+                call_date != 0
+                or (
+                    not protocol.enabled("default_values_for_callable")
+                    and not protocol.is_test_network()
+                )
+            ):
+                problems.append("cannot advance call date")
+            if last_issuance["call_price"] > call_price:
+                problems.append("cannot reduce call price")
         if issuance_locked and quantity:
             problems.append("locked asset and non‐zero quantity")
         if issuance_locked and reset:

--- a/counterparty-core/counterpartycore/protocol_changes.json
+++ b/counterparty-core/counterpartycore/protocol_changes.json
@@ -1410,5 +1410,14 @@
         "testnet3_block_index": 4961300,
         "testnet4_block_index": 136300,
         "signet_block_index": 310300
+    },
+    "issuance_callable_lock_fix": {
+        "minimum_version_major": 11,
+        "minimum_version_minor": 1,
+        "minimum_version_revision": 0,
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     }
 }

--- a/counterparty-core/counterpartycore/test/units/messages/issuance_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/issuance_test.py
@@ -5,6 +5,7 @@ import cbor2
 import pytest
 from counterpartycore.lib import config, exceptions
 from counterpartycore.lib.api import apiwatcher
+from counterpartycore.lib.ledger.currentstate import CurrentState
 from counterpartycore.lib.messages import issuance
 from counterpartycore.test.mocks.counterpartydbs import ProtocolChangesDisabled
 
@@ -213,25 +214,8 @@ def test_validate(ledger_db, defaults, current_block_index):
         (defaults["addresses"][0], defaults["addresses"][0]),
     )
 
-    assert issuance.validate(
-        ledger_db,
-        defaults["addresses"][0],
-        "OLDCALLABLE",
-        0,
-        True,
-        True,
-        False,
-        False,
-        0,
-        0.0,
-        "",
-        None,
-        None,
-        current_block_index,
-    ) == (0, 0.0, [], 0, "", True, True, False, True, None)
-
-    with ProtocolChangesDisabled(["issuance_callability_parameters_removal"]):
-        assert issuance.validate(
+    def validate_callable_lock_at(block_index):
+        return issuance.validate(
             ledger_db,
             defaults["addresses"][0],
             "OLDCALLABLE",
@@ -245,8 +229,35 @@ def test_validate(ledger_db, defaults, current_block_index):
             "",
             None,
             None,
-            current_block_index,
-        )[2] == ["cannot change callability", "cannot reduce call price"]
+            block_index,
+        )[2]
+
+    current_state = CurrentState()
+    original_block_index = current_state.current_block_index()
+    original_network = (config.REGTEST, config.TESTNET3, config.TESTNET4, config.SIGNET)
+    try:
+        config.REGTEST = False
+        config.TESTNET3 = False
+        config.TESTNET4 = False
+        config.SIGNET = False
+
+        current_state.set_current_block_index(952799)
+        assert validate_callable_lock_at(952799) == [
+            "cannot change callability",
+            "cannot reduce call price",
+        ]
+
+        current_state.set_current_block_index(952800)
+        assert validate_callable_lock_at(952800) == []
+    finally:
+        config.REGTEST, config.TESTNET3, config.TESTNET4, config.SIGNET = original_network
+        current_state.set_current_block_index(original_block_index)
+
+    with ProtocolChangesDisabled(["issuance_callable_lock_fix"]):
+        assert validate_callable_lock_at(952800) == [
+            "cannot change callability",
+            "cannot reduce call price",
+        ]
 
     assert issuance.validate(
         ledger_db,

--- a/counterparty-core/counterpartycore/test/units/messages/issuance_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/issuance_test.py
@@ -196,6 +196,58 @@ def test_validate(ledger_db, defaults, current_block_index):
         current_block_index,
     ) == (0, "abc", ["call_price must be a float"], 0, "", True, None, None)
 
+    ledger_db.execute(
+        """
+        INSERT INTO issuances (
+            tx_index, tx_hash, msg_index, block_index, asset, quantity,
+            divisible, source, issuer, transfer, callable, call_date,
+            call_price, description, fee_paid, locked, reset, status,
+            asset_longname
+        ) VALUES (
+            999999, 'test_hash_callable_lock', 0, 310000, 'OLDCALLABLE', 1000,
+            1, ?, ?, 0, 1, 1409401723,
+            1.5, 'Old callable asset', 0, 0, 0, 'valid',
+            NULL
+        )
+        """,
+        (defaults["addresses"][0], defaults["addresses"][0]),
+    )
+
+    assert issuance.validate(
+        ledger_db,
+        defaults["addresses"][0],
+        "OLDCALLABLE",
+        0,
+        True,
+        True,
+        False,
+        False,
+        0,
+        0.0,
+        "",
+        None,
+        None,
+        current_block_index,
+    ) == (0, 0.0, [], 0, "", True, True, False, True, None)
+
+    with ProtocolChangesDisabled(["issuance_callability_parameters_removal"]):
+        assert issuance.validate(
+            ledger_db,
+            defaults["addresses"][0],
+            "OLDCALLABLE",
+            0,
+            True,
+            True,
+            False,
+            False,
+            0,
+            0.0,
+            "",
+            None,
+            None,
+            current_block_index,
+        )[2] == ["cannot change callability", "cannot reduce call price"]
+
     assert issuance.validate(
         ledger_db,
         defaults["addresses"][0],


### PR DESCRIPTION
Fixes #1338.

`issuance_callability_parameters_removal` already skips the reissuance check for changing `callable`, but validation still rejected old callable assets when newer lock/reset issuance formats decoded removed callability fields as `call_price=0.0`. That left old callable assets unable to be locked because `last_issuance["call_price"] > call_price` still produced `cannot reduce call price`.

This keeps the old validation behavior before the protocol change, but skips all deprecated callability-parameter comparisons after `issuance_callability_parameters_removal` is active:
- `callable`
- `call_date`
- `call_price`

Tests:
- `.venv/bin/ruff format counterpartycore/lib/messages/issuance.py counterpartycore/test/units/messages/issuance_test.py`
- `.venv/bin/ruff check counterpartycore/lib/messages/issuance.py counterpartycore/test/units/messages/issuance_test.py`
- `.venv/bin/pytest counterpartycore/test/units/messages/issuance_test.py::test_validate`
- `.venv/bin/pytest counterpartycore/test/units/messages/issuance_test.py` — 30 passed
- `git diff --check`

BTC payout address, if applicable: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`