### PR TITLE
Validate dispenser integer parameters before comparisons

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/dispenser.py
+++ b/counterparty-core/counterpartycore/lib/messages/dispenser.py
@@ -76,6 +76,17 @@ def validate(
     # resolve subassets
     asset = issuances.resolve_subasset_longname(db, asset)
 
+    for param_name, param_value in {
+        "give_quantity": give_quantity,
+        "escrow_quantity": escrow_quantity,
+        "mainchainrate": mainchainrate,
+    }.items():
+        if not isinstance(param_value, int):
+            problems.append(f"{param_name} must be an integer")
+
+    if problems:
+        return None, problems
+
     if status in [STATUS_OPEN, STATUS_OPEN_EMPTY_ADDRESS]:
         if give_quantity <= 0:
             problems.append("give_quantity must be positive")

--- a/counterparty-core/counterpartycore/test/units/messages/dispenser_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/dispenser_test.py
@@ -141,6 +141,38 @@ def test_validate(ledger_db, defaults):
     ) == (None, ["dispenser must be created by source"])
 
 
+@pytest.mark.parametrize(
+    ("param_name", "param_value", "expected_problem"),
+    [
+        ("give_quantity", "100", "give_quantity must be an integer"),
+        ("escrow_quantity", "100", "escrow_quantity must be an integer"),
+        ("mainchainrate", "100", "mainchainrate must be an integer"),
+    ],
+)
+def test_validate_rejects_non_integer_parameters(
+    ledger_db, defaults, param_name, param_value, expected_problem
+):
+    params = {
+        "give_quantity": 100,
+        "escrow_quantity": 100,
+        "mainchainrate": 100,
+    }
+    params[param_name] = param_value
+
+    assert dispenser.validate(
+        ledger_db,
+        defaults["addresses"][0],
+        "XCP",
+        params["give_quantity"],
+        params["escrow_quantity"],
+        params["mainchainrate"],
+        dispenser.STATUS_OPEN,
+        None,
+        config.BURN_START,
+        None,
+    ) == (None, [expected_problem])
+
+
 def test_compose(ledger_db, defaults):
     assert dispenser.compose(ledger_db, defaults["addresses"][0], config.XCP, 100, 100, 100, 0) == (
         defaults["addresses"][0],


### PR DESCRIPTION
## Summary

Dispenser validation compared `give_quantity`, `escrow_quantity`, and `mainchainrate` before confirming those inputs were integers. String values could raise a Python `TypeError` during positive, ordering, balance, or overflow checks instead of returning a compose-level validation error.

This adds explicit integer validation for those three dispenser parameters before the existing comparison logic.

## Tests

- `.venv/bin/python -m pytest counterpartycore/test/units/messages/dispenser_test.py::test_validate counterpartycore/test/units/messages/dispenser_test.py::test_validate_rejects_non_integer_parameters -q`
- `.venv/bin/python -m pytest counterpartycore/test/units/messages/dispenser_test.py -q`
- `.venv/bin/python -m pytest counterpartycore/test/units/api/compose_test.py::test_compose_dispenser -q`
- `.venv/bin/python -m ruff check counterpartycore/lib/messages/dispenser.py counterpartycore/test/units/messages/dispenser_test.py`
- `.venv/bin/python -m ruff format --check counterpartycore/lib/messages/dispenser.py counterpartycore/test/units/messages/dispenser_test.py`
- `git diff --check`

## Bounty address

BTC: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
