### PR TITLE
Validate dispense BTC quantity

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/dispense.py
+++ b/counterparty-core/counterpartycore/lib/messages/dispense.py
@@ -48,6 +48,13 @@ def validate_compose(db, source, destination, quantity):
     if source == destination:
         raise exceptions.ComposeError("source and destination must be different")
 
+    if not isinstance(quantity, int):
+        problems.append("quantity must be in satoshis")
+        return problems
+    if quantity <= 0:
+        problems.append("quantity must be positive")
+        return problems
+
     dispensers = ledger.markets.get_dispensers(db, address=destination)
     if len(dispensers) == 0:
         problems.append("address doesn't have any open dispenser")

--- a/counterparty-core/counterpartycore/test/units/messages/dispense_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/dispense_test.py
@@ -22,6 +22,12 @@ def test_compose(ledger_db, defaults):
     with pytest.raises(exceptions.ComposeError, match=error):
         assert dispense.compose(ledger_db, defaults["addresses"][0], defaults["addresses"][5], 10)
 
+    with pytest.raises(exceptions.ComposeError, match=str(["quantity must be positive"])):
+        dispense.compose(ledger_db, defaults["addresses"][0], defaults["addresses"][5], -100)
+
+    with pytest.raises(exceptions.ComposeError, match=str(["quantity must be in satoshis"])):
+        dispense.compose(ledger_db, defaults["addresses"][0], defaults["addresses"][5], "100")
+
     error = str(
         [
             "dispenser for XCP doesn't have enough asset to give",


### PR DESCRIPTION
## Summary

`dispense.compose()` did not validate the BTC `quantity` before checking open dispensers. A negative quantity could bypass the "not enough BTC" guard because `must_give` becomes negative rather than zero, then the composer returns a destination output with a negative amount.

This PR rejects non-integer and non-positive dispense quantities at the compose validation boundary.

## Impact

Caller-provided negative BTC quantities can pass message-level validation and reach transaction construction as an invalid output amount. The compose path should fail with a clear `ComposeError` before building transaction outputs.

## Changes

- Require `dispense` quantity to be an integer.
- Reject zero or negative dispense quantity.
- Add regression coverage for negative and non-integer quantities.

## Tests

- `python -m pytest counterpartycore/test/units/messages/dispense_test.py::test_compose`
- `python -m pytest counterpartycore/test/units/messages/dispense_test.py`
- `python -m pytest counterpartycore/test/units/api/compose_test.py::test_compose_dispense`
- `python -m ruff check counterpartycore/lib/messages/dispense.py counterpartycore/test/units/messages/dispense_test.py`
- `python -m ruff format --check counterpartycore/lib/messages/dispense.py counterpartycore/test/units/messages/dispense_test.py`
- `git diff --check`

## Bounty note

If this fix qualifies for a bounty, please send it to:

`bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
