### PR TITLE
Make AMM LP tokens redeem-only

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/destroy.py
+++ b/counterparty-core/counterpartycore/lib/messages/destroy.py
@@ -4,7 +4,7 @@ import logging
 import struct
 
 from counterpartycore.lib import config, exceptions, ledger
-from counterpartycore.lib.parser import messagetype
+from counterpartycore.lib.parser import messagetype, protocol
 from counterpartycore.lib.utils import address
 
 logger = logging.getLogger(config.LOGGER_NAME)
@@ -50,7 +50,7 @@ def unpack(db, message, return_dict=False):
     return asset, quantity, tag
 
 
-def validate(db, source, destination, asset, quantity):
+def validate(db, source, destination, asset, quantity, block_index=None):
     try:
         ledger.issuances.get_asset_id(db, asset)
     except exceptions.AssetError as e:
@@ -66,6 +66,16 @@ def validate(db, source, destination, asset, quantity):
 
     if asset == config.BTC:
         raise exceptions.ValidateError(f"cannot destroy {config.BTC}")
+
+    # LP tokens are redeem-only: liquidity must be withdrawn through poolwithdraw,
+    # which returns the underlying reserves. Destroying LP tokens directly would
+    # burn the claim while leaving the reserves in the pool.
+    if protocol.enabled("forbid_lp_token_destroy", block_index) and (
+        ledger.markets.get_pool_by_lp_asset(db, asset) is not None
+    ):
+        raise exceptions.ValidateError(
+            f"cannot destroy LP token {asset}; use poolwithdraw to redeem liquidity"
+        )
 
     if not isinstance(quantity, int):
         raise exceptions.ValidateError("quantity not integer")
@@ -98,7 +108,7 @@ def parse(db, tx, message):
 
     try:
         asset, quantity, tag = unpack(db, message)
-        validate(db, tx["source"], tx["destination"], asset, quantity)
+        validate(db, tx["source"], tx["destination"], asset, quantity, tx["block_index"])
         ledger.events.debit(
             db, tx["source"], asset, quantity, tx["tx_index"], "destroy", tx["tx_hash"]
         )

--- a/counterparty-core/counterpartycore/lib/messages/pooldeposit.py
+++ b/counterparty-core/counterpartycore/lib/messages/pooldeposit.py
@@ -6,7 +6,7 @@ import struct
 from counterpartycore.lib import config, exceptions, ledger
 from counterpartycore.lib.ledger.currentstate import CurrentState
 from counterpartycore.lib.messages import gas
-from counterpartycore.lib.parser import messagetype
+from counterpartycore.lib.parser import messagetype, protocol
 from counterpartycore.lib.utils import assetnames
 
 logger = logging.getLogger(config.LOGGER_NAME)
@@ -96,7 +96,18 @@ def validate(
             # Abnormal: LP tokens exist but a reserve is zero — reject to prevent div-by-zero
             problems.append("pool has no liquidity")
             return problems
-        # total_lp_supply == 0 means pool fully drained; treat as restart below
+        # total_lp_supply == 0 means pool fully drained; treat as restart below.
+        # A restart is only well-defined when the pool is genuinely empty: a fully
+        # withdrawn pool returns its reserves to zero. If reserves remain while the
+        # LP supply is zero, the pool is in an inconsistent state and minting LP
+        # from the new deposit alone would hand the depositor the residual reserves.
+        if (
+            protocol.enabled("forbid_lp_token_destroy", block_index)
+            and total_lp_supply == 0
+            and (existing_pool["reserve_a"] > 0 or existing_pool["reserve_b"] > 0)
+        ):
+            problems.append("pool has stranded reserves; cannot restart")
+            return problems
 
     if total_lp_supply == 0:
         actual_a_sorted = sorted_quantity_a

--- a/counterparty-core/counterpartycore/protocol_changes.json
+++ b/counterparty-core/counterpartycore/protocol_changes.json
@@ -1410,5 +1410,14 @@
         "testnet3_block_index": 4961300,
         "testnet4_block_index": 136300,
         "signet_block_index": 310300
+    },
+    "forbid_lp_token_destroy": {
+        "minimum_version_major": 11,
+        "minimum_version_minor": 2,
+        "minimum_version_revision": 0,
+        "block_index": 99999999,
+        "testnet3_block_index": 99999999,
+        "testnet4_block_index": 99999999,
+        "signet_block_index": 99999999
     }
 }

--- a/counterparty-core/counterpartycore/test/units/messages/destroy_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/destroy_test.py
@@ -1,6 +1,6 @@
 import pytest
-from counterpartycore.lib import exceptions
-from counterpartycore.lib.messages import destroy
+from counterpartycore.lib import exceptions, ledger
+from counterpartycore.lib.messages import destroy, pooldeposit
 
 
 def test_validate(ledger_db, defaults):
@@ -28,6 +28,22 @@ def test_validate(ledger_db, defaults):
 
     with pytest.raises(exceptions.BalanceError, match="balance insufficient"):
         destroy.validate(ledger_db, defaults["addresses"][0], None, "XCP", 2**62)
+
+
+def test_validate_lp_token_forbidden(ledger_db, defaults, blockchain_mock):
+    """An AMM LP token cannot be destroyed; it must be redeemed via poolwithdraw."""
+    quantity = defaults["quantity"] // 4
+    source = defaults["addresses"][0]
+
+    tx = blockchain_mock.dummy_tx(ledger_db, source)
+    _, _, data = pooldeposit.compose(ledger_db, source, "XCP", "DIVISIBLE", quantity, quantity)
+    pooldeposit.parse(ledger_db, tx, data[1:])
+
+    pool = ledger.markets.get_pool(ledger_db, "DIVISIBLE", "XCP")
+    lp_asset = pool["lp_asset"]
+
+    with pytest.raises(exceptions.ValidateError, match="cannot destroy LP token"):
+        destroy.validate(ledger_db, source, None, lp_asset, 1)
 
 
 def test_pack(ledger_db):

--- a/counterparty-core/counterpartycore/test/units/messages/pooldeposit_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/pooldeposit_test.py
@@ -3,6 +3,7 @@ import struct
 import pytest
 from counterpartycore.lib import config, exceptions, ledger
 from counterpartycore.lib.messages import destroy, gas, pooldeposit, poolwithdraw
+from counterpartycore.lib.parser import protocol
 
 
 def test_validate_valid(ledger_db, defaults):
@@ -510,8 +511,8 @@ def test_empty_pool_refund_respects_min_lp_quantity(ledger_db, defaults, blockch
         )
 
 
-def test_restart_after_external_lp_destroy(ledger_db, defaults, blockchain_mock):
-    """Pool is recoverable when every LP holder destroys their LP externally."""
+def test_restart_after_full_withdraw(ledger_db, defaults, blockchain_mock):
+    """A pool fully drained via poolwithdraw (reserves back to zero) can be restarted."""
     quantity = defaults["quantity"] // 4
     source = defaults["addresses"][0]
 
@@ -523,24 +524,63 @@ def test_restart_after_external_lp_destroy(ledger_db, defaults, blockchain_mock)
     lp_asset = pool["lp_asset"]
     lp_balance = ledger.balances.get_balance(ledger_db, source, lp_asset)
 
+    # Withdraw 100% of the LP supply: reserves return to zero.
     tx = blockchain_mock.dummy_tx(ledger_db, source)
-    _, _, ddata = destroy.compose(ledger_db, source, lp_asset, lp_balance, b"brick")
-    destroy.parse(ledger_db, tx, ddata[1:])
+    _, _, wdata = poolwithdraw.compose(
+        ledger_db, source, pool["asset_a"], pool["asset_b"], lp_balance
+    )
+    poolwithdraw.parse(ledger_db, tx, wdata[1:])
 
     assert ledger.supplies.asset_supply(ledger_db, lp_asset) == 0
     pool = ledger.markets.get_pool(ledger_db, "DIVISIBLE", "XCP")
-    stranded_a, stranded_b = pool["reserve_a"], pool["reserve_b"]
-    assert stranded_a > 0 and stranded_b > 0
+    assert pool["reserve_a"] == 0 and pool["reserve_b"] == 0
 
+    # Redepositing restarts the empty pool, reusing the existing LP asset.
     tx = blockchain_mock.dummy_tx(ledger_db, source)
     _, _, rdata = pooldeposit.compose(ledger_db, source, "XCP", "DIVISIBLE", quantity, quantity)
     pooldeposit.parse(ledger_db, tx, rdata[1:])
 
     pool = ledger.markets.get_pool(ledger_db, "DIVISIBLE", "XCP")
-    assert pool["reserve_a"] == stranded_a + quantity
-    assert pool["reserve_b"] == stranded_b + quantity
+    assert pool["reserve_a"] == quantity
+    assert pool["reserve_b"] == quantity
     assert ledger.supplies.asset_supply(ledger_db, lp_asset) > 0
     assert ledger.balances.get_balance(ledger_db, source, lp_asset) > 0
+
+
+def test_pooldeposit_rejects_stranded_reserves(ledger_db, defaults, blockchain_mock, monkeypatch):
+    """A pool with reserves but zero LP supply is inconsistent and cannot be restarted."""
+    quantity = defaults["quantity"] // 4
+    source = defaults["addresses"][0]
+
+    tx = blockchain_mock.dummy_tx(ledger_db, source)
+    _, _, data = pooldeposit.compose(ledger_db, source, "XCP", "DIVISIBLE", quantity, quantity)
+    pooldeposit.parse(ledger_db, tx, data[1:])
+
+    pool = ledger.markets.get_pool(ledger_db, "DIVISIBLE", "XCP")
+    lp_asset = pool["lp_asset"]
+    lp_balance = ledger.balances.get_balance(ledger_db, source, lp_asset)
+
+    # Force the stranded state by destroying the whole LP supply with the guard
+    # disabled (this is what an unpatched node would have allowed).
+    real_enabled = protocol.enabled
+    monkeypatch.setattr(
+        "counterpartycore.lib.parser.protocol.enabled",
+        lambda name, block_index=None: (
+            False if name == "forbid_lp_token_destroy" else real_enabled(name, block_index)
+        ),
+    )
+    tx = blockchain_mock.dummy_tx(ledger_db, source)
+    ddata = destroy.pack(ledger_db, lp_asset, lp_balance, b"brick")
+    destroy.parse(ledger_db, tx, ddata[1:])
+    monkeypatch.undo()
+
+    pool = ledger.markets.get_pool(ledger_db, "DIVISIBLE", "XCP")
+    assert ledger.supplies.asset_supply(ledger_db, lp_asset) == 0
+    assert pool["reserve_a"] > 0 and pool["reserve_b"] > 0
+
+    # With the guard active again, the stranded pool cannot be restarted.
+    problems = pooldeposit.validate(ledger_db, source, "XCP", "DIVISIBLE", quantity, quantity)
+    assert any("stranded reserves" in p for p in problems)
 
 
 def test_validate_lp_token_cannot_be_pooled(ledger_db, defaults, blockchain_mock):

--- a/counterparty-core/counterpartycore/test/units/messages/poolwithdraw_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/poolwithdraw_test.py
@@ -353,8 +353,8 @@ def test_parse_partial_withdrawal(ledger_db, defaults, blockchain_mock, test_hel
     assert pool_after["reserve_b"] > 0
 
 
-def test_lp_destroy_benefits_remaining_holders(ledger_db, defaults, blockchain_mock, test_helpers):
-    """Destroying LP tokens locks reserves — remaining holders get more on withdrawal."""
+def test_lp_destroy_forbidden(ledger_db, defaults, blockchain_mock):
+    """LP tokens are redeem-only: destroying them is rejected, so reserves can't be stranded."""
     # Create pool with addr0
     create_pool(
         ledger_db,
@@ -367,41 +367,21 @@ def test_lp_destroy_benefits_remaining_holders(ledger_db, defaults, blockchain_m
     lp_asset = pool["lp_asset"]
     total_lp = ledger.balances.get_balance(ledger_db, defaults["addresses"][0], lp_asset)
 
-    # Destroy half the LP tokens
-    half = total_lp // 2
+    # Composing a destroy of LP tokens is rejected.
+    with pytest.raises(exceptions.ValidateError, match="cannot destroy LP token"):
+        destroy.compose(
+            ledger_db, defaults["addresses"][0], lp_asset, total_lp // 2, b"lock liquidity"
+        )
+
+    # Parsing one is recorded invalid: supply, balance and reserves stay untouched.
     tx = blockchain_mock.dummy_tx(ledger_db, defaults["addresses"][0])
-    _, _, data = destroy.compose(
-        ledger_db, defaults["addresses"][0], lp_asset, half, b"lock liquidity"
-    )
+    data = destroy.pack(ledger_db, lp_asset, total_lp // 2, b"lock liquidity")
     destroy.parse(ledger_db, tx, data[1:])
 
-    # Remaining LP balance
-    remaining_lp = ledger.balances.get_balance(ledger_db, defaults["addresses"][0], lp_asset)
-    assert remaining_lp == total_lp - half
-
-    # Withdraw remaining — should get proportional share
-    xcp_before = ledger.balances.get_balance(ledger_db, defaults["addresses"][0], "XCP")
-    tx = blockchain_mock.dummy_tx(ledger_db, defaults["addresses"][0])
-    _, _, wdata = poolwithdraw.compose(
-        ledger_db,
-        defaults["addresses"][0],
-        "XCP",
-        "DIVISIBLE",
-        remaining_lp,
-        skip_validation=True,
-    )
-    poolwithdraw.parse(ledger_db, tx, wdata[1:])
-    xcp_after = ledger.balances.get_balance(ledger_db, defaults["addresses"][0], "XCP")
-
-    # Remaining LP holder gets ALL reserves (destroying LP reduces supply,
-    # making remaining tokens claim 100% of pool)
+    assert ledger.balances.get_balance(ledger_db, defaults["addresses"][0], lp_asset) == total_lp
     pool_after = ledger.markets.get_pool(ledger_db, "DIVISIBLE", "XCP")
-    assert pool_after["reserve_a"] == 0, "All reserves withdrawn by remaining holder"
-    assert pool_after["reserve_b"] == 0, "All reserves withdrawn by remaining holder"
-
-    # LP holder got back MORE per token than they would have without the destroy
-    xcp_got = xcp_after - xcp_before
-    assert xcp_got > 0, "Holder received reserves"
+    assert pool_after["reserve_a"] == pool["reserve_a"]
+    assert pool_after["reserve_b"] == pool["reserve_b"]
 
 
 def test_parse_no_pool(ledger_db, defaults, blockchain_mock, test_helpers):

--- a/release-notes/release-notes-v11.2.0.md
+++ b/release-notes/release-notes-v11.2.0.md
@@ -1,0 +1,44 @@
+# Release Notes - Counterparty Core v11.2.0 (2026-??-??)
+
+# Upgrading
+
+**Upgrade Instructions:**
+
+To upgrade, download the latest version of `counterparty-core` and restart `counterparty-server`.
+
+With Docker Compose:
+
+```bash
+cd counterparty-core
+git pull
+docker compose stop counterparty-core
+docker compose --profile mainnet up -d
+```
+
+or use `ctrl-c` to interrupt the server:
+
+```bash
+cd counterparty-core
+git pull
+cd counterparty-rs
+pip install -e .
+cd ../counterparty-core
+pip install -e .
+counterparty-server start
+```
+
+# ChangeLog
+
+## Protocol Changes
+
+- `forbid_lp_token_destroy`: AMM LP tokens are redeem-only. Destroying an LP token is rejected (liquidity must be withdrawn via `poolwithdraw`, which returns the underlying reserves), and a pool that somehow holds reserves with zero LP supply can no longer be restarted by a new deposit.
+
+## Bugfixes
+
+## API
+
+## Codebase
+
+# Credits
+
+- Adam Krellenstein


### PR DESCRIPTION
## Summary

Tightens AMM input validation so that LP tokens behave consistently as redeem-only claims, gated behind a new `forbid_lp_token_destroy` protocol change. Targeted for **v11.2.0** (minor bump, as it introduces a protocol change).

- **`destroy` rejects AMM LP tokens.** Liquidity is meant to be redeemed via `poolwithdraw`, which returns the underlying reserves to the holder. Allowing an LP token to be `destroy`ed burns the claim while leaving its reserves in the pool, which is inconsistent with how `pooldeposit` already treats LP tokens (it rejects them as pool assets). This adds the symmetric guard to `destroy.validate`.
- **`pooldeposit` rejects restarting an inconsistent pool.** The pool-restart branch (taken when LP supply is zero) is only well-defined for a genuinely empty pool — a full `poolwithdraw` returns reserves to zero. If a pool ever holds reserves while its LP supply is zero, a new deposit is now rejected instead of minting LP from the deposit alone and absorbing the residual reserves.

## Gating

Both checks are gated behind the new `forbid_lp_token_destroy` key in `protocol_changes.json` (`minimum_version` 11.2.0). `destroy` is a long-active consensus message, so the new behavior must only take effect at a future block to preserve replay consensus. The activation block is a placeholder (`99999999`) to be finalized for the release.

## Implementation notes

- `block_index` is threaded into `destroy.validate` so the gate can be evaluated at the transaction's block; `compose` falls back to the current block via `CurrentState`.
- Reuses the existing `ledger.markets.get_pool_by_lp_asset` helper (already used by `pooldeposit.validate`).
- The internal LP burn performed by `poolwithdraw` is a separate code path and is unaffected.

## Tests

- `destroy_test.py`: LP tokens cannot be destroyed.
- `pooldeposit_test.py`: a pool fully drained via `poolwithdraw` still restarts correctly; a pool left with stranded reserves cannot be restarted.
- `poolwithdraw_test.py`: updated the prior LP-destroy test to assert destruction is now rejected and reserves/supply are untouched.

All affected unit tests pass; `ruff check` clean.