### PR TITLE
Document Counterparty transaction data format

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -82,6 +82,16 @@ All responses contain a `result_count` field allowing you to calculate the numbe
 
 Routes in the `/v2/bitcoin` group serve as a proxy to make requests to Bitcoin Core.
 
+## Counterparty Transaction Data
+
+Every Counterparty action is a Bitcoin transaction that carries an embedded Counterparty message. The embedded byte stream is identified by the 8-byte `CNTRPRTY` prefix. After the prefix is removed, the parser reads a message type identifier and passes the remaining bytes to the decoder for that message type.
+
+Message type identifiers are normally encoded as 4-byte big-endian integers. When the `short_tx_type_id` protocol change is active, nonzero message type identifiers below 256 may instead be encoded in one byte. The remaining payload is message-specific; for example, a send, issuance, order, or dispenser message each has its own unpacking logic.
+
+Counterparty data can be carried in Bitcoin outputs in different ways. The preferred compact form is `OP_RETURN` when the prefixed payload fits the configured size limit. Legacy or larger encodings may use multisig or P2SH-related data chunks, where the encoded chunks are recovered by the parser before the same `CNTRPRTY` prefix and message type rules are applied.
+
+For application code, prefer the compose and decode helpers rather than parsing scripts manually. Compose routes accept an `encoding` parameter and return the extracted `data` field; `/v2/transactions/unpack` decodes extracted Counterparty data into a `message_type`, `message_type_id`, and message-specific `message_data`. Transaction routes with `verbose=true` can also include `unpacked_data`.
+
 ## Events API
 
 One of the new features of API v2 is the ability to make requests by events. This is the most powerful way to recover the vast majority of data.

--- a/counterparty-core/counterpartycore/test/integrations/regtest/apidoc/blueprint-template.md
+++ b/counterparty-core/counterpartycore/test/integrations/regtest/apidoc/blueprint-template.md
@@ -53,6 +53,16 @@ All responses contain a `result_count` field allowing you to calculate the numbe
 
 Routes in the `/v2/bitcoin` group serve as a proxy to make requests to Bitcoin Core.
 
+## Counterparty Transaction Data
+
+Every Counterparty action is a Bitcoin transaction that carries an embedded Counterparty message. The embedded byte stream is identified by the 8-byte `CNTRPRTY` prefix. After the prefix is removed, the parser reads a message type identifier and passes the remaining bytes to the decoder for that message type.
+
+Message type identifiers are normally encoded as 4-byte big-endian integers. When the `short_tx_type_id` protocol change is active, nonzero message type identifiers below 256 may instead be encoded in one byte. The remaining payload is message-specific; for example, a send, issuance, order, or dispenser message each has its own unpacking logic.
+
+Counterparty data can be carried in Bitcoin outputs in different ways. The preferred compact form is `OP_RETURN` when the prefixed payload fits the configured size limit. Legacy or larger encodings may use multisig or P2SH-related data chunks, where the encoded chunks are recovered by the parser before the same `CNTRPRTY` prefix and message type rules are applied.
+
+For application code, prefer the compose and decode helpers rather than parsing scripts manually. Compose routes accept an `encoding` parameter and return the extracted `data` field; `/v2/transactions/unpack` decodes extracted Counterparty data into a `message_type`, `message_type_id`, and message-specific `message_data`. Transaction routes with `verbose=true` can also include `unpacked_data`.
+
 ## Events API
 
 One of the new features of API v2 is the ability to make requests by events. This is the most powerful way to recover the vast majority of data.


### PR DESCRIPTION
## Summary
- add a high-level Counterparty transaction data format section to the API docs
- document the CNTRPRTY prefix, message type identifier formats, and message-specific payload handoff
- describe OP_RETURN and legacy/larger data carriers at a practical level
- point application code toward compose routes, extracted data, /v2/transactions/unpack, and verbose unpacked_data instead of manual script parsing

Related issue: https://github.com/CounterpartyXCP/counterparty-core/issues/1319

## Verification
- git diff --check

Bounty payment address (BTC): bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc