### PR TITLE
Validate dust size parameters

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/composer.py
+++ b/counterparty-core/counterpartycore/lib/api/composer.py
@@ -123,12 +123,16 @@ def create_tx_output(value, address_or_script, unspent_list, construct_params):
 
 def regular_dust_size(construct_params):
     if construct_params.get("regular_dust_size") is not None:
+        if construct_params["regular_dust_size"] < 0:
+            raise exceptions.ComposeError("Invalid regular_dust_size: must be non-negative")
         return construct_params["regular_dust_size"]
     return config.DEFAULT_REGULAR_DUST_SIZE
 
 
 def multisig_dust_size(construct_params):
     if construct_params.get("multisig_dust_size") is not None:
+        if construct_params["multisig_dust_size"] < 0:
+            raise exceptions.ComposeError("Invalid multisig_dust_size: must be non-negative")
         return construct_params["multisig_dust_size"]
     return config.DEFAULT_MULTISIG_DUST_SIZE
 

--- a/counterparty-core/counterpartycore/test/units/api/composer_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/composer_test.py
@@ -110,9 +110,13 @@ def test_dust_size(defaults):
     assert composer.regular_dust_size({}) == 546
     assert composer.regular_dust_size({"regular_dust_size": 666}) == 666
     assert composer.regular_dust_size({"regular_dust_size": None}) == 546
+    with pytest.raises(exceptions.ComposeError, match="Invalid regular_dust_size"):
+        composer.regular_dust_size({"regular_dust_size": -1})
     assert composer.multisig_dust_size({}) == 1000
     assert composer.multisig_dust_size({"multisig_dust_size": 666}) == 666
     assert composer.multisig_dust_size({"multisig_dust_size": None}) == 1000
+    with pytest.raises(exceptions.ComposeError, match="Invalid multisig_dust_size"):
+        composer.multisig_dust_size({"multisig_dust_size": -1})
     assert composer.dust_size(defaults["addresses"][0], {}) == 546
     assert composer.dust_size(defaults["addresses"][0], {"regular_dust_size": 666}) == 666
     assert composer.dust_size(defaults["p2ms_addresses"][0], {}) == 1000


### PR DESCRIPTION
## Summary

Deprecated but still-active compose parameters `regular_dust_size` and `multisig_dust_size` accepted negative values. Those values are used directly when creating default destination/change/data outputs, so a negative dust size can become an invalid transaction output amount.

This PR rejects negative dust size overrides with a clear `ComposeError`.

## Impact

Invalid caller-provided dust sizes can flow into `TxOutput` creation and transaction sanity checks instead of failing at the parameter boundary. This can produce confusing compose behavior and malformed transaction output objects.

## Changes

- Reject negative `regular_dust_size`.
- Reject negative `multisig_dust_size`.
- Add regression coverage for both parameters while preserving the existing default and positive override behavior.

## Tests

- `python -m pytest counterpartycore/test/units/api/composer_test.py::test_dust_size`
- `python -m pytest counterpartycore/test/units/api/composer_test.py`
- `python -m ruff check counterpartycore/lib/api/composer.py counterpartycore/test/units/api/composer_test.py`
- `python -m ruff format --check counterpartycore/lib/api/composer.py counterpartycore/test/units/api/composer_test.py`
