### PR TITLE
Support custom_inputs compose alias

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/composer.py
+++ b/counterparty-core/counterpartycore/lib/api/composer.py
@@ -1211,6 +1211,7 @@ CONSTRUCT_PARAMS = {
         None,
         "A comma-separated list of UTXOs (`<txid>:<vout>`) to use as inputs for the transaction being created. To speed up the composition you can also use the following format for utxos: `<txid>:<vout>:<value>:<script_pub_key>`.",
     ),
+    "custom_inputs": (str, None, "Deprecated, use `inputs_set` instead"),
     "allow_unconfirmed_inputs": (
         bool,
         False,
@@ -1284,6 +1285,7 @@ DEPRECATED_CONSTRUCT_PARAMS = [
     "p2sh_pretx_txid",
     "segwit",
     "unspent_tx_hash",
+    "custom_inputs",
 ]
 
 
@@ -1301,6 +1303,7 @@ def prepare_construct_params(construct_params):
         ("fee_provided", "max_fee", lambda x: x),
         ("dust_return_pubkey", "multisig_pubkey", lambda x: x),
         ("return_psbt", "verbose", lambda x: x),
+        ("custom_inputs", "inputs_set", lambda x: x),
     ]:
         if deprecated_param in construct_params:
             if (

--- a/counterparty-core/counterpartycore/test/units/api/composer_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/composer_test.py
@@ -1616,6 +1616,7 @@ def test_prepare_construct_params(defaults):
         "p2sh_pretx_txid": "aabbb",
         "segwit": True,
         "unspent_tx_hash": "aabbcc",
+        "custom_inputs": "ccddee:0",
     }
 
     expected_params = {
@@ -1630,6 +1631,7 @@ def test_prepare_construct_params(defaults):
         "p2sh_pretx_txid": "aabbb",
         "segwit": True,
         "unspent_tx_hash": "aabbcc",
+        "inputs_set": "ccddee:0",
     }
 
     expected_warnings = [
@@ -1644,6 +1646,7 @@ def test_prepare_construct_params(defaults):
         "The `p2sh_pretx_txid` parameter is ignored, p2sh disabled",
         "The `segwit` parameter is ignored, segwit automatically detected",
         "The `unspent_tx_hash` parameter is deprecated, use `inputs_set` instead",
+        "The `custom_inputs` parameter is deprecated, use `inputs_set` instead",
     ]
 
     result_params, result_warnings = composer.prepare_construct_params(params)
@@ -1663,6 +1666,7 @@ def test_prepare_construct_params(defaults):
         "p2sh_pretx_txid": "aabbb",
         "segwit": True,
         "unspent_tx_hash": "aabbcc",
+        "custom_inputs": "ccddee:0",
     }
 
     expected_params = {
@@ -1677,11 +1681,22 @@ def test_prepare_construct_params(defaults):
         "p2sh_pretx_txid": "aabbb",
         "segwit": True,
         "unspent_tx_hash": "aabbcc",
+        "inputs_set": "ccddee:0",
     }
 
     result_params, result_warnings = composer.prepare_construct_params(params)
     assert result_params == expected_params
     assert result_warnings == expected_warnings
+
+    # Test case 3: Explicit inputs_set takes precedence over custom_inputs
+    result_params, result_warnings = composer.prepare_construct_params(
+        {"inputs_set": "aabbcc:0", "custom_inputs": "ccddee:0"}
+    )
+    assert result_params["inputs_set"] == "aabbcc:0"
+    assert "custom_inputs" not in result_params
+    assert result_warnings == [
+        "The `custom_inputs` parameter is deprecated, use `inputs_set` instead"
+    ]
 
 
 def test_compose_transaction(ledger_db, defaults, monkeypatch):
@@ -2396,6 +2411,20 @@ def test_compose_attach(ledger_db, defaults):
         },
     )
     assert result == expected
+
+    result = composer.compose_transaction(
+        ledger_db,
+        "attach",
+        params,
+        {
+            "verbose": True,
+            "custom_inputs": "ae241be7be83ebb14902757ad94854f787d9730fc553d6f695346c9375c0d8c1:0:1052:76a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788ac",
+            "disable_utxo_locks": True,
+        },
+    )
+    assert result == expected | {
+        "warnings": ["The `custom_inputs` parameter is deprecated, use `inputs_set` instead"]
+    }
 
     with pytest.raises(
         exceptions.ComposeError, match="Insufficient funds for the target amount: 546 < 1052"


### PR DESCRIPTION
Fixes #2186.

This adds `custom_inputs` as a deprecated compose parameter alias for `inputs_set`, matching the older API/docs wording while preserving the current `inputs_set` name as canonical. If both are provided, explicit `inputs_set` takes precedence.

Verification:
- `.venv/bin/pytest counterpartycore/test/units/api/composer_test.py::test_prepare_construct_params counterpartycore/test/units/api/composer_test.py::test_compose_attach -q`
- `.venv/bin/pytest counterpartycore/test/units/api/composer_test.py -q`
- `.venv/bin/pytest counterpartycore/test/units/api/compose_test.py::test_compose_mpma -q`
- `.venv/bin/ruff check counterpartycore/lib/api/composer.py counterpartycore/test/units/api/composer_test.py`
- `.venv/bin/ruff format --check counterpartycore/lib/api/composer.py counterpartycore/test/units/api/composer_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`