### PR TITLE
Validate confirmation target

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/composer.py
+++ b/counterparty-core/counterpartycore/lib/api/composer.py
@@ -35,6 +35,7 @@ from counterpartycore.lib.parser import deserialize, messagetype, utxosinfo
 from counterpartycore.lib.utils import helpers, multisig, script
 
 MAX_INPUTS_SET = 100
+MAX_CONFIRMATION_TARGET = 1008
 
 logger = logging.getLogger(config.LOGGER_NAME)
 
@@ -928,6 +929,10 @@ def prepare_fee_parameters(construct_params):
         sat_per_vbyte, confirmation_target, max_fee = None, None, None
     elif sat_per_vbyte is None:
         if confirmation_target is not None:
+            if confirmation_target < 1 or confirmation_target > MAX_CONFIRMATION_TARGET:
+                raise exceptions.ComposeError(
+                    f"Invalid confirmation_target: must be between 1 and {MAX_CONFIRMATION_TARGET}"
+                )
             sat_per_vbyte = backend.bitcoind.satoshis_per_vbyte(confirmation_target)
         else:
             sat_per_vbyte = backend.bitcoind.satoshis_per_vbyte()

--- a/counterparty-core/counterpartycore/test/units/api/composer_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/composer_test.py
@@ -987,6 +987,15 @@ def test_prepare_fee_parameters():
         1000,
     )
 
+    with pytest.raises(exceptions.ComposeError, match="Invalid confirmation_target"):
+        composer.prepare_fee_parameters({"confirmation_target": 0})
+
+    with pytest.raises(exceptions.ComposeError, match="Invalid confirmation_target"):
+        composer.prepare_fee_parameters({"confirmation_target": -1})
+
+    with pytest.raises(exceptions.ComposeError, match="Invalid confirmation_target"):
+        composer.prepare_fee_parameters({"confirmation_target": 1009})
+
 
 def test_prepare_unspent_list(ledger_db, defaults, monkeypatch):
     txs = {


### PR DESCRIPTION
## Summary

`prepare_fee_parameters()` accepted any `confirmation_target` value before passing it to Bitcoin Core fee estimation. The backend helper documents the valid range as 1 to 1008 blocks, but compose-time callers could pass 0, negative values, or values above 1008 and let the error surface later at the RPC layer.

This PR validates the confirmation target before calling `estimatesmartfee`.

## Impact

Invalid caller-provided confirmation targets can produce unclear compose failures from Bitcoin Core instead of a direct `ComposeError` at the parameter boundary.

## Changes

- Add `MAX_CONFIRMATION_TARGET = 1008`.
- Reject `confirmation_target` values below 1 or above 1008 when fee estimation will use the parameter.
- Add regression coverage for 0, negative, and above-range values.

## Tests

- `python -m pytest counterpartycore/test/units/api/composer_test.py::test_prepare_fee_parameters`
- `python -m pytest counterpartycore/test/units/api/composer_test.py`
- `python -m ruff check counterpartycore/lib/api/composer.py counterpartycore/test/units/api/composer_test.py`
- `python -m ruff format --check counterpartycore/lib/api/composer.py counterpartycore/test/units/api/composer_test.py`
- `git diff --check`
