### PR TITLE
Validate UTXO vout range

### DIFF
--- a/counterparty-core/counterpartycore/lib/parser/utxosinfo.py
+++ b/counterparty-core/counterpartycore/lib/parser/utxosinfo.py
@@ -1,3 +1,6 @@
+MAX_VOUT = 0xFFFFFFFF
+
+
 def is_utxo_format(value):
     if not isinstance(value, str):
         return False
@@ -6,7 +9,10 @@ def is_utxo_format(value):
         return False
     if not values[1].isnumeric():
         return False
-    if str(int(values[1])) != values[1]:
+    vout = int(values[1])
+    if str(vout) != values[1]:
+        return False
+    if vout > MAX_VOUT:
         return False
     try:
         int(values[0], 16)

--- a/counterparty-core/counterpartycore/test/units/parser/utxosinfo_test.py
+++ b/counterparty-core/counterpartycore/test/units/parser/utxosinfo_test.py
@@ -1,0 +1,10 @@
+from counterpartycore.lib.parser import utxosinfo
+
+TXID = "0" * 64
+
+
+def test_is_utxo_format_rejects_vout_above_uint32():
+    assert utxosinfo.is_utxo_format(f"{TXID}:0")
+    assert utxosinfo.is_utxo_format(f"{TXID}:4294967295")
+    assert not utxosinfo.is_utxo_format(f"{TXID}:4294967296")
+    assert not utxosinfo.is_utxo_format(f"{TXID}:999999999999999999999")


### PR DESCRIPTION
## Summary

`utxosinfo.is_utxo_format()` accepted UTXO strings whose `vout` component is larger than the uint32 outpoint index supported by Bitcoin transaction inputs. Values such as `4294967296` were treated as valid UTXO format and could reach later transaction-input construction, where serialization fails with a lower-level struct packing error.

This PR validates the UTXO `vout` range at the format boundary.

## Impact

Invalid caller-provided UTXO identifiers can pass initial validation and fail later with an unclear transaction serialization error. The format helper should reject impossible outpoint indexes directly.

## Changes

- Add `MAX_VOUT = 0xffffffff`.
- Reject UTXO strings with `vout > MAX_VOUT`.
- Add regression coverage for the valid uint32 boundary and above-range values.

## Tests

- `python -m pytest counterpartycore/test/units/parser/utxosinfo_test.py`
- `python -m pytest counterpartycore/test/units/api/composer_test.py::test_prepare_inputs_set`
- `python -m pytest counterpartycore/test/units/parser/utxosinfo_test.py counterpartycore/test/units/api/composer_test.py::test_prepare_inputs_set`
- `python -m ruff check counterpartycore/lib/parser/utxosinfo.py counterpartycore/test/units/parser/utxosinfo_test.py`
- `python -m ruff format --check counterpartycore/lib/parser/utxosinfo.py counterpartycore/test/units/parser/utxosinfo_test.py`
- `git diff --check`
