### PR TITLE
Encode MPMA text memo lengths as UTF-8 bytes

### DIFF
--- a/counterparty-core/counterpartycore/lib/utils/mpmaencoding.py
+++ b/counterparty-core/counterpartycore/lib/utils/mpmaencoding.py
@@ -56,9 +56,10 @@ def _encode_memo(memo=None, is_hex=False):
             barr.append(memo)
         else:
             # signal a 0 bit for a string encoded memo
+            memo = memo.encode("utf-8")
             barr.append("0b0")
             barr.append(f"uint:6={len(memo)}")
-            barr.append(BitArray(memo.encode("utf-8")))
+            barr.append(BitArray(memo))
 
         return barr
     # if the memo is None, return just a 0 bit

--- a/counterparty-core/counterpartycore/test/units/messages/versions/mpma_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/versions/mpma_test.py
@@ -410,6 +410,26 @@ def test_compose_valid(ledger_db, defaults):
     )
 
 
+def test_compose_roundtrips_utf8_memo(ledger_db, defaults):
+    _source, _destination, data = mpma.compose(
+        ledger_db,
+        defaults["addresses"][0],
+        [
+            ("XCP", defaults["addresses"][2], defaults["quantity"]),
+            ("XCP", defaults["addresses"][1], defaults["quantity"]),
+        ],
+        "∞",
+        False,
+    )
+
+    assert mpma.unpack(data[1:]) == {
+        "XCP": [
+            (defaults["addresses"][2], defaults["quantity"], "∞", False),
+            (defaults["addresses"][1], defaults["quantity"], "∞", False),
+        ]
+    }
+
+
 def test_compose_invalid(ledger_db, defaults):
     with pytest.raises(exceptions.ComposeError, match="insufficient funds for XCP"):
         mpma.compose(


### PR DESCRIPTION
Fixes #1248.

MPMA text memo encoding currently stores `len(memo)` in the 6-bit memo length field, but writes `memo.encode("utf-8")` into the payload. For non-ASCII memo text such as `∞`, the encoded byte length is larger than the character count, so decoding reads a truncated UTF-8 sequence and raises a UnicodeDecodeError.

This PR encodes the text memo first, then writes the encoded byte length before appending the bytes. Hex memo handling is unchanged.

Added a regression test that composes an MPMA with `∞` as the message-wide memo and verifies it unpacks back to the same text memo for each send.

Tests run:
- `.venv/bin/pytest counterpartycore/test/units/messages/versions/mpma_test.py::test_compose_roundtrips_utf8_memo -q`
- `.venv/bin/pytest counterpartycore/test/units/messages/versions/mpma_test.py -q`
- `.venv/bin/ruff format --check counterpartycore/lib/utils/mpmaencoding.py counterpartycore/test/units/messages/versions/mpma_test.py`
- `.venv/bin/ruff check counterpartycore/lib/utils/mpmaencoding.py counterpartycore/test/units/messages/versions/mpma_test.py`
- `git diff --check`

BTC address for bounty consideration: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`