### PR TITLE
Validate dividend quantity before comparisons

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/dividend.py
+++ b/counterparty-core/counterpartycore/lib/messages/dividend.py
@@ -35,6 +35,10 @@ def validate(db, source, quantity_per_unit, asset, dividend_asset, block_index):
         ):  # Protocol change.
             problems.append(f"cannot pay dividends to holders of {config.XCP}")
 
+    if not isinstance(quantity_per_unit, int):
+        problems.append("quantity_per_unit must be an integer")
+        return None, None, problems, 0
+
     if quantity_per_unit <= 0:
         problems.append("non‐positive quantity per unit")
 

--- a/counterparty-core/counterpartycore/test/units/messages/dividend_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/dividend_test.py
@@ -89,6 +89,17 @@ def test_validate(ledger_db, defaults, current_block_index):
     ) == (None, None, ["insufficient funds (XCP)"], 0)
 
 
+def test_validate_rejects_non_integer_quantity_per_unit(ledger_db, defaults, current_block_index):
+    assert dividend.validate(
+        ledger_db,
+        defaults["addresses"][0],
+        "100000000",
+        "DIVISIBLE",
+        "XCP",
+        current_block_index,
+    ) == (None, None, ["quantity_per_unit must be an integer"], 0)
+
+
 def test_compose(ledger_db, defaults):
     assert dividend.compose(
         ledger_db, defaults["addresses"][0], defaults["quantity"], "DIVISIBLE", "XCP"


### PR DESCRIPTION
## Summary

Dividend validation compared `quantity_per_unit` before checking that it was an integer. A string value could raise a Python `TypeError` at `quantity_per_unit <= 0` instead of returning a compose-level validation error.

This adds an explicit integer check before the existing non-positive and overflow checks.

## Tests

- `.venv/bin/python -m pytest counterpartycore/test/units/messages/dividend_test.py::test_validate counterpartycore/test/units/messages/dividend_test.py::test_validate_rejects_non_integer_quantity_per_unit -q`
- `.venv/bin/python -m pytest counterpartycore/test/units/messages/dividend_test.py -q`
- `.venv/bin/python -m pytest counterpartycore/test/units/api/compose_test.py::test_compose_dividend -q`
- `.venv/bin/python -m ruff check counterpartycore/lib/messages/dividend.py counterpartycore/test/units/messages/dividend_test.py`
- `.venv/bin/python -m ruff format --check counterpartycore/lib/messages/dividend.py counterpartycore/test/units/messages/dividend_test.py`
- `git diff --check`

## Bounty address

BTC: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
