### PR TITLE
Format Gunicorn IPv6 API bind addresses

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/wsgi.py
+++ b/counterparty-core/counterpartycore/lib/api/wsgi.py
@@ -26,6 +26,12 @@ multiprocessing.set_start_method("spawn", force=True)
 logger = logging.getLogger(config.LOGGER_NAME)
 
 
+def format_bind_address(host, port):
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]:{port}"
+    return f"{host}:{port}"
+
+
 class LazyLogger(metaclass=helpers.SingletonMeta):
     def __init__(self):
         self.last_message = None
@@ -215,7 +221,7 @@ class GunicornArbiter(Arbiter):
 class GunicornApplication(gunicorn.app.base.BaseApplication):  # pylint: disable=abstract-method
     def __init__(self, app, args=None):
         self.options = {
-            "bind": f"{config.API_HOST}:{config.API_PORT}",
+            "bind": format_bind_address(config.API_HOST, config.API_PORT),
             "timeout": 10,
             "graceful_timeout": 10,
             "max_requests": 1000,

--- a/counterparty-core/counterpartycore/test/units/api/wsgi_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/wsgi_test.py
@@ -6,6 +6,13 @@ from unittest.mock import MagicMock
 from counterpartycore.lib.api import wsgi
 
 
+def test_format_bind_address():
+    assert wsgi.format_bind_address("127.0.0.1", 4000) == "127.0.0.1:4000"
+    assert wsgi.format_bind_address("localhost", 4000) == "localhost:4000"
+    assert wsgi.format_bind_address("::1", 4000) == "[::1]:4000"
+    assert wsgi.format_bind_address("::", 4000) == "[::]:4000"
+
+
 def test_lazy_logger(caplog, test_helpers):
     lazy_logger = wsgi.LazyLogger()
     assert lazy_logger.last_message is None
@@ -243,3 +250,12 @@ def test_gunicorn_application_run_and_stop(monkeypatch):
     app.stop()
     assert app.arbiter.killed is True
     assert server_ready_value.value == 2
+
+
+def test_gunicorn_application_uses_ipv6_bind(monkeypatch):
+    monkeypatch.setattr(wsgi.config, "API_HOST", "::1")
+    monkeypatch.setattr(wsgi.config, "API_PORT", 4000)
+
+    app = wsgi.GunicornApplication(lambda *_args, **_kwargs: None)
+
+    assert app.options["bind"] == "[::1]:4000"


### PR DESCRIPTION
Fixes #3084.

This fixes the Gunicorn API bind string for IPv6 hosts. IPv4 and hostnames still use `host:port`, while IPv6 hosts now use the bracketed form Gunicorn expects, such as `[::1]:4000` or `[::]:4000`.

Tests:
- `.venv/bin/pytest counterpartycore/test/units/api/wsgi_test.py::test_format_bind_address counterpartycore/test/units/api/wsgi_test.py::test_gunicorn_application_uses_ipv6_bind counterpartycore/test/units/api/wsgi_test.py::test_gunicorn_application_run_and_stop -q`
- `.venv/bin/ruff check counterpartycore/lib/api/wsgi.py counterpartycore/test/units/api/wsgi_test.py`
- `.venv/bin/ruff format --check counterpartycore/lib/api/wsgi.py counterpartycore/test/units/api/wsgi_test.py`
- `git diff --check`

Bounty payout address, if eligible: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`