### PR TITLE
Skip count query for single-row selects

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/queries.py
+++ b/counterparty-core/counterpartycore/lib/api/queries.py
@@ -195,6 +195,7 @@ def select_rows(
     order="DESC",
     wrap_where=None,
     sort=None,
+    with_count=True,
 ):
     if offset is not None or sort is not None:
         last_cursor = None
@@ -344,10 +345,12 @@ def select_rows(
         cursor.execute(query, bindings)
         result = cursor.fetchall()
 
-    with start_sentry_span(op="db.sql.execute", description=query_count) as sql_span:
-        sql_span.set_tag("db.system", "sqlite3")
-        cursor.execute(query_count, bindings_count)
-        result_count = cursor.fetchone()["count"]
+    result_count = None
+    if with_count:
+        with start_sentry_span(op="db.sql.execute", description=query_count) as sql_span:
+            sql_span.set_tag("db.system", "sqlite3")
+            cursor.execute(query_count, bindings_count)
+            result_count = cursor.fetchone()["count"]
 
     if result and len(result) > limit:
         # Don't return a cursor when using sort or offset
@@ -374,7 +377,15 @@ def select_rows(
 
 
 def select_row(db, table, where, select="*", group_by=""):
-    query_result = select_rows(db, table, where, limit=1, select=select, group_by=group_by)
+    query_result = select_rows(
+        db,
+        table,
+        where,
+        limit=1,
+        select=select,
+        group_by=group_by,
+        with_count=False,
+    )
     if query_result.result:
         return QueryResult(query_result.result[0], None, table, 1)
     return None

--- a/counterparty-core/counterpartycore/test/units/api/queries_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/queries_test.py
@@ -170,6 +170,26 @@ def test_select_row_returns_none(ledger_db):
     assert result is None
 
 
+def test_select_rows_can_skip_result_count(ledger_db):
+    """Test select_rows can skip the extra count query for single-row lookups."""
+    counted_result = queries.select_rows(
+        ledger_db,
+        "transactions",
+        limit=1,
+    )
+    assert counted_result is not None
+    assert counted_result.result_count is not None
+
+    result = queries.select_rows(
+        ledger_db,
+        "transactions",
+        limit=1,
+        with_count=False,
+    )
+    assert result is not None
+    assert result.result_count is None
+
+
 # =============================================================================
 # Tests for transaction queries
 # =============================================================================


### PR DESCRIPTION
Addresses #2965.

Summary:
- Let `select_rows()` skip the extra `COUNT(*)` query when callers do not need `result_count`.
- Use that lighter path from `select_row()`, which covers single-record endpoints such as `/v2/assets/<asset>`.
- Preserve the default counted behavior for list/paginated endpoints.

Tests:
- `.venv/bin/pytest counterpartycore/test/units/api/queries_test.py::test_select_rows_can_skip_result_count counterpartycore/test/units/api/apiserver_test.py::test_new_get_asset_info counterpartycore/test/units/api/apiserver_test.py::test_get_asset_by_longname_case_insensitive -q`
- `.venv/bin/ruff check counterpartycore/lib/api/queries.py counterpartycore/test/units/api/queries_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`