### PR TITLE
Validate cancel offer hashes

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/cancel.py
+++ b/counterparty-core/counterpartycore/lib/messages/cancel.py
@@ -18,6 +18,15 @@ LENGTH = 32
 ID = 70
 
 
+def pack_offer_hash(offer_hash):
+    if not isinstance(offer_hash, str) or len(offer_hash) != 64:
+        raise exceptions.ComposeError("invalid offer_hash")
+    try:
+        return binascii.unhexlify(bytes(offer_hash, "utf-8"))
+    except binascii.Error as e:
+        raise exceptions.ComposeError("invalid offer_hash") from e
+
+
 def validate(db, source, offer_hash):
     problems = []
 
@@ -45,11 +54,12 @@ def validate(db, source, offer_hash):
 
 
 def compose(db, source: str, offer_hash: str, skip_validation: bool = False):
+    offer_hash_bytes = pack_offer_hash(offer_hash)
+
     _offer, _offer_type, problems = validate(db, source, offer_hash)
     if problems and not skip_validation:
         raise exceptions.ComposeError(problems)
 
-    offer_hash_bytes = binascii.unhexlify(bytes(offer_hash, "utf-8"))
     data = messagetype.pack(ID)
     data += struct.pack(FORMAT, offer_hash_bytes)
     return (source, [], data)

--- a/counterparty-core/counterpartycore/test/units/messages/cancel_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/cancel_test.py
@@ -22,7 +22,7 @@ def test_compose(ledger_db, defaults):
         b"F\xfd\xcd]\xdf\x084\xb1\xf6\xe7\xd7\xe4\xb9^\x92=\xd5\x1a:\xd4\xdaW\x95\xc0\xf5\xf2q\xa5\x1f\xc3\xab\xb4.",
     )
 
-    with pytest.raises(exceptions.ComposeError, match="no open offer with that hash"):
+    with pytest.raises(exceptions.ComposeError, match="invalid offer_hash"):
         cancel.compose(ledger_db, defaults["addresses"][1], "bet_hash")
 
     with pytest.raises(exceptions.ComposeError, match="incorrect source address"):
@@ -35,6 +35,13 @@ def test_compose(ledger_db, defaults):
 
     with pytest.raises(exceptions.ComposeError, match="offer not open"):
         cancel.compose(ledger_db, closed_bet["source"], closed_bet["tx_hash"])
+
+
+def test_compose_rejects_malformed_offer_hash(ledger_db, defaults):
+    invalid_offer_hashes = ["bet_hash", "g" * 64, 1]
+    for offer_hash in invalid_offer_hashes:
+        with pytest.raises(exceptions.ComposeError, match="invalid offer_hash"):
+            cancel.compose(ledger_db, defaults["addresses"][0], offer_hash, skip_validation=True)
 
 
 def test_unpack_invalid_length():


### PR DESCRIPTION
## Summary
- validate cancel `offer_hash` as a 64-character hex string before packing it
- return a compose-level `invalid offer_hash` error instead of leaking lower-level hex/type errors
- keep parser behavior unchanged

## Verification
- `.venv/bin/pytest counterpartycore/test/units/messages/cancel_test.py -q`
- `.venv/bin/ruff check counterpartycore/lib/messages/cancel.py counterpartycore/test/units/messages/cancel_test.py`
- `.venv/bin/ruff format --check counterpartycore/lib/messages/cancel.py counterpartycore/test/units/messages/cancel_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`