### PR TITLE
Document sortable route fields

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/routes.py
+++ b/counterparty-core/counterpartycore/lib/api/routes.py
@@ -327,7 +327,7 @@ def function_needs_db(function):
     return " ".join(dbs)
 
 
-def prepare_route_args(function):
+def prepare_route_args(function, route_category=None):
     args = []
     function_args = inspect.signature(function).parameters
     args_description = get_args_description(function)
@@ -361,6 +361,13 @@ def prepare_route_args(function):
             route_arg["members"] = list(typing.get_args(annotation))
         if arg_name in args_description:
             route_arg["description"] = args_description[arg_name]
+        if arg_name == "sort" and route_category in queries.SUPPORTED_SORT_FIELDS:
+            sort_fields = queries.SUPPORTED_SORT_FIELDS[route_category]
+            route_arg["supported_values"] = sort_fields
+            route_arg["description"] = (
+                f"{route_arg.get('description', 'The sort order to return')}. "
+                f"Sortable fields: {', '.join(sort_fields)}."
+            )
         args.append(route_arg)
     if not function.__name__.endswith("_v1"):
         args.append(
@@ -388,7 +395,7 @@ def prepare_routes(routes):
         prepared_routes[route] = {
             "function": route_function,
             "description": get_function_description(route_function),
-            "args": prepare_route_args(route_function),
+            "args": prepare_route_args(route_function, route_category),
             "category": route_category,
         }
     return prepared_routes

--- a/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 import pytest
 from counterpartycore.lib import config, ledger
 from counterpartycore.lib.api import apiserver, apiwatcher, composer
-from counterpartycore.lib.api.routes import ALL_ROUTES
+from counterpartycore.lib.api.routes import ALL_ROUTES, ROUTES
 from counterpartycore.lib.messages import dispense, dividend, sweep
 from counterpartycore.lib.parser import blocks
 from counterpartycore.lib.utils import helpers
@@ -27,6 +27,22 @@ def test_apiserver_root(apiv2_client, current_block_index):
             "current_commit": helpers.get_current_commit_hash(),
         }
     }
+
+
+def test_routes_document_sort_fields():
+    orders_sort_arg = next(arg for arg in ROUTES["/v2/orders"]["args"] if arg["name"] == "sort")
+
+    assert orders_sort_arg["supported_values"] == [
+        "block_index",
+        "give_asset",
+        "give_quantity",
+        "get_asset",
+        "get_quantity",
+        "expiration",
+        "give_price",
+        "get_price",
+    ]
+    assert "Sortable fields:" in orders_sort_arg["description"]
 
 
 def prepare_url(db, current_block_index, defaults, rawtransaction, route):


### PR DESCRIPTION
Addresses #2249.

Summary:
- Add sortable field metadata to generated route argument docs for `sort` parameters.
- Reuse `queries.SUPPORTED_SORT_FIELDS` so route documentation updates automatically when sort support changes.
- Include the sortable field names in the `sort` argument description and expose them as `supported_values`.
- Add route metadata coverage for `/v2/orders`.

Tests:
- `.venv/bin/pytest counterpartycore/test/units/api/apiserver_test.py::test_routes_document_sort_fields -q`
- `.venv/bin/ruff check counterpartycore/lib/api/routes.py counterpartycore/test/units/api/apiserver_test.py`
- `.venv/bin/ruff format --check counterpartycore/lib/api/routes.py counterpartycore/test/units/api/apiserver_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`