### PR TITLE
Preserve subasset longname case in balance lookups

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/queries.py
+++ b/counterparty-core/counterpartycore/lib/api/queries.py
@@ -2145,11 +2145,12 @@ def get_balances_by_address_and_asset(
     :param int limit: The maximum number of balances to return (e.g. 5)
     :param int offset: The number of lines to skip before returning results (overrides the `cursor` parameter)
     """
+    asset_name = asset.upper()
     where = [
-        {"address": address, "asset": asset.upper(), "quantity__gt": 0},
-        {"address": address, "asset_longname": asset.upper(), "quantity__gt": 0},
-        {"utxo_address": address, "asset": asset.upper(), "quantity__gt": 0},
-        {"utxo_address": address, "asset_longname": asset.upper(), "quantity__gt": 0},
+        {"address": address, "asset": asset_name, "quantity__gt": 0},
+        {"address": address, "asset_longname": asset, "quantity__gt": 0},
+        {"utxo_address": address, "asset": asset_name, "quantity__gt": 0},
+        {"utxo_address": address, "asset_longname": asset, "quantity__gt": 0},
     ]
     if type == "utxo":
         where.pop(0)
@@ -2846,9 +2847,10 @@ def get_asset_balances(
     :param int offset: The number of lines to skip before returning results (overrides the `cursor` parameter)
     :param str sort: The sort order of the balances to return (overrides the `cursor` parameter) (e.g. quantity:desc)
     """
+    asset_name = asset.upper()
     where = [
-        {"asset": asset.upper(), "quantity__gt": 0},
-        {"asset_longname": asset.upper(), "quantity__gt": 0},
+        {"asset": asset_name, "quantity__gt": 0},
+        {"asset_longname": asset, "quantity__gt": 0},
     ]
     if type == "utxo":
         where[0]["utxo__notnull"] = True

--- a/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
@@ -477,6 +477,18 @@ def test_get_balances_by_addresses(apiv2_client, defaults):
     result = apiv2_client.get(url).json["result"]
     assert len(result) == 0
 
+    url = f"/v2/addresses/{defaults['addresses'][0]}/balances/PARENT.already.issued?verbose=true"
+    result = apiv2_client.get(url).json["result"]
+    assert len(result) > 0
+    assert result[0]["asset"] == "A95428959342453541"
+    assert result[0]["asset_longname"] == "PARENT.already.issued"
+
+    url = "/v2/assets/PARENT.already.issued/balances?verbose=true"
+    result = apiv2_client.get(url).json["result"]
+    assert len(result) > 0
+    assert result[0]["asset"] == "A95428959342453541"
+    assert result[0]["asset_longname"] == "PARENT.already.issued"
+
 
 def test_get_transactions_valid(apiv2_client, monkeypatch):
     url = "/v2/transactions"

--- a/counterparty-core/counterpartycore/test/units/api/queries_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/queries_test.py
@@ -596,6 +596,18 @@ def test_get_balances_by_address_and_asset_address_type(state_db, defaults):
     assert result is not None
 
 
+def test_get_balances_by_address_and_asset_subasset_longname(state_db, defaults):
+    result = queries.get_balances_by_address_and_asset(
+        state_db,
+        address=defaults["addresses"][0],
+        asset="PARENT.already.issued",
+    )
+
+    assert len(result.result) > 0
+    assert result.result[0]["asset"] == "A95428959342453541"
+    assert result.result[0]["asset_longname"] == "PARENT.already.issued"
+
+
 # =============================================================================
 # Tests for dispensers
 # =============================================================================
@@ -804,6 +816,14 @@ def test_get_asset_balances_address_type(state_db):
         type="address",
     )
     assert result is not None
+
+
+def test_get_asset_balances_subasset_longname(state_db):
+    result = queries.get_asset_balances(state_db, asset="PARENT.already.issued")
+
+    assert len(result.result) > 0
+    assert result.result[0]["asset"] == "A95428959342453541"
+    assert result.result[0]["asset_longname"] == "PARENT.already.issued"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Balance lookups for a single address/asset and for an asset's balances uppercased the request asset before comparing against `asset_longname`.

That keeps regular named-asset lookups working, but it misses case-sensitive subasset longnames such as `PARENT.already.issued` because the query compares against `PARENT.ALREADY.ISSUED`.

This preserves the existing uppercase lookup for the canonical `asset` column while using the caller-provided value for `asset_longname`.

## Tests

- `.venv/bin/python -m pytest counterpartycore/test/units/api/queries_test.py::test_get_balances_by_address_and_asset_subasset_longname counterpartycore/test/units/api/queries_test.py::test_get_asset_balances_subasset_longname -q`
- `.venv/bin/python -m pytest counterpartycore/test/units/api/apiserver_test.py::test_get_balances_by_addresses -q`
- `.venv/bin/python -m pytest counterpartycore/test/units/api/queries_test.py -q`
- `.venv/bin/python -m ruff check counterpartycore/lib/api/queries.py counterpartycore/test/units/api/queries_test.py counterpartycore/test/units/api/apiserver_test.py`
- `.venv/bin/python -m ruff format --check counterpartycore/lib/api/queries.py counterpartycore/test/units/api/queries_test.py counterpartycore/test/units/api/apiserver_test.py`
- `git diff --check`

## Bounty address

BTC: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
