### PR TITLE
Encode MPMA text memo lengths as bytes

### DIFF
--- a/counterparty-core/counterpartycore/lib/utils/mpmaencoding.py
+++ b/counterparty-core/counterpartycore/lib/utils/mpmaencoding.py
@@ -56,9 +56,10 @@ def _encode_memo(memo=None, is_hex=False):
             barr.append(memo)
         else:
             # signal a 0 bit for a string encoded memo
+            memo = memo.encode("utf-8")
             barr.append("0b0")
             barr.append(f"uint:6={len(memo)}")
-            barr.append(BitArray(memo.encode("utf-8")))
+            barr.append(BitArray(memo))
 
         return barr
     # if the memo is None, return just a 0 bit

--- a/counterparty-core/counterpartycore/test/units/messages/versions/mpma_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/versions/mpma_test.py
@@ -4,6 +4,7 @@ import re
 import pytest
 from counterpartycore.lib import config, exceptions, ledger
 from counterpartycore.lib.messages.versions import mpma
+from counterpartycore.lib.utils.mpmaencoding import _decode_mpma_send_decode, _encode_mpma_send
 
 
 def test_unpack(defaults, current_block_index):
@@ -150,6 +151,26 @@ def test_unpack(defaults, current_block_index):
         "PEPEKFC": [("172nmZbxDR6erc5PqNqV28fnMj7g6besru", 5)],
         "PEPEWYATT": [("172nmZbxDR6erc5PqNqV28fnMj7g6besru", 5)],
         "XCHAINPEPE": [("172nmZbxDR6erc5PqNqV28fnMj7g6besru", 1)],
+    }
+
+
+def test_utf8_memo_roundtrip(defaults, monkeypatch):
+    monkeypatch.setattr(ledger.issuances, "resolve_subasset_longname", lambda db, asset: asset)
+    monkeypatch.setattr(ledger.issuances, "get_asset_id", lambda db, asset: 1)
+
+    payload = _encode_mpma_send(
+        None,
+        [
+            ("XCP", defaults["addresses"][1], 1, "∞", False),
+            ("XCP", defaults["addresses"][2], 2),
+        ],
+    )
+
+    assert _decode_mpma_send_decode(payload) == {
+        "XCP": [
+            (defaults["addresses"][1], 1, "∞", False),
+            (defaults["addresses"][2], 2),
+        ]
     }
 
 


### PR DESCRIPTION
### What changed

- Encodes non-hex MPMA memo text once to UTF-8 bytes before writing the memo length.
- Makes the length prefix match the actual byte payload, so multi-byte characters like `∞` round-trip instead of causing a UTF-8 decode error.
- Adds regression coverage for an MPMA memo containing `∞`.

Closes #1248.

### Verification

- Reproduced the original failure locally: MPMA payload with `∞` raised `UnicodeDecodeError`.
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m pytest counterpartycore/test/units/messages/versions/mpma_test.py::test_utf8_memo_roundtrip -q`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m pytest counterpartycore/test/units/messages/versions/mpma_test.py -q`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m ruff check counterpartycore/lib/utils/mpmaencoding.py counterpartycore/test/units/messages/versions/mpma_test.py`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m ruff format --check counterpartycore/lib/utils/mpmaencoding.py counterpartycore/test/units/messages/versions/mpma_test.py`
- `git diff --check`

### Payout

If this qualifies for a contributor or bug-fix reward, please send BTC to:

`bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
