### PR TITLE
Add address options API route

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/queries.py
+++ b/counterparty-core/counterpartycore/lib/api/queries.py
@@ -583,6 +583,26 @@ def get_transactions_by_addresses(
     )
 
 
+def get_address(ledger_db, address: str):
+    """
+    Returns the latest options for an address.
+    :param str address: The address to return (e.g. $ADDRESS_1)
+    """
+    query_result = select_row(ledger_db, "addresses", where={"address": address})
+    if query_result:
+        return query_result
+    return QueryResult(
+        {
+            "address": address,
+            "options": 0,
+            "block_index": None,
+        },
+        None,
+        "addresses",
+        1,
+    )
+
+
 def get_transaction_types_count(state_db):
     """
     Returns the count of each transaction type

--- a/counterparty-core/counterpartycore/lib/api/routes.py
+++ b/counterparty-core/counterpartycore/lib/api/routes.py
@@ -80,6 +80,8 @@ ALL_ROUTES = {
     "/v2/addresses/transactions": (queries.get_transactions_by_addresses, "addresses"),
     "/v2/addresses/events": (queries.get_events_by_addresses, "addresses"),
     "/v2/addresses/mempool": (queries.get_mempool_events_by_addresses, "addresses"),
+    "/v2/addresses/<address>": (queries.get_address, "addresses"),
+    "/v2/addresses/<address>/options": (queries.get_address, "addresses"),
     "/v2/addresses/<address>/balances": (queries.get_address_balances, "addresses"),
     "/v2/addresses/<address>/balances/<asset>": (
         queries.get_balances_by_address_and_asset,

--- a/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
@@ -421,6 +421,22 @@ def test_get_all_transactions_verbose(apiv2_client):
         assert "message_data" in tx["unpacked_data"]
 
 
+def test_get_address_options(apiv2_client, defaults):
+    result = apiv2_client.get(f"/v2/addresses/{defaults['addresses'][4]}").json["result"]
+    assert result == {
+        "address": defaults["addresses"][4],
+        "options": 0,
+        "block_index": None,
+    }
+
+    result = apiv2_client.get(f"/v2/addresses/{defaults['addresses'][4]}/options").json["result"]
+    assert result == {
+        "address": defaults["addresses"][4],
+        "options": 0,
+        "block_index": None,
+    }
+
+
 def test_get_balances_by_addresses(apiv2_client, defaults):
     url = f"/v2/addresses/balances?addresses={defaults['addresses'][0]}&verbose=true"
     result = apiv2_client.get(url).json["result"]

--- a/counterparty-core/counterpartycore/test/units/api/queries_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/queries_test.py
@@ -3,6 +3,7 @@ Unit tests for counterpartycore.lib.api.queries module.
 Tests focus on covering uncovered lines in the module.
 """
 
+from counterpartycore.lib import config
 from counterpartycore.lib.api import queries
 
 # =============================================================================
@@ -168,6 +169,27 @@ def test_select_row_returns_none(ledger_db):
         where={"tx_hash": "nonexistent_hash_that_does_not_exist"},
     )
     assert result is None
+
+
+def test_get_address_options(ledger_db, defaults):
+    unset_address = defaults["addresses"][4]
+    result = queries.get_address(ledger_db, unset_address)
+    assert result.result == {
+        "address": unset_address,
+        "options": 0,
+        "block_index": None,
+    }
+
+    address_with_options = defaults["addresses"][6]
+    ledger_db.execute(
+        "INSERT INTO addresses (address, options, block_index) VALUES (?, ?, ?)",
+        (address_with_options, config.ADDRESS_OPTION_REQUIRE_MEMO, 123),
+    )
+
+    result = queries.get_address(ledger_db, address_with_options)
+    assert result.result["address"] == address_with_options
+    assert result.result["options"] == config.ADDRESS_OPTION_REQUIRE_MEMO
+    assert result.result["block_index"] == 123
 
 
 # =============================================================================


### PR DESCRIPTION
Addresses #2640.

Summary:
- Add `/v2/addresses/<address>` and `/v2/addresses/<address>/options`.
- Return the latest stored address options when present.
- Return default `options: 0` for addresses without an options record.
- Add API and query coverage.

Tests:
- `.venv/bin/pytest counterpartycore/test/units/api/apiserver_test.py::test_get_address_options counterpartycore/test/units/api/apiserver_test.py::test_all_routes counterpartycore/test/units/api/queries_test.py::test_get_address_options -q`
- `.venv/bin/ruff check counterpartycore/lib/api/queries.py counterpartycore/lib/api/routes.py counterpartycore/test/units/api/apiserver_test.py counterpartycore/test/units/api/queries_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`