### PR TITLE
Include XCP fees in compose responses

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/compose.py
+++ b/counterparty-core/counterpartycore/lib/api/compose.py
@@ -17,6 +17,11 @@ from counterpartycore.lib.parser import deserialize, gettxinfo, messagetype
 D = decimal.Decimal
 
 
+def _add_xcp_fee(result, xcp_fee):
+    result["xcp_fee"] = xcp_fee
+    return result
+
+
 def compose_bet(
     db,
     address: str,
@@ -181,7 +186,10 @@ def compose_dividend(
         "asset": asset,
         "dividend_asset": dividend_asset,
     }
-    return composer.compose_transaction(db, "dividend", params, construct_params)
+    return _add_xcp_fee(
+        composer.compose_transaction(db, "dividend", params, construct_params),
+        messages.dividend.get_estimate_xcp_fee(db, asset),
+    )
 
 
 def get_dividend_estimate_xcp_fee(db, address: str, asset: str):  # noqa # pylint: disable=W0613
@@ -396,7 +404,10 @@ def compose_sweep(db, address: str, destination: str, flags: int, memo: str, **c
         "flags": flags,
         "memo": memo,
     }
-    return composer.compose_transaction(db, "sweep", params, construct_params)
+    return _add_xcp_fee(
+        composer.compose_transaction(db, "sweep", params, construct_params),
+        messages.sweep.get_total_fee(db, address, CurrentState().current_block_index()),
+    )
 
 
 def get_sweep_estimate_xcp_fee(db, address: str):
@@ -530,7 +541,10 @@ def compose_pooldeposit(
         "min_lp_quantity": min_lp_quantity,
         "lp_asset": lp_asset,
     }
-    return composer.compose_transaction(db, "pooldeposit", params, construct_params)
+    return _add_xcp_fee(
+        composer.compose_transaction(db, "pooldeposit", params, construct_params),
+        gas.get_transaction_fee(db, 120, CurrentState().current_block_index()),
+    )
 
 
 def get_pool_deposit_estimate_xcp_fee(db, address: str = None):  # noqa  # pylint: disable=W0613
@@ -575,7 +589,10 @@ def compose_poolwithdraw(
         "min_quantity_a": min_quantity_a,
         "min_quantity_b": min_quantity_b,
     }
-    return composer.compose_transaction(db, "poolwithdraw", params, construct_params)
+    return _add_xcp_fee(
+        composer.compose_transaction(db, "poolwithdraw", params, construct_params),
+        gas.get_transaction_fee(db, 121, CurrentState().current_block_index()),
+    )
 
 
 def get_pool_withdraw_estimate_xcp_fee(db, address: str = None):  # noqa  # pylint: disable=W0613
@@ -611,7 +628,10 @@ def compose_attach(
         "utxo_value": utxo_value,
         "destination_vout": destination_vout,
     }
-    return composer.compose_transaction(db, "attach", params, construct_params)
+    return _add_xcp_fee(
+        composer.compose_transaction(db, "attach", params, construct_params),
+        gas.get_transaction_fee(db, UTXO_ID, CurrentState().current_block_index()),
+    )
 
 
 def get_attach_estimate_xcp_fee(db, address: str = None):  # noqa  # pylint: disable=W0613

--- a/counterparty-core/counterpartycore/test/units/api/compose_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/compose_test.py
@@ -304,6 +304,73 @@ def test_get_pool_withdraw_estimate_xcp_fee(apiv2_client, defaults):
     assert result is None or (isinstance(result, int) and result >= 0)
 
 
+def test_compose_responses_include_xcp_fee(ledger_db, defaults, monkeypatch):
+    def fake_compose_transaction(db, name, params, construct_params):  # noqa: ARG001
+        return {
+            "name": name,
+            "params": params,
+            "rawtransaction": "00",
+        }
+
+    monkeypatch.setattr(compose.composer, "compose_transaction", fake_compose_transaction)
+    monkeypatch.setattr(compose.messages.dividend, "get_estimate_xcp_fee", lambda db, asset: 11)
+    monkeypatch.setattr(
+        compose.messages.sweep, "get_total_fee", lambda db, address, block_index: 22
+    )
+    monkeypatch.setattr(compose.gas, "get_transaction_fee", lambda db, tx_id, block_index: tx_id)
+
+    assert (
+        compose.compose_dividend(
+            ledger_db,
+            defaults["addresses"][0],
+            quantity_per_unit=1,
+            asset="DIVISIBLE",
+            dividend_asset="XCP",
+        )["xcp_fee"]
+        == 11
+    )
+    assert (
+        compose.compose_sweep(
+            ledger_db,
+            defaults["addresses"][0],
+            destination=defaults["addresses"][1],
+            flags=1,
+            memo="",
+        )["xcp_fee"]
+        == 22
+    )
+    assert (
+        compose.compose_attach(
+            ledger_db,
+            defaults["addresses"][0],
+            asset="XCP",
+            quantity=1,
+        )["xcp_fee"]
+        == compose.UTXO_ID
+    )
+    assert (
+        compose.compose_pooldeposit(
+            ledger_db,
+            defaults["addresses"][0],
+            asset_a="XCP",
+            asset_b="DIVISIBLE",
+            quantity_a=1,
+            quantity_b=1,
+        )["xcp_fee"]
+        == 120
+    )
+    assert (
+        compose.compose_poolwithdraw(
+            ledger_db,
+            defaults["addresses"][0],
+            asset_a="XCP",
+            asset_b="DIVISIBLE",
+            quantity=1,
+        )["xcp_fee"]
+        == 121
+    )
+
+
 def test_compose_pooldeposit_with_lp_asset(apiv2_client, defaults):
     address = defaults["addresses"][0]
     response = apiv2_client.get(


### PR DESCRIPTION
Addresses #2636.

Summary:
- Add `xcp_fee` to compose responses for transaction types with existing XCP fee estimate endpoints.
- Covered dividend, sweep, attach, pool deposit, and pool withdrawal compose responses.
- Reuse the existing fee estimators rather than changing transaction construction or fee calculation.
- Add API compose coverage for the new response field.

Tests:
- `.venv/bin/pytest counterpartycore/test/units/api/compose_test.py::test_compose_responses_include_xcp_fee counterpartycore/test/units/api/compose_test.py::test_get_dividend_estimate_xcp_fee counterpartycore/test/units/api/compose_test.py::test_get_sweep_estimate_xcp_fee counterpartycore/test/units/api/compose_test.py::test_get_attach_estimate_xcp_fee counterpartycore/test/units/api/compose_test.py::test_get_pool_deposit_estimate_xcp_fee counterpartycore/test/units/api/compose_test.py::test_get_pool_withdraw_estimate_xcp_fee -q`
- `.venv/bin/ruff check counterpartycore/lib/api/compose.py counterpartycore/test/units/api/compose_test.py`
- `.venv/bin/ruff format --check counterpartycore/lib/api/compose.py counterpartycore/test/units/api/compose_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`