### PR TITLE
Add Cache-Control headers for API responses

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/apiserver.py
+++ b/counterparty-core/counterpartycore/lib/api/apiserver.py
@@ -132,6 +132,17 @@ def set_cors_headers(response):
         response.headers["Access-Control-Allow-Methods"] = "*"
 
 
+def set_cache_control_headers(response, http_code, result):
+    if http_code == 200 and result is not None:
+        url_rule = getattr(request, "url_rule", None)
+        rule = str(url_rule.rule) if url_rule else request.path
+        route = ROUTES.get(rule)
+        if is_cachable(rule, route=route, result=result):
+            response.headers["Cache-Control"] = "public, max-age=60"
+            return
+    response.headers["Cache-Control"] = "no-store"
+
+
 def return_result(
     http_code,
     result=None,
@@ -157,6 +168,7 @@ def return_result(
     response.headers["X-BITCOIN-HEIGHT"] = CurrentState().current_backend_height()
     response.headers["X-LEDGER-STATE"] = CurrentState().ledger_state()
     response.headers["Content-Type"] = "application/json"
+    set_cache_control_headers(response, http_code, result)
     set_cors_headers(response)
 
     if http_code != 404:

--- a/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
@@ -395,6 +395,26 @@ def test_ledger_state(apiv2_client, current_block_index, ledger_db):
     }
 
 
+def test_api_cache_control_headers(apiv2_client, monkeypatch):
+    monkeypatch.setattr(config, "DISABLE_API_CACHE", False)
+
+    response = apiv2_client.get("/v2/blocks")
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "public, max-age=60"
+
+    response = apiv2_client.get("/v2/transactions?show_unconfirmed=true&limit=1")
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "no-store"
+
+    response = apiv2_client.get("/v2/healthz")
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "no-store"
+
+    response = apiv2_client.get("/v2/transactions?limit=0")
+    assert response.status_code == 400
+    assert response.headers["Cache-Control"] == "no-store"
+
+
 def test_get_transactions(apiv2_client, monkeypatch):
     url = "/v2/transactions?limit=1&verbose=true"
     result = apiv2_client.get(url).json["result"]


### PR DESCRIPTION
Fixes #2651.

This adds explicit `Cache-Control` headers to v2 API responses using the existing `is_cachable()` rules:

- cacheable successful GET responses now return `Cache-Control: public, max-age=60`
- dynamic, mempool, health, unconfirmed, error, and disabled-cache responses return `Cache-Control: no-store`
- the policy stays aligned with the existing internal API cache exclusions

Tests:
- `.venv/bin/pytest counterpartycore/test/units/api/apiserver_test.py::test_api_cache_control_headers counterpartycore/test/units/api/apiserver_test.py::test_is_cachable -q`
- `.venv/bin/ruff check counterpartycore/lib/api/apiserver.py counterpartycore/test/units/api/apiserver_test.py`
- `.venv/bin/ruff format --check counterpartycore/lib/api/apiserver.py counterpartycore/test/units/api/apiserver_test.py`
- `git diff --check`

Bounty payout address, if eligible: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`