### PR TITLE
Fix NotSupportedTransactionsCache unbounded growth; improve memory profiling

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/apiserver.py
+++ b/counterparty-core/counterpartycore/lib/api/apiserver.py
@@ -560,7 +560,7 @@ def run_apiserver(
         if getattr(config, "MEMORY_PROFILE", False):
             mem_profiler = memory_profiler.start_memory_profiler(
                 interval_seconds=60,
-                enable_tracemalloc=False,
+                enable_tracemalloc=getattr(config, "MEMORY_PROFILE_TRACEMALLOC", False),
             )
 
         # Start connection pool monitor

--- a/counterparty-core/counterpartycore/lib/cli/initialise.py
+++ b/counterparty-core/counterpartycore/lib/cli/initialise.py
@@ -140,6 +140,7 @@ def initialise_config(
     api_only=False,
     profile=False,
     memory_profile=False,
+    memory_profile_tracemalloc=False,
     enable_all_protocol_changes=False,
 ):
     # log config already initialized
@@ -564,7 +565,9 @@ def initialise_config(
 
     config.API_ONLY = api_only
     config.PROFILE = profile
-    config.MEMORY_PROFILE = memory_profile
+    # tracemalloc tracking is an extension of the memory profiler
+    config.MEMORY_PROFILE = memory_profile or memory_profile_tracemalloc
+    config.MEMORY_PROFILE_TRACEMALLOC = memory_profile_tracemalloc
     config.ENABLE_ALL_PROTOCOL_CHANGES = enable_all_protocol_changes
 
 
@@ -617,6 +620,7 @@ def initialise_log_and_config(args, api=False, log_stream=None):
         "api_only": args.api_only,
         "profile": args.profile,
         "memory_profile": args.memory_profile,
+        "memory_profile_tracemalloc": getattr(args, "memory_profile_tracemalloc", False),
         "enable_all_protocol_changes": args.enable_all_protocol_changes,
     }
     # for tests

--- a/counterparty-core/counterpartycore/lib/cli/main.py
+++ b/counterparty-core/counterpartycore/lib/cli/main.py
@@ -448,6 +448,14 @@ CONFIG_ARGS = [
         },
     ],
     [
+        ("--memory-profile-tracemalloc",),
+        {
+            "action": "store_true",
+            "default": False,
+            "help": "Enable tracemalloc allocation tracking in the memory profiler; logs top allocation sites (adds overhead, implies --memory-profile)",
+        },
+    ],
+    [
         ("--enable-all-protocol-changes",),
         {
             "action": "store_true",

--- a/counterparty-core/counterpartycore/lib/cli/server.py
+++ b/counterparty-core/counterpartycore/lib/cli/server.py
@@ -155,7 +155,7 @@ class CounterpartyServer(threading.Thread):
         if getattr(config, "MEMORY_PROFILE", False):
             self.mem_profiler = memory_profiler.start_memory_profiler(
                 interval_seconds=60,
-                enable_tracemalloc=False,
+                enable_tracemalloc=getattr(config, "MEMORY_PROFILE_TRACEMALLOC", False),
             )
 
         # download bootstrap if necessary

--- a/counterparty-core/counterpartycore/lib/monitors/memory_profiler.py
+++ b/counterparty-core/counterpartycore/lib/monitors/memory_profiler.py
@@ -18,6 +18,7 @@ import tracemalloc
 
 from counterpartycore.lib import config
 from counterpartycore.lib.api.blockcache import BLOCK_CACHE
+from counterpartycore.lib.backend import bitcoind
 from counterpartycore.lib.ledger.caches import AssetCache, OrdersCache, UTXOBalancesCache
 from counterpartycore.lib.parser.follow import NotSupportedTransactionsCache
 from counterpartycore.lib.utils import helpers
@@ -179,6 +180,24 @@ def get_cache_sizes():
         sizes["BLOCK_CACHE_bytes"] = total_size
     except RuntimeError:
         sizes["BLOCK_CACHE_bytes"] = "skipped"
+
+    # Backend module-level caches (lib/backend/bitcoind.py)
+    sizes["bitcoind.TRANSACTIONS_CACHE"] = len(bitcoind.TRANSACTIONS_CACHE)
+    sizes["bitcoind.TRANSACTIONS_CACHE_MB"] = estimate_dict_memory(bitcoind.TRANSACTIONS_CACHE) / (
+        1024 * 1024
+    )
+    sizes["bitcoind.BLOCKS_CACHE"] = len(bitcoind.BLOCKS_CACHE)
+    sizes["bitcoind.BLOCKS_CACHE_MB"] = estimate_dict_memory(bitcoind.BLOCKS_CACHE) / (1024 * 1024)
+
+    # functools.lru_cache wrappers (entry counts only; payload sizes are not
+    # directly measurable). Test fixtures monkey-patch these with plain
+    # functions, so guard with hasattr.
+    if hasattr(bitcoind.getrawtransaction, "cache_info"):
+        sizes["bitcoind.getrawtransaction_lru"] = bitcoind.getrawtransaction.cache_info().currsize
+    if hasattr(bitcoind.get_utxo_address_and_value, "cache_info"):
+        sizes["bitcoind.get_utxo_address_and_value_lru"] = (
+            bitcoind.get_utxo_address_and_value.cache_info().currsize
+        )
 
     # Connection pool sizes
     # pylint: disable=protected-access

--- a/counterparty-core/counterpartycore/lib/parser/follow.py
+++ b/counterparty-core/counterpartycore/lib/parser/follow.py
@@ -537,10 +537,18 @@ class RawMempoolParser(threading.Thread):
 
 
 class NotSupportedTransactionsCache(metaclass=helpers.SingletonMeta):
+    # Maximum number of tx hashes kept in memory and on disk. The cache only
+    # needs to cover transactions that may still reappear in the mempool;
+    # evicting a hash early is harmless (the tx is just re-parsed and
+    # re-added the next time it is seen), while an unbounded cache grows by
+    # every non-Counterparty transaction on the network (~50-120MB/day on
+    # mainnet) and is persisted across restarts, so it never resets.
+    MAX_SIZE = 1_000_000
+
     def __init__(self):
         # Use set for O(1) lookups instead of O(n) list
         self.not_suppported_txs = set()
-        # Keep a list for ordering (for backup/restore)
+        # Keep a list for ordering (for backup/restore and FIFO eviction)
         self._ordered_txs = []
         self.cache_path = os.path.join(
             config.CACHE_DIR, f"not_supported_tx_cache.{config.NETWORK_NAME}.txt"
@@ -550,15 +558,30 @@ class NotSupportedTransactionsCache(metaclass=helpers.SingletonMeta):
     def restore(self):
         if os.path.exists(self.cache_path):
             with open(self.cache_path, "r", encoding="utf-8") as f:
-                self._ordered_txs = [line.strip() for line in f]
-                self.not_suppported_txs = set(self._ordered_txs)
+                lines = [stripped for line in f if (stripped := line.strip())]
+            # Deduplicate (the file is append-only between compactions),
+            # keeping the most recent occurrence, then keep only the last
+            # MAX_SIZE entries.
+            seen = set()
+            deduped_reversed = []
+            for tx_hash in reversed(lines):
+                if tx_hash not in seen:
+                    seen.add(tx_hash)
+                    deduped_reversed.append(tx_hash)
+            deduped_reversed.reverse()
+            self._ordered_txs = deduped_reversed[-self.MAX_SIZE :]
+            self.not_suppported_txs = set(self._ordered_txs)
+            # Rewrite once at startup: compacts the file and guarantees the
+            # trailing-newline format that add() relies on when appending
+            # (legacy files were written without a trailing newline).
+            self.backup()
             logger.debug(
                 "Restored %d not supported transactions from cache", len(self.not_suppported_txs)
             )
 
     def backup(self):
         with open(self.cache_path, "w", encoding="utf-8") as f:
-            f.write("\n".join(self._ordered_txs))
+            f.writelines(tx_hash + "\n" for tx_hash in self._ordered_txs)
         logger.trace(
             f"Backed up {len(self.not_suppported_txs)} not supported transactions to cache"
         )
@@ -570,11 +593,25 @@ class NotSupportedTransactionsCache(metaclass=helpers.SingletonMeta):
             os.remove(self.cache_path)
 
     def add(self, more_not_supported_txs):
+        new_txs = []
         for tx in more_not_supported_txs:
             if tx not in self.not_suppported_txs:
                 self.not_suppported_txs.add(tx)
                 self._ordered_txs.append(tx)
-        self.backup()
+                new_txs.append(tx)
+        if not new_txs:
+            return
+        if len(self._ordered_txs) > self.MAX_SIZE:
+            # Evict oldest entries and compact the file.
+            evicted = self._ordered_txs[: -self.MAX_SIZE]
+            self._ordered_txs = self._ordered_txs[-self.MAX_SIZE :]
+            for tx_hash in evicted:
+                self.not_suppported_txs.discard(tx_hash)
+            self.backup()
+        else:
+            # Append only the new hashes instead of rewriting the whole file.
+            with open(self.cache_path, "a", encoding="utf-8") as f:
+                f.writelines(tx_hash + "\n" for tx_hash in new_txs)
 
     def is_not_supported(self, tx_hash):
         return tx_hash in self.not_suppported_txs

--- a/counterparty-core/counterpartycore/test/units/cli/main_test.py
+++ b/counterparty-core/counterpartycore/test/units/cli/main_test.py
@@ -133,6 +133,7 @@ def test_argparser():
         "api_only": False,
         "profile": False,
         "memory_profile": False,
+        "memory_profile_tracemalloc": False,
         "enable_all_protocol_changes": False,
     }
 

--- a/counterparty-core/counterpartycore/test/units/parser/follow_test.py
+++ b/counterparty-core/counterpartycore/test/units/parser/follow_test.py
@@ -868,6 +868,63 @@ class TestNotSupportedTransactionsCache:
         assert "tx1" in cache.not_suppported_txs
         assert "tx2" in cache.not_suppported_txs
 
+    def test_max_size_eviction(self, reset_not_supported_cache, temp_cache_dir, monkeypatch):
+        """Test oldest entries are evicted when MAX_SIZE is exceeded"""
+        monkeypatch.setattr(follow.NotSupportedTransactionsCache, "MAX_SIZE", 3)
+        cache = follow.NotSupportedTransactionsCache()
+
+        cache.add(["tx1", "tx2", "tx3"])
+        cache.add(["tx4", "tx5"])
+
+        assert cache._ordered_txs == ["tx3", "tx4", "tx5"]
+        assert cache.not_suppported_txs == {"tx3", "tx4", "tx5"}
+        assert cache.is_not_supported("tx1") is False
+
+        # The compacted file matches the in-memory state
+        cache_path = os.path.join(temp_cache_dir, "not_supported_tx_cache.regtest.txt")
+        with open(cache_path, "r", encoding="utf-8") as f:
+            assert [line.strip() for line in f] == ["tx3", "tx4", "tx5"]
+
+    def test_restore_trims_to_max_size(
+        self, reset_not_supported_cache, temp_cache_dir, monkeypatch
+    ):
+        """Test restore keeps only the most recent MAX_SIZE entries"""
+        monkeypatch.setattr(follow.NotSupportedTransactionsCache, "MAX_SIZE", 2)
+        cache_path = os.path.join(temp_cache_dir, "not_supported_tx_cache.regtest.txt")
+        with open(cache_path, "w", encoding="utf-8") as f:
+            f.write("tx1\ntx2\ntx3\n")
+
+        cache = follow.NotSupportedTransactionsCache()
+
+        assert cache._ordered_txs == ["tx2", "tx3"]
+        # The oversized file is compacted on restore
+        with open(cache_path, "r", encoding="utf-8") as f:
+            assert [line.strip() for line in f] == ["tx2", "tx3"]
+
+    def test_add_appends_to_legacy_file(self, reset_not_supported_cache, temp_cache_dir):
+        """Test appending after restoring a legacy file without trailing newline"""
+        cache_path = os.path.join(temp_cache_dir, "not_supported_tx_cache.regtest.txt")
+        with open(cache_path, "w", encoding="utf-8") as f:
+            f.write("tx1\ntx2")  # legacy format: no trailing newline
+
+        cache = follow.NotSupportedTransactionsCache()
+        cache.add(["tx3"])
+
+        with open(cache_path, "r", encoding="utf-8") as f:
+            assert [line.strip() for line in f] == ["tx1", "tx2", "tx3"]
+
+    def test_persistence_across_restart(self, reset_not_supported_cache, temp_cache_dir):
+        """Test appended entries survive a singleton reset (process restart)"""
+        cache = follow.NotSupportedTransactionsCache()
+        cache.add(["tx1", "tx2"])
+        cache.add(["tx3"])
+
+        del helpers.SingletonMeta._instances[follow.NotSupportedTransactionsCache]
+        restored = follow.NotSupportedTransactionsCache()
+
+        assert restored._ordered_txs == ["tx1", "tx2", "tx3"]
+        assert restored.not_suppported_txs == {"tx1", "tx2", "tx3"}
+
 
 # ============================================================================
 # Tests for receive_multipart (using asyncio.run)


### PR DESCRIPTION
## Summary

Follow-up to #3396 (counterparty-server reaching ~12 GiB on mainnet). Three changes:

### 1. Bound `NotSupportedTransactionsCache` (fixes a real leak)

Measured on mainnet v11.1.0: **1.93M entries (~270MB), growing ~600 hashes/min** — every non-Counterparty transaction on the network — and persisted across restarts, so it never resets (~50-120MB/day, GBs within months). The cache is now capped at 1M entries with FIFO eviction. Early eviction is harmless: the transaction is simply re-parsed and re-added if it reappears in the mempool.

Bonus fix: `add()` previously rewrote the entire backing file (~125MB at current mainnet size) on every batch. It now appends new hashes and only rewrites on eviction and once at startup (which also compacts legacy files written without a trailing newline).

### 2. `--memory-profile-tracemalloc` flag

The profiler supports tracemalloc allocation-site logging but it was hardcoded off (`enable_tracemalloc=False` in both `cli/server.py` and `api/apiserver.py`). On our mainnet pods the API process reaches 5.5GB RSS while tracked caches explain only ~280MB — without tracemalloc the rest is invisible. The flag implies `--memory-profile`; defaults are unchanged.

### 3. Profiler blind spots

`backend/bitcoind.py`'s module-level `TRANSACTIONS_CACHE`/`BLOCKS_CACHE` and the `getrawtransaction`/`get_utxo_address_and_value` `lru_cache`s are now included in the periodic cache report.

## Testing

- New unit tests for eviction, restore-trimming, legacy-file append compatibility, and persistence across restart.
- `pytest counterpartycore/test/units/cli counterpartycore/test/units/parser/follow_test.py counterpartycore/test/units/api`: 428 passed.
- `ruff check` / `ruff format`: clean.