### PR TITLE
Validate BTCPay order match IDs

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/btcpay.py
+++ b/counterparty-core/counterpartycore/lib/messages/btcpay.py
@@ -18,6 +18,24 @@ LENGTH = 32 + 32
 ID = 11
 
 
+def unpack_order_match_id(order_match_id):
+    if not isinstance(order_match_id, str):
+        raise exceptions.ComposeError("invalid order_match_id")
+    if len(order_match_id) != 129 or order_match_id[64] != "_":
+        raise exceptions.ComposeError("invalid order_match_id")
+
+    tx0_hash, tx1_hash = order_match_id[:64], order_match_id[65:]
+    try:
+        tx0_hash_bytes, tx1_hash_bytes = (
+            binascii.unhexlify(bytes(tx0_hash, "utf-8")),
+            binascii.unhexlify(bytes(tx1_hash, "utf-8")),
+        )
+    except binascii.Error as e:
+        raise exceptions.ComposeError("invalid order_match_id") from e
+
+    return tx0_hash_bytes, tx1_hash_bytes
+
+
 def validate(db, source, order_match_id, block_index):  # pylint: disable=unused-argument
     problems = []
     order_match = None
@@ -66,15 +84,13 @@ def validate(db, source, order_match_id, block_index):  # pylint: disable=unused
 
 
 def compose(db, source: str, order_match_id: str, skip_validation: bool = False):
-    assert order_match_id[64] == "_"
-    tx0_hash, tx1_hash = (
-        order_match_id[:64],
-        order_match_id[65:],
-    )  # UTF-8 encoding means that the indices are doubled.
+    tx0_hash_bytes, tx1_hash_bytes = unpack_order_match_id(order_match_id)
 
     destination, btc_quantity, _escrowed_asset, _escrowed_quantity, order_match, problems = (
         validate(db, source, order_match_id, CurrentState().current_block_index())
     )
+    if problems and order_match is None:
+        raise exceptions.ComposeError(problems)
     if problems and not skip_validation:
         raise exceptions.ComposeError(problems)
 
@@ -88,10 +104,6 @@ def compose(db, source: str, order_match_id: str, skip_validation: bool = False)
     if 10 - time_left < 4:
         logger.warning("Order match has only %s confirmation(s).", 10 - time_left)
 
-    tx0_hash_bytes, tx1_hash_bytes = (
-        binascii.unhexlify(bytes(tx0_hash, "utf-8")),
-        binascii.unhexlify(bytes(tx1_hash, "utf-8")),
-    )
     data = messagetype.pack(ID)
     data += struct.pack(FORMAT, tx0_hash_bytes, tx1_hash_bytes)
     return (source, [(destination, btc_quantity)], data)

--- a/counterparty-core/counterpartycore/test/units/messages/btcpay_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/btcpay_test.py
@@ -83,6 +83,32 @@ def test_validate_no_order_match(ledger_db):
     assert "no such order match" in problems[0]
 
 
+def test_compose_rejects_malformed_order_match_id(ledger_db, defaults):
+    """BTCPay compose must not leak index/assert/hexlify errors for bad IDs."""
+    invalid_order_match_ids = [
+        "abc_def",
+        "0" * 64 + "-" + "0" * 64,
+        "g" * 64 + "_" + "0" * 64,
+    ]
+    for order_match_id in invalid_order_match_ids:
+        with pytest.raises(exceptions.ComposeError, match="invalid order_match_id"):
+            btcpay.compose(
+                ledger_db, defaults["addresses"][0], order_match_id, skip_validation=True
+            )
+
+
+def test_compose_requires_existing_order_match(ledger_db, defaults):
+    """A missing order match is not skippable because compose needs its terms."""
+    fake_order_match_id = (
+        "0000000000000000000000000000000000000000000000000000000000000001_"
+        "0000000000000000000000000000000000000000000000000000000000000002"
+    )
+    with pytest.raises(exceptions.ComposeError, match="no such order match"):
+        btcpay.compose(
+            ledger_db, defaults["addresses"][0], fake_order_match_id, skip_validation=True
+        )
+
+
 def test_validate_expired_order_match(ledger_db, defaults, monkeypatch):
     """Test btcpay validate with an expired order match."""
     fake_order_match_id = "abc_def"


### PR DESCRIPTION
## Summary
- validate BTCPay `order_match_id` shape before indexing or hex decoding it
- return a compose-level error for malformed IDs instead of leaking `IndexError`, `AssertionError`, or `binascii` exceptions
- keep missing order matches non-skippable because BTCPay composition needs the match terms for destination and BTC amount

## Verification
- `.venv/bin/pytest counterpartycore/test/units/messages/btcpay_test.py -q`
- `.venv/bin/ruff check counterpartycore/lib/messages/btcpay.py counterpartycore/test/units/messages/btcpay_test.py`
- `.venv/bin/ruff format --check counterpartycore/lib/messages/btcpay.py counterpartycore/test/units/messages/btcpay_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`