### PR TITLE
Skip oracle fee for dispenser closes

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/dispenser.py
+++ b/counterparty-core/counterpartycore/lib/messages/dispenser.py
@@ -219,7 +219,11 @@ def validate(
 
     cursor.close()
 
-    if oracle_address is not None and protocol.enabled("oracle_dispensers", block_index):
+    if (
+        oracle_address is not None
+        and protocol.enabled("oracle_dispensers", block_index)
+        and status in [STATUS_OPEN, STATUS_OPEN_EMPTY_ADDRESS]
+    ):
         last_price, _last_fee, _last_label, _last_updated = other.get_oracle_last_price(
             db, oracle_address, block_index
         )
@@ -284,17 +288,18 @@ def compose(
     ):
         data += address_pack(open_address)
     if oracle_address is not None and protocol.enabled("oracle_dispensers"):
-        oracle_fee = calculate_oracle_fee(
-            db,
-            escrow_quantity,
-            give_quantity,
-            mainchainrate,
-            oracle_address,
-            CurrentState().current_block_index(),
-        )
+        if status in [STATUS_OPEN, STATUS_OPEN_EMPTY_ADDRESS]:
+            oracle_fee = calculate_oracle_fee(
+                db,
+                escrow_quantity,
+                give_quantity,
+                mainchainrate,
+                oracle_address,
+                CurrentState().current_block_index(),
+            )
 
-        if oracle_fee >= config.DEFAULT_REGULAR_DUST_SIZE:
-            destination.append((oracle_address, oracle_fee))
+            if oracle_fee >= config.DEFAULT_REGULAR_DUST_SIZE:
+                destination.append((oracle_address, oracle_fee))
         data += address_pack(oracle_address)
 
     return (source, destination, data)

--- a/counterparty-core/counterpartycore/test/units/messages/dispenser_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/dispenser_test.py
@@ -254,6 +254,40 @@ def test_compose_with_oracle(ledger_db, defaults, monkeypatch):
         )
 
 
+def test_compose_close_with_oracle_does_not_pay_fee(ledger_db, defaults, monkeypatch):
+    oracle_fee = config.DEFAULT_REGULAR_DUST_SIZE + 1
+    monkeypatch.setattr(dispenser, "calculate_oracle_fee", lambda *args: oracle_fee)
+
+    assert dispenser.compose(
+        ledger_db,
+        defaults["addresses"][0],
+        "PARENT",
+        100,
+        1000000000,
+        0,
+        dispenser.STATUS_OPEN,
+        None,
+        defaults["addresses"][1],
+        True,
+    )[1] == [(defaults["addresses"][1], oracle_fee)]
+
+    assert dispenser.compose(
+        ledger_db,
+        defaults["addresses"][5],
+        config.XCP,
+        0,
+        0,
+        0,
+        dispenser.STATUS_CLOSED,
+        None,
+        defaults["addresses"][1],
+    ) == (
+        defaults["addresses"][5],
+        [],
+        b"\x0c\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\no\x8dj\xe8\xa3\xb3\x81f1\x18\xb4\xe1\xef\xf4\xcf\xc7\xd0\x95M\xd6\xec",
+    )
+
+
 def test_parse_open_dispenser(
     ledger_db, blockchain_mock, defaults, test_helpers, current_block_index
 ):


### PR DESCRIPTION
Fixes #1271.

Dispenser close transactions do not consume oracle pricing or enforce oracle-fee payment during parsing, but compose/validation still treated any `oracle_address` as requiring a current oracle price and a fee output.

This limits oracle price validation and oracle fee output generation to dispenser open/refill actions (`STATUS_OPEN` and `STATUS_OPEN_EMPTY_ADDRESS`). Close messages can still encode an oracle address, but they no longer add a BTC fee output or fail validation just because the oracle has no current price.

Tests:
- `.venv/bin/ruff format counterpartycore/lib/messages/dispenser.py counterpartycore/test/units/messages/dispenser_test.py`
- `.venv/bin/ruff check counterpartycore/lib/messages/dispenser.py counterpartycore/test/units/messages/dispenser_test.py`
- `.venv/bin/pytest counterpartycore/test/units/messages/dispenser_test.py::test_compose_close_with_oracle_does_not_pay_fee counterpartycore/test/units/messages/dispenser_test.py -q` — 12 passed
- `.venv/bin/pytest counterpartycore/test/units/api/compose_test.py::test_compose_dispenser`
- `git diff --check`

BTC payout address, if applicable: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`