### PR TITLE
Validate v2 API enum parameters

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/apiserver.py
+++ b/counterparty-core/counterpartycore/lib/api/apiserver.py
@@ -216,6 +216,22 @@ def prepare_args(route, **kwargs):
         else:
             function_args[arg_name] = str_arg
 
+        if "members" in arg:
+            arg_values = (
+                function_args[arg_name].split(",")
+                if arg.get("allow_csv") and isinstance(function_args[arg_name], str)
+                else [function_args[arg_name]]
+            )
+            invalid_values = [value for value in arg_values if value not in arg["members"]]
+            if invalid_values:
+                allowed_values = ", ".join(
+                    "null" if member is None else str(member) for member in arg["members"]
+                )
+                raise ValueError(
+                    f"Invalid value for {arg_name}: {', '.join(map(str, invalid_values))} "
+                    f"(expected one of: {allowed_values})"
+                )
+
     for arg_name, str_arg in function_args.items():
         if str_arg is not None and str_arg != "":
             if arg_name.startswith("address"):

--- a/counterparty-core/counterpartycore/lib/api/routes.py
+++ b/counterparty-core/counterpartycore/lib/api/routes.py
@@ -6,6 +6,16 @@ from docstring_parser import parse as parse_docstring
 from counterpartycore.lib.api import apiv1, compose, composer, healthz, queries
 from counterpartycore.lib.backend import bitcoind, electrs
 
+CSV_ENUM_ANNOTATIONS = (
+    queries.TransactionType,
+    queries.SendType,
+    queries.IssuancesAssetEvents,
+    queries.DispenserStatus,
+    queries.OrderStatus,
+    queries.OrderMatchesStatus,
+    queries.FairmintersStatus,
+)
+
 
 def get_routes():
     """Return the API routes."""
@@ -359,6 +369,12 @@ def prepare_route_args(function):
         if route_arg["type"] == "Literal":
             route_arg["type"] = "enum[str]"
             route_arg["members"] = list(typing.get_args(annotation))
+            if annotation == queries.DispenserStatus:
+                route_arg["members"].extend(
+                    str(value) for value in queries.DispenserStatusNumber.values()
+                )
+            if annotation in CSV_ENUM_ANNOTATIONS:
+                route_arg["allow_csv"] = True
         if arg_name in args_description:
             route_arg["description"] = args_description[arg_name]
         args.append(route_arg)

--- a/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
@@ -769,6 +769,44 @@ def test_limit_param_negative_rejected(apiv2_client):
     assert response.status_code != 200 or "error" in response.json
 
 
+def test_invalid_enum_param_rejected(apiv2_client, defaults):
+    """Literal/enum route arguments must reject unsupported values before query execution."""
+    response = apiv2_client.get("/v2/orders?status=invalid-status")
+    assert response.status_code == 400
+    assert "Invalid value for status" in response.json["error"]
+
+    response = apiv2_client.get("/v2/orders?status=open,invalid-status")
+    assert response.status_code == 400
+    assert "Invalid value for status" in response.json["error"]
+
+    response = apiv2_client.get(
+        f"/v2/addresses/balances?addresses={defaults['addresses'][0]}&type=invalid-type"
+    )
+    assert response.status_code == 400
+    assert "Invalid value for type" in response.json["error"]
+
+    response = apiv2_client.get(
+        f"/v2/addresses/balances?addresses={defaults['addresses'][0]}&type=address,utxo"
+    )
+    assert response.status_code == 400
+    assert "Invalid value for type" in response.json["error"]
+
+
+def test_valid_csv_enum_param_accepted(apiv2_client):
+    """Enum routes that already support comma-separated filters must keep accepting them."""
+    response = apiv2_client.get("/v2/orders?status=open,filled")
+    assert response.status_code == 200
+    assert "result" in response.json
+
+    response = apiv2_client.get("/v2/transactions?type=send,order")
+    assert response.status_code == 200
+    assert "result" in response.json
+
+    response = apiv2_client.get("/v2/dispensers?status=0")
+    assert response.status_code == 200
+    assert "result" in response.json
+
+
 def test_limit_param_unlimited_when_zero(apiv2_client, monkeypatch):
     """When config.API_LIMIT_ROWS == 0 the cap is disabled."""
     monkeypatch.setattr(config, "API_LIMIT_ROWS", 0)


### PR DESCRIPTION
## Summary

This validates v2 API enum parameters at the shared request-argument layer.

Route metadata already exposes `Literal[...]` annotations as `enum[str]` with a `members` list, but `prepare_args()` did not enforce those members. Unsupported enum values were passed through to query functions. That could turn invalid requests into successful but misleading responses, such as:

- `/v2/orders?status=invalid-status` returning `200 OK`
- `/v2/addresses/balances?...&type=invalid-type` reaching query execution instead of returning a clear parameter error

The fix rejects unsupported enum values before query execution and returns the existing API-level `400` response path with a clear message.

For enum filters that already support comma-separated values in the query layer, the validation checks each token while preserving the existing accepted forms. It also preserves the dispenser numeric status aliases such as `status=0`.

## Tests

- `.venv/bin/pytest counterpartycore/test/units/api/apiserver_test.py::test_invalid_enum_param_rejected -q`
- `.venv/bin/pytest counterpartycore/test/units/api/apiserver_test.py::test_invalid_enum_param_rejected counterpartycore/test/units/api/apiserver_test.py::test_limit_param_capped_to_api_limit_rows counterpartycore/test/units/api/apiserver_test.py::test_limit_param_zero_rejected counterpartycore/test/units/api/apiserver_test.py::test_limit_param_negative_rejected counterpartycore/test/units/api/apiserver_test.py::test_limit_param_unlimited_when_zero -q`
- `.venv/bin/pytest counterpartycore/test/units/api/apiserver_test.py::test_invalid_enum_param_rejected counterpartycore/test/units/api/apiserver_test.py::test_valid_csv_enum_param_accepted -q`
- `.venv/bin/pytest counterpartycore/test/units/api/apiserver_test.py -q`
- `.venv/bin/ruff check counterpartycore/lib/api/apiserver.py counterpartycore/lib/api/routes.py counterpartycore/test/units/api/apiserver_test.py`
- `.venv/bin/ruff format --check counterpartycore/lib/api/apiserver.py counterpartycore/lib/api/routes.py counterpartycore/test/units/api/apiserver_test.py`
- `git diff --check`

If this qualifies for the project bounty program, BTC payout address:
`bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
