### PR TITLE
Validate bet integer parameters before overflow checks

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/bet.py
+++ b/counterparty-core/counterpartycore/lib/messages/bet.py
@@ -126,17 +126,6 @@ def validate(
     if leverage is None:
         leverage = 5040
 
-    # For SQLite3
-    if (
-        wager_quantity > config.MAX_INT  # pylint: disable=too-many-boolean-expressions
-        or counterwager_quantity > config.MAX_INT
-        or bet_type > config.MAX_INT
-        or deadline > config.MAX_INT
-        or leverage > config.MAX_INT
-        or block_index + expiration > config.MAX_INT
-    ):
-        problems.append("integer overflow")
-
     # Look at feed to be bet on.
     broadcasts = ledger.other.get_broadcasts_by_source(db, feed_address, "valid", order_by="ASC")
     if not broadcasts:
@@ -171,6 +160,17 @@ def validate(
     if not isinstance(expiration, int):
         problems.append("expiration must be expressed as an integer block delta")
         return problems, leverage
+
+    # For SQLite3
+    if (
+        wager_quantity > config.MAX_INT  # pylint: disable=too-many-boolean-expressions
+        or counterwager_quantity > config.MAX_INT
+        or bet_type > config.MAX_INT
+        or deadline > config.MAX_INT
+        or leverage > config.MAX_INT
+        or block_index + expiration > config.MAX_INT
+    ):
+        problems.insert(0, "integer overflow")
 
     if wager_quantity <= 0:
         problems.append("non‐positive wager")

--- a/counterparty-core/counterpartycore/test/units/messages/bet_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/bet_test.py
@@ -333,6 +333,47 @@ def test_validate(ledger_db, defaults, current_block_index):
     ) == (["integer overflow"], 15120)
 
 
+@pytest.mark.parametrize(
+    ("param_name", "param_value", "expected_problem"),
+    [
+        ("wager_quantity", "1000", "wager_quantity must be in satoshis"),
+        ("counterwager_quantity", "1000", "counterwager_quantity must be in satoshis"),
+        (
+            "expiration",
+            "10",
+            "expiration must be expressed as an integer block delta",
+        ),
+    ],
+)
+def test_validate_rejects_non_integer_parameters(
+    ledger_db, defaults, current_block_index, param_name, param_value, expected_problem
+):
+    params = {
+        "feed_address": defaults["addresses"][0],
+        "bet_type": 0,
+        "deadline": 1488000100,
+        "wager_quantity": defaults["small"],
+        "counterwager_quantity": defaults["small"],
+        "target_value": 0.0,
+        "leverage": 15120,
+        "expiration": defaults["expiration"],
+    }
+    params[param_name] = param_value
+
+    assert bet.validate(
+        ledger_db,
+        params["feed_address"],
+        params["bet_type"],
+        params["deadline"],
+        params["wager_quantity"],
+        params["counterwager_quantity"],
+        params["target_value"],
+        params["leverage"],
+        params["expiration"],
+        current_block_index,
+    ) == ([expected_problem], params["leverage"])
+
+
 def test_compose(ledger_db, defaults):
     with pytest.raises(exceptions.ComposeError, match="insufficient funds"):
         bet.compose(


### PR DESCRIPTION
## Summary

Bet validation checked the SQLite integer overflow guard before the existing type checks for `wager_quantity`, `counterwager_quantity`, and `expiration`. String values for those fields could therefore raise a Python `TypeError` while comparing or adding them to integers, instead of returning the compose-level validation messages already used for non-integer values.

This moves the overflow guard until after those integer checks and preserves the existing error ordering by keeping `integer overflow` first when it applies.

## Tests

- `.venv/bin/python -m pytest counterpartycore/test/units/messages/bet_test.py::test_validate counterpartycore/test/units/messages/bet_test.py::test_validate_rejects_non_integer_parameters -q`
- `.venv/bin/python -m pytest counterpartycore/test/units/messages/bet_test.py -q`
- `.venv/bin/python -m pytest counterpartycore/test/units/api/compose_test.py::test_compose_bet -q`
- `.venv/bin/python -m ruff check counterpartycore/lib/messages/bet.py counterpartycore/test/units/messages/bet_test.py`
- `.venv/bin/python -m ruff format --check counterpartycore/lib/messages/bet.py counterpartycore/test/units/messages/bet_test.py`
- `git diff --check`

## Bounty address

BTC: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
