### PR TITLE
Resolve subasset longnames for fairmints

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/fairmint.py
+++ b/counterparty-core/counterpartycore/lib/messages/fairmint.py
@@ -18,6 +18,10 @@ def D(value):  # pylint: disable=invalid-name
     return decimal.Decimal(str(value))
 
 
+def resolve_asset_name(db, asset):
+    return ledger.issuances.resolve_subasset_longname(db, asset)
+
+
 def validate(
     db,
     source,
@@ -29,7 +33,8 @@ def validate(
     if not isinstance(quantity, int):
         problems.append("quantity must be an integer")
 
-    fairminter = ledger.issuances.get_fairminter_by_asset(db, asset)
+    resolved_asset = resolve_asset_name(db, asset)
+    fairminter = ledger.issuances.get_fairminter_by_asset(db, resolved_asset)
     if not fairminter:
         problems.append(f"fairminter not found for asset: `{asset}`")
         return problems
@@ -82,12 +87,13 @@ def validate(
 
 
 def compose(db, source: str, asset: str, quantity: int = 0, skip_validation: bool = False):
+    resolved_asset = resolve_asset_name(db, asset)
     problems = validate(db, source, asset, quantity)
     if len(problems) > 0 and not skip_validation:
         raise exceptions.ComposeError(problems)
 
     if quantity != 0 and not skip_validation:
-        fairminter = ledger.issuances.get_fairminter_by_asset(db, asset)
+        fairminter = ledger.issuances.get_fairminter_by_asset(db, resolved_asset)
         if fairminter["price"] == 0:
             raise exceptions.ComposeError("quantity is not allowed for free fairminters")
         if quantity % fairminter["quantity_by_price"] != 0:
@@ -97,14 +103,14 @@ def compose(db, source: str, asset: str, quantity: int = 0, skip_validation: boo
     data = struct.pack(config.SHORT_TXTYPE_FORMAT, ID)
 
     if protocol.enabled("fairminter_v2"):
-        asset_id = ledger.issuances.generate_asset_id(asset)
+        asset_id = ledger.issuances.generate_asset_id(resolved_asset)
         data += cbor2.dumps([asset_id, quantity])
     else:
         data_content = "|".join(
             [
                 str(value)
                 for value in [
-                    asset,
+                    resolved_asset,
                     quantity,
                 ]
             ]

--- a/counterparty-core/counterpartycore/test/units/messages/fairmint_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/fairmint_test.py
@@ -125,6 +125,58 @@ def test_compose(ledger_db, defaults):
         )
 
 
+def test_compose_resolves_subasset_longname(ledger_db, defaults):
+    asset_longname = "PARENT.already.issued"
+    asset_name = "A95428959342453541"
+    ledger_db.execute(
+        """
+        INSERT INTO fairminters (
+            tx_hash, tx_index, block_index, source, asset, asset_parent,
+            asset_longname, description, price, quantity_by_price, hard_cap,
+            burn_payment, max_mint_per_tx, premint_quantity, start_block,
+            end_block, minted_asset_commission_int, soft_cap,
+            soft_cap_deadline_block, lock_description, lock_quantity,
+            divisible, status
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "a" * 64,
+            10_000,
+            1,
+            defaults["addresses"][0],
+            asset_name,
+            "PARENT",
+            asset_longname,
+            "",
+            0,
+            1,
+            0,
+            False,
+            10,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            False,
+            False,
+            True,
+            "open",
+        ),
+    )
+
+    assert fairmint.validate(ledger_db, defaults["addresses"][1], asset_longname, 0) == []
+    assert fairmint.compose(
+        ledger_db, defaults["addresses"][1], asset_longname, 0
+    ) == fairmint.compose(
+        ledger_db,
+        defaults["addresses"][1],
+        asset_name,
+        0,
+    )
+
+
 def test_unpack():
     assert fairmint.unpack(b"\x82\x1b\x00\x02\xd6\xb1\x16H\xdbu\x00", False) == ("FREEFAIRMIN", 0)
     assert fairmint.unpack(b"\x82\x1b\x00\x02\xd6\xb1\x16H\xdbu\x00", True) == {


### PR DESCRIPTION
Fixes #2479.

Summary:
- resolve fairmint subasset longnames to their numeric asset names before validation and message packing
- keep existing fairmint behavior unchanged for named and numeric assets
- add a regression test covering full subasset longname mint composition

Tests:
- `.venv/bin/pytest counterpartycore/test/units/messages/fairmint_test.py -q`
- `.venv/bin/ruff format --check counterpartycore/lib/messages/fairmint.py counterpartycore/test/units/messages/fairmint_test.py`
- `.venv/bin/ruff check counterpartycore/lib/messages/fairmint.py counterpartycore/test/units/messages/fairmint_test.py`
- `git diff --check`

Bounty claim address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`