### PR TITLE
Fix dispense compose API response

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/compose.py
+++ b/counterparty-core/counterpartycore/lib/api/compose.py
@@ -375,7 +375,14 @@ def compose_dispense(
         "destination": dispenser,
         "quantity": quantity,
     }
-    return composer.compose_transaction(db, "dispense", params, construct_params)
+    result = composer.compose_transaction(db, "dispense", params, construct_params)
+    if "params" in result:
+        result["params"]["address"] = result["params"].pop("source")
+        result["params"]["dispenser"] = result["params"].pop("destination")
+        result["params"]["quantity_normalized"] = (
+            f"{D(result['params']['quantity']) / D(config.UNIT):.8f}"
+        )
+    return result
 
 
 def compose_sweep(db, address: str, destination: str, flags: int, memo: str, **construct_params):

--- a/counterparty-core/counterpartycore/lib/api/routes.py
+++ b/counterparty-core/counterpartycore/lib/api/routes.py
@@ -54,6 +54,7 @@ ALL_ROUTES = {
     "/v2/transactions/counts": (queries.get_transaction_types_count, "transactions"),
     "/v2/transactions/info": (compose.info, "transactions"),
     "/v2/transactions/<tx_hash>/info": (compose.info_by_tx_hash, "transactions"),
+    "/v2/bitcoin/transactions/<tx_hash>/info": (compose.info_by_tx_hash, "bitcoin"),
     "/v2/transactions/unpack": (compose.unpack, "transactions"),
     "/v2/transactions/<int:tx_index>": (queries.get_transaction_by_tx_index, "transactions"),
     "/v2/transactions/<tx_hash>": (queries.get_transaction_by_hash, "transactions"),

--- a/counterparty-core/counterpartycore/test/units/api/compose_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/compose_test.py
@@ -198,6 +198,36 @@ def test_compose_dispense(apiv2_client, defaults, ledger_db):
         assert response.status_code in [200, 400]
 
 
+def test_compose_dispense_verbose_params_use_api_names(monkeypatch, ledger_db, defaults):
+    """Test compose_dispense verbose params use public API field names."""
+
+    def mock_compose_transaction(db, name, params, construct_params):
+        assert db == ledger_db
+        assert name == "dispense"
+        assert construct_params == {"verbose": True}
+        return {
+            "rawtransaction": "00",
+            "params": params | {"skip_validation": False},
+            "name": "dispense",
+        }
+
+    monkeypatch.setattr(compose.composer, "compose_transaction", mock_compose_transaction)
+
+    result = compose.compose_dispense(
+        ledger_db,
+        defaults["addresses"][0],
+        defaults["addresses"][5],
+        1000,
+        verbose=True,
+    )
+
+    assert result["params"]["address"] == defaults["addresses"][0]
+    assert result["params"]["dispenser"] == defaults["addresses"][5]
+    assert "source" not in result["params"]
+    assert "destination" not in result["params"]
+    assert result["params"]["quantity_normalized"] == "0.00001000"
+
+
 def test_compose_sweep(apiv2_client, defaults):
     """Test compose_sweep function via API."""
     address = defaults["addresses"][0]
@@ -1660,6 +1690,13 @@ def test_info_by_tx_hash_invalid(apiv2_client):
     result = apiv2_client.get(f"/v2/transactions/{invalid_tx_hash}/info")
     # Will fail with 400 due to invalid format
     assert result.status_code in [400, 404]
+
+
+def test_bitcoin_info_by_tx_hash_route_invalid(apiv2_client):
+    """Test bitcoin info_by_tx_hash route with invalid transaction hash."""
+    invalid_tx_hash = "invalid_hash"
+    result = apiv2_client.get(f"/v2/bitcoin/transactions/{invalid_tx_hash}/info")
+    assert result.status_code == 400
 
 
 def test_info_invalid_rawtransaction(apiv2_client):


### PR DESCRIPTION
Fixes part/all of #2355.

Changes:
- Return public API parameter names in `compose/dispense` verbose params: `address` and `dispenser` instead of internal `source` and `destination`.
- Add `quantity_normalized` for the BTC dispense quantity in verbose params.
- Add `/v2/bitcoin/transactions/<tx_hash>/info` as a compatibility-safe route to `info_by_tx_hash`, while keeping the existing route intact.

Tests:
- `.venv/bin/pytest counterpartycore/test/units/api/compose_test.py counterpartycore/test/units/api/apiserver_test.py -q`
- `.venv/bin/ruff check counterpartycore/lib/api/compose.py counterpartycore/lib/api/routes.py counterpartycore/test/units/api/compose_test.py`
- `.venv/bin/ruff format --check counterpartycore/lib/api/compose.py counterpartycore/lib/api/routes.py counterpartycore/test/units/api/compose_test.py`
- `git diff --check`

Bounty payout address, if eligible: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`