### PR TITLE
Add multiple detach compose route

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/compose.py
+++ b/counterparty-core/counterpartycore/lib/api/compose.py
@@ -640,6 +640,36 @@ def compose_detach(
     return composer.compose_transaction(db, "detach", params, construct_params)
 
 
+def compose_detach_by_utxos(
+    db,
+    utxos: str,
+    destination: str = None,
+    **construct_params,
+):
+    """
+    Composes a transaction to detach assets from multiple UTXOs to an address.
+    :param utxos: A comma-separated list of UTXOs from which assets are detached (e.g. $UTXO_WITH_BALANCE,$UTXO_WITH_BALANCE_2)
+    :param destination: The address to detach the assets to, if not provided the address corresponding to each UTXO is used (e.g. $ADDRESS_1)
+    """
+    if construct_params.get("inputs_set") is not None:
+        raise exceptions.ComposeError("`utxos` cannot be combined with `inputs_set`")
+
+    parsed_utxos = composer.prepare_inputs_set(utxos)
+    source = f"{parsed_utxos[0]['txid']}:{parsed_utxos[0]['vout']}"
+    if construct_params.get("validate", True):
+        for parsed_utxo in parsed_utxos:
+            utxo_id = f"{parsed_utxo['txid']}:{parsed_utxo['vout']}"
+            if ledger.balances.get_utxo_balances(db, utxo_id):
+                source = utxo_id
+                break
+
+    construct_params["inputs_set"] = utxos
+    construct_params["use_all_inputs_set"] = True
+    construct_params["use_utxos_with_balances"] = True
+
+    return compose_detach(db, source, destination, **construct_params)
+
+
 def compose_movetoutxo(db, utxo: str, destination: str, utxo_value: int = None, **construct_params):
     """
     Composes a transaction like a send but for moving from one UTXO to another, with the destination is specified as an address.

--- a/counterparty-core/counterpartycore/lib/api/routes.py
+++ b/counterparty-core/counterpartycore/lib/api/routes.py
@@ -187,6 +187,7 @@ ALL_ROUTES = {
     ),
     "/v2/utxos/<utxo>/compose/detach": (compose.compose_detach, "compose"),
     "/v2/utxos/<utxo>/compose/movetoutxo": (compose.compose_movetoutxo, "compose"),
+    "/v2/compose/detach": (compose.compose_detach_by_utxos, "compose"),
     "/v2/compose/attach/estimatexcpfees": (compose.get_attach_estimate_xcp_fee, "compose"),
     ### /assets ###
     "/v2/assets": (queries.get_valid_assets, "assets"),

--- a/counterparty-core/counterpartycore/test/units/api/compose_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/compose_test.py
@@ -418,6 +418,42 @@ def test_compose_detach(ledger_db, defaults):
         pass  # Expected to fail on validation
 
 
+def test_compose_multiple_detach_route(apiv2_client, defaults, monkeypatch):
+    txid_1 = "a" * 64
+    txid_2 = "b" * 64
+    script_pub_key = "76a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788ac"
+    utxos = f"{txid_1}:0:546:{script_pub_key},{txid_2}:1:546:{script_pub_key}"
+
+    def fake_compose_transaction(db, name, params, construct_params):  # noqa: ARG001
+        return {
+            "name": name,
+            "params": params,
+            "construct_params": construct_params,
+        }
+
+    monkeypatch.setattr(compose.composer, "compose_transaction", fake_compose_transaction)
+
+    result = apiv2_client.get(
+        f"/v2/compose/detach?utxos={utxos}&destination={defaults['addresses'][0]}"
+    ).json["result"]
+
+    assert result["name"] == "detach"
+    assert result["params"] == {
+        "source": f"{txid_1}:0",
+        "destination": defaults["addresses"][0],
+    }
+    assert result["construct_params"]["inputs_set"] == utxos
+    assert result["construct_params"]["use_all_inputs_set"] is True
+    assert result["construct_params"]["use_utxos_with_balances"] is True
+
+
+def test_compose_multiple_detach_rejects_inputs_set(ledger_db):
+    txid = "a" * 64
+    utxo = f"{txid}:0"
+    with pytest.raises(exceptions.ComposeError, match="cannot be combined"):
+        compose.compose_detach_by_utxos(ledger_db, utxos=utxo, inputs_set=utxo)
+
+
 def test_compose_movetoutxo(ledger_db, defaults):
     """Test compose_movetoutxo function directly."""
     # Test compose_movetoutxo function directly to cover the code path


### PR DESCRIPTION
Addresses #3219.

Summary:
- Add `/v2/compose/detach?utxos=<utxo1>,<utxo2>,...` as a cleaner multiple-detach composition route.
- Reuse the existing detach composer and transaction construction by mapping `utxos` to `inputs_set` and enabling `use_all_inputs_set`.
- Enable `use_utxos_with_balances` so the provided UTXOs with attached balances can all be included in the detach transaction.
- Add route-level coverage and conflict validation for `inputs_set`.

Tests:
- `.venv/bin/pytest counterpartycore/test/units/api/compose_test.py::test_compose_multiple_detach_route counterpartycore/test/units/api/compose_test.py::test_compose_multiple_detach_rejects_inputs_set counterpartycore/test/units/api/apiserver_test.py::test_all_routes -q`
- `.venv/bin/ruff check counterpartycore/lib/api/compose.py counterpartycore/lib/api/routes.py counterpartycore/test/units/api/compose_test.py`
- `.venv/bin/ruff format --check counterpartycore/lib/api/compose.py counterpartycore/lib/api/routes.py counterpartycore/test/units/api/compose_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`