### PR TITLE
Limit route docs to available parameters

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/routes.py
+++ b/counterparty-core/counterpartycore/lib/api/routes.py
@@ -6,6 +6,8 @@ from docstring_parser import parse as parse_docstring
 from counterpartycore.lib.api import apiv1, compose, composer, healthz, queries
 from counterpartycore.lib.backend import bitcoind, electrs
 
+ROUTE_CATEGORIES_WITHOUT_VERBOSE = {"bitcoin", "compose", "healthz", "routes", "v1"}
+
 
 def get_routes():
     """Return the API routes."""
@@ -327,7 +329,13 @@ def function_needs_db(function):
     return " ".join(dbs)
 
 
-def prepare_route_args(function):
+def should_include_verbose_arg(function, route_category=None):
+    if route_category in ROUTE_CATEGORIES_WITHOUT_VERBOSE:
+        return False
+    return not function.__name__.endswith("_v1")
+
+
+def prepare_route_args(function, route_category=None):
     args = []
     function_args = inspect.signature(function).parameters
     args_description = get_args_description(function)
@@ -362,7 +370,7 @@ def prepare_route_args(function):
         if arg_name in args_description:
             route_arg["description"] = args_description[arg_name]
         args.append(route_arg)
-    if not function.__name__.endswith("_v1"):
+    if should_include_verbose_arg(function, route_category):
         args.append(
             {
                 "name": "verbose",
@@ -388,7 +396,7 @@ def prepare_routes(routes):
         prepared_routes[route] = {
             "function": route_function,
             "description": get_function_description(route_function),
-            "args": prepare_route_args(route_function),
+            "args": prepare_route_args(route_function, route_category),
             "category": route_category,
         }
     return prepared_routes

--- a/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 import pytest
 from counterpartycore.lib import config, ledger
 from counterpartycore.lib.api import apiserver, apiwatcher, composer
-from counterpartycore.lib.api.routes import ALL_ROUTES
+from counterpartycore.lib.api.routes import ALL_ROUTES, ROUTES
 from counterpartycore.lib.messages import dispense, dividend, sweep
 from counterpartycore.lib.parser import blocks
 from counterpartycore.lib.utils import helpers
@@ -27,6 +27,33 @@ def test_apiserver_root(apiv2_client, current_block_index):
             "current_commit": helpers.get_current_commit_hash(),
         }
     }
+
+
+def get_route_args(route, name):
+    return [arg for arg in ROUTES[route]["args"] if arg["name"] == name]
+
+
+def test_routes_only_document_available_verbose_args():
+    assert get_route_args("/v2/transactions", "verbose")
+    assert get_route_args("/v2/orders", "verbose")
+
+    assert not get_route_args("/v2/routes", "verbose")
+    assert not get_route_args("/v2/healthz", "verbose")
+    assert not get_route_args("/healthz", "verbose")
+    assert not get_route_args("/v2/bitcoin/getmempoolinfo", "verbose")
+    assert not get_route_args("/v2/addresses/<address>/compose/dividend/estimatexcpfees", "verbose")
+
+    compose_verbose_args = get_route_args("/v2/addresses/<address>/compose/send", "verbose")
+    assert len(compose_verbose_args) == 1
+    assert compose_verbose_args[0]["category"] == "secondary"
+
+
+def test_routes_only_document_available_show_unconfirmed_args():
+    assert get_route_args("/v2/transactions", "show_unconfirmed")
+    assert get_route_args("/v2/blocks/<int:block_index>/transactions", "show_unconfirmed")
+
+    assert not get_route_args("/v2/transactions/counts", "show_unconfirmed")
+    assert not get_route_args("/v2/routes", "show_unconfirmed")
 
 
 def prepare_url(db, current_block_index, defaults, rawtransaction, route):


### PR DESCRIPTION
Fixes #2234.

This updates the v2 route metadata so `verbose` is only documented where it is available/useful:

- keep the query-result `verbose` parameter on normal API query routes
- keep the compose `verbose` construct parameter on compose routes without adding a duplicate tertiary parameter
- omit global `verbose` from routes, health checks, bitcoin backend routes, and compose-only fee estimate routes
- add route metadata tests for available/unavailable `verbose` and `show_unconfirmed` parameters

Tests:
- `.venv/bin/pytest counterpartycore/test/units/api/apiserver_test.py::test_routes_only_document_available_verbose_args counterpartycore/test/units/api/apiserver_test.py::test_routes_only_document_available_show_unconfirmed_args counterpartycore/test/units/api/apiserver_test.py::test_apiserver_root -q`
- `.venv/bin/ruff check counterpartycore/lib/api/routes.py counterpartycore/test/units/api/apiserver_test.py`
- `.venv/bin/ruff format --check counterpartycore/lib/api/routes.py counterpartycore/test/units/api/apiserver_test.py`
- `git diff --check`

Bounty payout address, if eligible: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`