### PR TITLE
Validate order integer parameters before overflow checks

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/order.py
+++ b/counterparty-core/counterpartycore/lib/messages/order.py
@@ -238,15 +238,6 @@ def validate(
     problems = []
     cursor = db.cursor()
 
-    # For SQLite3
-    if (
-        give_quantity > config.MAX_INT
-        or get_quantity > config.MAX_INT
-        or fee_required > config.MAX_INT
-        or block_index + expiration > config.MAX_INT
-    ):
-        problems.append("integer overflow")
-
     if give_asset == config.BTC and get_asset == config.BTC:
         problems.append(f"cannot trade {config.BTC} for itself")
 
@@ -262,6 +253,15 @@ def validate(
     if not isinstance(expiration, int):
         problems.append("expiration must be expressed as an integer block delta")
         return problems
+
+    # For SQLite3
+    if (
+        give_quantity > config.MAX_INT
+        or get_quantity > config.MAX_INT
+        or fee_required > config.MAX_INT
+        or block_index + expiration > config.MAX_INT
+    ):
+        problems.append("integer overflow")
 
     if give_quantity <= 0:
         problems.append("non‐positive give quantity")

--- a/counterparty-core/counterpartycore/test/units/messages/order_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/order_test.py
@@ -140,6 +140,44 @@ def test_validate(ledger_db, defaults, current_block_index):
     ) == ["integer overflow"]
 
 
+@pytest.mark.parametrize(
+    ("param_name", "param_value", "expected_problem"),
+    [
+        ("give_quantity", "1000", "give_quantity must be in satoshis"),
+        ("get_quantity", "1000", "get_quantity must be in satoshis"),
+        ("fee_required", "0", "fee_required must be in satoshis"),
+        (
+            "expiration",
+            "10",
+            "expiration must be expressed as an integer block delta",
+        ),
+    ],
+)
+def test_validate_rejects_non_integer_parameters(
+    ledger_db, defaults, current_block_index, param_name, param_value, expected_problem
+):
+    params = {
+        "give_asset": "DIVISIBLE",
+        "give_quantity": defaults["quantity"],
+        "get_asset": "XCP",
+        "get_quantity": defaults["quantity"],
+        "expiration": 2000,
+        "fee_required": 0,
+    }
+    params[param_name] = param_value
+
+    assert order.validate(
+        ledger_db,
+        params["give_asset"],
+        params["give_quantity"],
+        params["get_asset"],
+        params["get_quantity"],
+        params["expiration"],
+        params["fee_required"],
+        current_block_index,
+    ) == [expected_problem]
+
+
 def test_compose(ledger_db, defaults, current_block_index):
     assert order.compose(
         ledger_db,


### PR DESCRIPTION
## Summary

Order validation checked the SQLite integer overflow guard before confirming that the numeric order parameters were actually integers. Non-integer values that do not support comparison or addition with integers, such as string `give_quantity`, `get_quantity`, `fee_required`, or `expiration`, could therefore raise a Python `TypeError` before the existing compose-level validation errors were returned.

This moves the integer type checks before the overflow guard, while preserving the existing validation messages and keeping the BTC-for-BTC asset check first.

## Tests

- `.venv/bin/python -m pytest counterpartycore/test/units/messages/order_test.py::test_validate counterpartycore/test/units/messages/order_test.py::test_validate_rejects_non_integer_parameters -q`
- `.venv/bin/python -m pytest counterpartycore/test/units/messages/order_test.py -q`
- `.venv/bin/python -m pytest counterpartycore/test/units/api/compose_test.py::test_compose_order -q`
- `.venv/bin/python -m ruff check counterpartycore/lib/messages/order.py counterpartycore/test/units/messages/order_test.py`
- `.venv/bin/python -m ruff format --check counterpartycore/lib/messages/order.py counterpartycore/test/units/messages/order_test.py`
- `git diff --check`

## Bounty address

BTC: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
