### PR TITLE
Clarify BTC dividend dust error

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/dividend.py
+++ b/counterparty-core/counterpartycore/lib/messages/dividend.py
@@ -72,6 +72,7 @@ def validate(db, source, quantity_per_unit, asset, dividend_asset, block_index):
     outputs = []
     addresses = []
     dividend_total = 0
+    btc_dust_outputs_skipped = False
     for holder in asset_holders:
         if (
             not protocol.enabled("price_as_fraction") and not protocol.is_test_network()
@@ -94,6 +95,7 @@ def validate(db, source, quantity_per_unit, asset, dividend_asset, block_index):
             dividend_quantity /= config.UNIT  # Pre-fix behaviour
 
         if dividend_asset == config.BTC and dividend_quantity < config.DEFAULT_MULTISIG_DUST_SIZE:
+            btc_dust_outputs_skipped = True
             continue  # A bit hackish.
         dividend_quantity = int(dividend_quantity)
 
@@ -108,7 +110,10 @@ def validate(db, source, quantity_per_unit, asset, dividend_asset, block_index):
         dividend_total += dividend_quantity
 
     if not dividend_total:
-        problems.append("zero dividend")
+        if dividend_asset == config.BTC and btc_dust_outputs_skipped:
+            problems.append("BTC dividend output below dust threshold")
+        else:
+            problems.append("zero dividend")
 
     if dividend_asset != config.BTC:
         dividend_balances = ledger.balances.get_balance(db, source, dividend_asset)

--- a/counterparty-core/counterpartycore/test/units/messages/dividend_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/dividend_test.py
@@ -1,4 +1,5 @@
-from counterpartycore.lib import ledger
+import pytest
+from counterpartycore.lib import exceptions, ledger
 from counterpartycore.lib.messages import dividend
 
 
@@ -57,6 +58,10 @@ def test_validate(ledger_db, defaults, current_block_index):
     ) == (None, None, ["non‐positive quantity per unit", "zero dividend"], 0)
 
     assert dividend.validate(
+        ledger_db, defaults["addresses"][0], 1, "DIVISIBLE", "BTC", current_block_index
+    ) == (None, None, ["BTC dividend output below dust threshold"], 0)
+
+    assert dividend.validate(
         ledger_db,
         defaults["addresses"][1],
         defaults["quantity"],
@@ -111,6 +116,9 @@ def test_compose(ledger_db, defaults):
         [],
         b'2\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\xa2[\xe3Kf\x01S\x08"\x06\xe4c%',
     )
+
+    with pytest.raises(exceptions.ComposeError, match="BTC dividend output below dust threshold"):
+        dividend.compose(ledger_db, defaults["addresses"][0], 1, "DIVISIBLE", "BTC")
 
 
 def test_parse_dividend(ledger_db, blockchain_mock, defaults, test_helpers, current_block_index):


### PR DESCRIPTION
Improves #958.

## Summary
- Track BTC dividend outputs skipped because they are below `DEFAULT_MULTISIG_DUST_SIZE`
- Report `BTC dividend output below dust threshold` instead of the generic `zero dividend` when every candidate BTC output is skipped
- Add validate and compose coverage for the BTC dust case

## Notes
This keeps the existing behavior of not emitting sub-dust BTC dividend outputs. It only makes the compose/validation failure explain the actual dust threshold reason.

## Tests
- `.venv/bin/pytest counterpartycore/test/units/messages/dividend_test.py`
- `.venv/bin/ruff check counterpartycore/lib/messages/dividend.py counterpartycore/test/units/messages/dividend_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`