### PR TITLE
Validate compose fee parameters

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/composer.py
+++ b/counterparty-core/counterpartycore/lib/api/composer.py
@@ -924,6 +924,12 @@ def prepare_fee_parameters(construct_params):
     sat_per_vbyte = construct_params.get("sat_per_vbyte")
     confirmation_target = construct_params.get("confirmation_target")
     max_fee = construct_params.get("max_fee")
+    if exact_fee is not None and exact_fee < 0:
+        raise exceptions.ComposeError("Invalid exact_fee: must be non-negative")
+    if sat_per_vbyte is not None and sat_per_vbyte < 0:
+        raise exceptions.ComposeError("Invalid sat_per_vbyte: must be non-negative")
+    if max_fee is not None and max_fee < 0:
+        raise exceptions.ComposeError("Invalid max_fee: must be non-negative")
     if exact_fee is not None:
         sat_per_vbyte, confirmation_target, max_fee = None, None, None
     elif sat_per_vbyte is None:

--- a/counterparty-core/counterpartycore/test/units/api/composer_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/composer_test.py
@@ -987,6 +987,15 @@ def test_prepare_fee_parameters():
         1000,
     )
 
+    with pytest.raises(exceptions.ComposeError, match="Invalid exact_fee"):
+        composer.prepare_fee_parameters({"exact_fee": -1})
+
+    with pytest.raises(exceptions.ComposeError, match="Invalid sat_per_vbyte"):
+        composer.prepare_fee_parameters({"sat_per_vbyte": -0.1})
+
+    with pytest.raises(exceptions.ComposeError, match="Invalid max_fee"):
+        composer.prepare_fee_parameters({"max_fee": -1, "sat_per_vbyte": 1})
+
 
 def test_prepare_unspent_list(ledger_db, defaults, monkeypatch):
     txs = {


### PR DESCRIPTION
## Summary

`prepare_fee_parameters()` accepted negative fee inputs. Negative `exact_fee`, `sat_per_vbyte`, or `max_fee` can flow into input selection and change calculation, producing impossible negative-fee compose results or change outputs larger than the selected inputs.

This PR rejects negative compose fee parameters up front with a clear `ComposeError`.

## Impact

Invalid caller-provided fee values can distort compose-time fee and change calculation. For example, `max_fee=-1` can clamp the calculated fee below zero, and `exact_fee=-1` can increase the computed change amount instead of charging a fee.

## Changes

- Reject negative `exact_fee`.
- Reject negative `sat_per_vbyte`.
- Reject negative `max_fee`.
- Add regression coverage for all three fee parameters.

## Tests

- `python -m pytest counterpartycore/test/units/api/composer_test.py::test_prepare_fee_parameters`
- `python -m pytest counterpartycore/test/units/api/composer_test.py`
- `python -m ruff check counterpartycore/lib/api/composer.py counterpartycore/test/units/api/composer_test.py`
- `python -m ruff format --check counterpartycore/lib/api/composer.py counterpartycore/test/units/api/composer_test.py`
