### PR TITLE
Add regression coverage for destroy string tags

### DIFF
--- a/counterparty-core/counterpartycore/test/units/messages/destroy_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/destroy_test.py
@@ -49,6 +49,12 @@ def test_compose(ledger_db, defaults):
         b"n\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01WASTE",
     )
 
+    assert destroy.compose(ledger_db, defaults["addresses"][0], "XCP", 1, "WASTE") == (
+        defaults["addresses"][0],
+        [],
+        b"n\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01WASTE",
+    )
+
     assert destroy.compose(ledger_db, defaults["addresses"][0], "XCP", 1, b"WASTEEEEE") == (
         defaults["addresses"][0],
         [],


### PR DESCRIPTION
### What changed

- Adds a regression assertion that `destroy.compose` accepts a string `tag` and encodes it into the destroy message payload.
- Covers the user-facing `tag=test` shape from #1066 so the old `argument for s must be a bytes object` path stays fixed.

Closes #1066.

### Verification

- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m pytest counterpartycore/test/units/messages/destroy_test.py::test_compose -q`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m pytest counterpartycore/test/units/messages/destroy_test.py -q`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m ruff check counterpartycore/test/units/messages/destroy_test.py`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m ruff format --check counterpartycore/test/units/messages/destroy_test.py`
- `git diff --check`

### Payout

If this qualifies for a contributor or bug-fix reward, please send BTC to:

`bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
