### PR TITLE
Validate inputs_set values

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/composer.py
+++ b/counterparty-core/counterpartycore/lib/api/composer.py
@@ -35,6 +35,7 @@ from counterpartycore.lib.parser import deserialize, messagetype, utxosinfo
 from counterpartycore.lib.utils import helpers, multisig, script
 
 MAX_INPUTS_SET = 100
+MAX_BTC_OUTPUT_VALUE = 21_000_000 * config.UNIT
 
 logger = logging.getLogger(config.LOGGER_NAME)
 
@@ -650,6 +651,8 @@ def prepare_inputs_set(inputs_set):
                 unspent["value"] = int(value)
             except ValueError as e:
                 raise exceptions.ComposeError(f"invalid UTXOs: {utxo} (invalid value)") from e
+            if unspent["value"] < 0 or unspent["value"] > MAX_BTC_OUTPUT_VALUE:
+                raise exceptions.ComposeError(f"invalid UTXOs: {utxo} (invalid value)")
 
         if script_pub_key is not None:
             try:

--- a/counterparty-core/counterpartycore/test/units/api/composer_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/composer_test.py
@@ -588,6 +588,27 @@ def test_prepare_inputs_set(defaults):
             "ae241be7be83ebb14902757ad94854f787d9730fc553d6f695346c9375c0d8c1:0:aa"
         )
 
+    with pytest.raises(
+        exceptions.ComposeError,
+        match=re.escape(
+            "invalid UTXOs: ae241be7be83ebb14902757ad94854f787d9730fc553d6f695346c9375c0d8c1:0:-1 (invalid value)"
+        ),
+    ):
+        composer.prepare_inputs_set(
+            "ae241be7be83ebb14902757ad94854f787d9730fc553d6f695346c9375c0d8c1:0:-1"
+        )
+
+    too_large_value = 21_000_000 * config.UNIT + 1
+    with pytest.raises(
+        exceptions.ComposeError,
+        match=re.escape(
+            f"invalid UTXOs: ae241be7be83ebb14902757ad94854f787d9730fc553d6f695346c9375c0d8c1:0:{too_large_value} (invalid value)"
+        ),
+    ):
+        composer.prepare_inputs_set(
+            f"ae241be7be83ebb14902757ad94854f787d9730fc553d6f695346c9375c0d8c1:0:{too_large_value}"
+        )
+
     # Test case 5: Invalid script_pub_key
     with pytest.raises(
         exceptions.ComposeError,


### PR DESCRIPTION
## Summary

`prepare_inputs_set()` accepted explicit UTXO values outside Bitcoin's valid output amount range. A caller could pass negative values such as `-1`, or values above the 21M BTC money supply limit, and those values were stored in the composed UTXO list.

This PR validates explicit `inputs_set` values before they are used for transaction input selection and change calculation.

## Impact

Invalid caller-provided UTXO values can distort compose-time BTC input totals, fee/change calculation, and later transaction-building behavior. The API should return a clear `ComposeError` instead of carrying impossible UTXO amounts deeper into the composer.

## Changes

- Add `MAX_BTC_OUTPUT_VALUE = 21_000_000 * config.UNIT`.
- Reject `inputs_set` values below 0 or above the BTC output limit.
- Add regression coverage for negative and too-large explicit UTXO values.

## Tests

- `python -m pytest counterpartycore/test/units/api/composer_test.py::test_prepare_inputs_set`
- `python -m pytest counterpartycore/test/units/api/composer_test.py`
- `python -m ruff check counterpartycore/lib/api/composer.py counterpartycore/test/units/api/composer_test.py`
- `python -m ruff format --check counterpartycore/lib/api/composer.py counterpartycore/test/units/api/composer_test.py`
