### PR TITLE
Skip oracle fees when closing dispensers

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/dispenser.py
+++ b/counterparty-core/counterpartycore/lib/messages/dispenser.py
@@ -253,7 +253,12 @@ def compose(
     oracle_address: str = None,
     skip_validation: bool = False,
 ):
-    if oracle_address is not None and len(address.pack(oracle_address)) > 22:
+    is_oracle_fee_status = status in [STATUS_OPEN, STATUS_OPEN_EMPTY_ADDRESS]
+    if (
+        oracle_address is not None
+        and is_oracle_fee_status
+        and len(address.pack(oracle_address)) > 22
+    ):
         raise exceptions.ComposeError("Oracle address not supported by dispenser")
 
     asset_id, problems = validate(
@@ -283,7 +288,11 @@ def compose(
         and open_address != source
     ):
         data += address_pack(open_address)
-    if oracle_address is not None and protocol.enabled("oracle_dispensers"):
+    if (
+        oracle_address is not None
+        and is_oracle_fee_status
+        and protocol.enabled("oracle_dispensers")
+    ):
         oracle_fee = calculate_oracle_fee(
             db,
             escrow_quantity,

--- a/counterparty-core/counterpartycore/test/units/messages/dispenser_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/dispenser_test.py
@@ -254,6 +254,50 @@ def test_compose_with_oracle(ledger_db, defaults, monkeypatch):
         )
 
 
+def test_compose_close_ignores_oracle_fee(ledger_db, defaults, monkeypatch):
+    def fail_calculate_oracle_fee(*args):
+        raise AssertionError("close dispenser should not calculate oracle fee")
+
+    monkeypatch.setattr(dispenser, "calculate_oracle_fee", fail_calculate_oracle_fee)
+
+    assert dispenser.compose(
+        ledger_db,
+        defaults["addresses"][5],
+        config.XCP,
+        0,
+        0,
+        0,
+        dispenser.STATUS_CLOSED,
+        None,
+        defaults["addresses"][1],
+        True,
+    ) == (
+        defaults["addresses"][5],
+        [],
+        b"\x0c\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\n",
+    )
+
+
+def test_validate_close_with_oracle_keeps_price_check(ledger_db, defaults, current_block_index):
+    assert dispenser.validate(
+        ledger_db,
+        defaults["addresses"][5],
+        config.XCP,
+        0,
+        0,
+        0,
+        dispenser.STATUS_CLOSED,
+        None,
+        current_block_index,
+        defaults["addresses"][1],
+    ) == (
+        None,
+        [
+            f"The oracle address {defaults['addresses'][1]} has not broadcasted any price yet",
+        ],
+    )
+
+
 def test_parse_open_dispenser(
     ledger_db, blockchain_mock, defaults, test_helpers, current_block_index
 ):


### PR DESCRIPTION
### What changed

- Stops dispenser close composition from adding oracle fee outputs when an API caller passes `oracle_address`.
- Keeps the consensus-relevant `validate()` / parse path unchanged: closes that encode an oracle address still require an oracle price unless validation is explicitly skipped by the composing caller.
- Adds regression coverage for both paths:
  - compose close with `skip_validation=True` does not calculate or add an oracle fee
  - validate close with an oracle address still reports the existing missing-price error

Closes #1271.

### Review context

This update addresses the blocker raised on the older `master` PR #3341 by dropping the `validate()` behavior change and keeping only the wallet/API compose-side fix.

### Verification

- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m pytest counterpartycore/test/units/messages/dispenser_test.py::test_compose_close_ignores_oracle_fee counterpartycore/test/units/messages/dispenser_test.py::test_validate_close_with_oracle_keeps_price_check -q`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m pytest counterpartycore/test/units/messages/dispenser_test.py counterpartycore/test/units/api/compose_test.py::test_compose_dispenser -q`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m ruff check counterpartycore/lib/messages/dispenser.py counterpartycore/test/units/messages/dispenser_test.py`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m ruff format --check counterpartycore/lib/messages/dispenser.py counterpartycore/test/units/messages/dispenser_test.py`
- `git diff --check`

### Payout

If this qualifies for a contributor or bug-fix reward, please send BTC to:

`bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
