### PR TITLE
Support message-only compose alias

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/composer.py
+++ b/counterparty-core/counterpartycore/lib/api/composer.py
@@ -1257,6 +1257,7 @@ CONSTRUCT_PARAMS = {
         "Include additional information in the result including data and psbt",
     ),
     "return_only_data": (bool, False, "Return only the data part of the transaction"),
+    "message_only": (bool, False, "Alias for `return_only_data`"),
     "segwit_dust_size": (int, None, "The dust size for segwit outputs (default is 330)"),
     "inscription": (bool, False, "Use Ordinals inscription script when possible"),
     # deprecated parameters
@@ -1295,6 +1296,11 @@ def fee_per_kb_to_sat_per_vbyte(fee_per_kb):
 
 def prepare_construct_params(construct_params):
     cleaned_construct_params = construct_params.copy()
+    if "message_only" in construct_params:
+        if construct_params.get("message_only") and not construct_params.get("return_only_data"):
+            cleaned_construct_params["return_only_data"] = construct_params["message_only"]
+        cleaned_construct_params.pop("message_only")
+
     # copy deprecated parameters to new ones
     for deprecated_param, new_param, copyer in [
         ("fee_per_kb", "sat_per_vbyte", fee_per_kb_to_sat_per_vbyte),

--- a/counterparty-core/counterpartycore/test/units/api/composer_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/composer_test.py
@@ -1683,6 +1683,17 @@ def test_prepare_construct_params(defaults):
     assert result_params == expected_params
     assert result_warnings == expected_warnings
 
+    # Test case 3: message_only is a public alias for return_only_data
+    result_params, result_warnings = composer.prepare_construct_params({"message_only": True})
+    assert result_params == {"return_only_data": True}
+    assert result_warnings == []
+
+    result_params, result_warnings = composer.prepare_construct_params(
+        {"return_only_data": True, "message_only": False}
+    )
+    assert result_params == {"return_only_data": True}
+    assert result_warnings == []
+
 
 def test_compose_transaction(ledger_db, defaults, monkeypatch):
     # Test case 1: Order transaction
@@ -1721,6 +1732,16 @@ def test_compose_transaction(ledger_db, defaults, monkeypatch):
 
     result = composer.compose_transaction(ledger_db, "send", params, {})
     assert result == expected
+
+    message_only_result = composer.compose_transaction(
+        ledger_db, "send", params, {"message_only": True}
+    )
+    return_only_data_result = composer.compose_transaction(
+        ledger_db, "send", params, {"return_only_data": True}
+    )
+    assert message_only_result == return_only_data_result
+    assert message_only_result["data"].startswith(config.PREFIX)
+    assert "rawtransaction" not in message_only_result
 
     params = {
         "source": defaults["addresses"][0],


### PR DESCRIPTION
Fixes #2185.

This adds `message_only` as a public compose parameter alias for the existing `return_only_data` behavior. When set, compose calls return only the packed Counterparty message data instead of constructing a full Bitcoin transaction, matching the message-only/pack use case discussed in the issue while keeping the existing `return_only_data` parameter unchanged.

Verification:
- `.venv/bin/pytest counterpartycore/test/units/api/composer_test.py::test_prepare_construct_params counterpartycore/test/units/api/composer_test.py::test_compose_transaction -q`
- `.venv/bin/pytest counterpartycore/test/units/api/composer_test.py -q`
- `.venv/bin/ruff check counterpartycore/lib/api/composer.py counterpartycore/test/units/api/composer_test.py`
- `.venv/bin/ruff format --check counterpartycore/lib/api/composer.py counterpartycore/test/units/api/composer_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`