### PR TITLE
Validate broadcast numeric parameters before comparisons

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/broadcast.py
+++ b/counterparty-core/counterpartycore/lib/messages/broadcast.py
@@ -75,6 +75,16 @@ def validate_address_options(options):
 def validate(db, source, timestamp, value, fee_fraction_int, text, mime_type, block_index=None):
     problems = []
 
+    if not isinstance(timestamp, int):
+        problems.append("timestamp must be an integer")
+        return problems
+    if not isinstance(value, (int, float, D, Fraction)):
+        problems.append("value must be numeric")
+        return problems
+    if not isinstance(fee_fraction_int, (int, float, D, Fraction)):
+        problems.append("fee_fraction_int must be numeric")
+        return problems
+
     # For SQLite3
     if timestamp > config.MAX_INT or value > config.MAX_INT or fee_fraction_int > config.MAX_INT:
         problems.append("integer overflow")

--- a/counterparty-core/counterpartycore/test/units/messages/broadcast_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/broadcast_test.py
@@ -106,6 +106,35 @@ def test_validate(ledger_db, defaults, current_block_index):
     ) == ["options not an integer"]
 
 
+@pytest.mark.parametrize(
+    ("param_name", "param_value", "expected_problem"),
+    [
+        ("timestamp", "1588000000", "timestamp must be an integer"),
+        ("value", "1", "value must be numeric"),
+        ("fee_fraction_int", "5000000", "fee_fraction_int must be numeric"),
+    ],
+)
+def test_validate_rejects_invalid_numeric_parameters(
+    ledger_db, defaults, param_name, param_value, expected_problem
+):
+    params = {
+        "timestamp": 1588000000,
+        "value": 1,
+        "fee_fraction_int": defaults["fee_multiplier"],
+    }
+    params[param_name] = param_value
+
+    assert broadcast.validate(
+        ledger_db,
+        defaults["addresses"][0],
+        params["timestamp"],
+        params["value"],
+        params["fee_fraction_int"],
+        "Unit Test",
+        "",
+    ) == [expected_problem]
+
+
 def test_compose(ledger_db, defaults):
     with ProtocolChangesDisabled(["broadcast_pack_text", "short_tx_type_id"]):
         assert broadcast.compose(


### PR DESCRIPTION
## Summary

Broadcast validation compared `timestamp`, `value`, and `fee_fraction_int` against numeric limits before checking that those inputs were numeric. String values could therefore raise a Python `TypeError` during validation instead of returning a compose-level validation error.

This adds explicit numeric validation before the existing comparison logic. Existing integer/float-style inputs are preserved, including the test-suite's current floating fee multiplier case.

## Tests

- `.venv/bin/python -m pytest counterpartycore/test/units/messages/broadcast_test.py::test_validate counterpartycore/test/units/messages/broadcast_test.py::test_validate_rejects_invalid_numeric_parameters -q`
- `.venv/bin/python -m pytest counterpartycore/test/units/messages/broadcast_test.py -q`
- `.venv/bin/python -m pytest counterpartycore/test/units/api/compose_test.py::test_compose_broadcast -q`
- `.venv/bin/python -m ruff check counterpartycore/lib/messages/broadcast.py counterpartycore/test/units/messages/broadcast_test.py`
- `.venv/bin/python -m ruff format --check counterpartycore/lib/messages/broadcast.py counterpartycore/test/units/messages/broadcast_test.py`
- `git diff --check`

## Bounty address

BTC: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
