### PR TITLE
Keep latest holder rows by consolidation key

### DIFF
--- a/counterparty-core/counterpartycore/lib/ledger/supplies.py
+++ b/counterparty-core/counterpartycore/lib/ledger/supplies.py
@@ -9,7 +9,7 @@ def _get_holders(cursor, id_fields, hold_fields_1, exclude_empty_holders=False):
     save_records = {}
     for record in cursor:
         record_id = " ".join([str(record[field]) for field in id_fields])
-        if id not in save_records:
+        if record_id not in save_records:
             save_records[record_id] = record
             continue
         if save_records[record_id]["rowid"] < record["rowid"]:

--- a/counterparty-core/counterpartycore/test/units/ledger/supplies_test.py
+++ b/counterparty-core/counterpartycore/test/units/ledger/supplies_test.py
@@ -1,6 +1,19 @@
 from counterpartycore.lib.ledger import supplies
 
 
+def test_get_holders_keeps_highest_rowid_for_duplicate_id():
+    records = [
+        {"asset": "XCP", "address": "addr1", "quantity": 7, "rowid": 10},
+        {"asset": "XCP", "address": "addr1", "quantity": 2, "rowid": 1},
+    ]
+
+    assert supplies._get_holders(  # pylint: disable=protected-access
+        records,
+        ["asset", "address"],
+        {"address": "address", "address_quantity": "quantity"},
+    ) == [{"address": "addr1", "address_quantity": 7, "escrow": None}]
+
+
 def test_supplies_functions(ledger_db, defaults):
     assert supplies.xcp_created(ledger_db) == 604514652382
     assert supplies.xcp_destroyed(ledger_db) == 900000000


### PR DESCRIPTION
## Summary

This fixes holder consolidation in `ledger.supplies._get_holders()`.

The function builds `record_id` from the configured id fields, but the membership check accidentally used Python's built-in `id` instead of `record_id`. As a result, duplicate holder ids were overwritten by cursor order before the rowid comparison could run. If rows are not returned in rowid order, holder calculations can keep an older balance or escrow row instead of the latest row.

The fix uses the computed `record_id` key so duplicate holder records are compared by rowid as intended.

## Why it matters

`holders()` feeds dividend validation/distribution, holder counts, and supply/held consistency checks. Keeping stale holder rows can under- or over-count balances when query order differs from latest row order.

## Tests

- `.venv/bin/pytest counterpartycore/test/units/ledger/supplies_test.py::test_get_holders_keeps_highest_rowid_for_duplicate_id -q`
- `.venv/bin/pytest counterpartycore/test/units/ledger/supplies_test.py -q`
- `.venv/bin/ruff check counterpartycore/lib/ledger/supplies.py counterpartycore/test/units/ledger/supplies_test.py`
- `.venv/bin/ruff format --check counterpartycore/lib/ledger/supplies.py counterpartycore/test/units/ledger/supplies_test.py`
- `git diff --check`

If this qualifies for the project bounty program, BTC payout address:
`bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
