### PR TITLE
Clarify BTC dividend dust errors

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/dividend.py
+++ b/counterparty-core/counterpartycore/lib/messages/dividend.py
@@ -72,6 +72,7 @@ def validate(db, source, quantity_per_unit, asset, dividend_asset, block_index):
     outputs = []
     addresses = []
     dividend_total = 0
+    btc_dust_outputs_skipped = False
     for holder in asset_holders:
         if (
             not protocol.enabled("price_as_fraction") and not protocol.is_test_network()
@@ -94,6 +95,7 @@ def validate(db, source, quantity_per_unit, asset, dividend_asset, block_index):
             dividend_quantity /= config.UNIT  # Pre-fix behaviour
 
         if dividend_asset == config.BTC and dividend_quantity < config.DEFAULT_MULTISIG_DUST_SIZE:
+            btc_dust_outputs_skipped = True
             continue  # A bit hackish.
         dividend_quantity = int(dividend_quantity)
 
@@ -108,7 +110,10 @@ def validate(db, source, quantity_per_unit, asset, dividend_asset, block_index):
         dividend_total += dividend_quantity
 
     if not dividend_total:
-        problems.append("zero dividend")
+        if dividend_asset == config.BTC and btc_dust_outputs_skipped:
+            problems.append("BTC dividend output below dust threshold")
+        else:
+            problems.append("zero dividend")
 
     if dividend_asset != config.BTC:
         dividend_balances = ledger.balances.get_balance(db, source, dividend_asset)

--- a/counterparty-core/counterpartycore/test/units/messages/dividend_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/dividend_test.py
@@ -1,4 +1,5 @@
-from counterpartycore.lib import ledger
+import pytest
+from counterpartycore.lib import exceptions, ledger
 from counterpartycore.lib.messages import dividend
 
 
@@ -57,6 +58,10 @@ def test_validate(ledger_db, defaults, current_block_index):
     ) == (None, None, ["non‐positive quantity per unit", "zero dividend"], 0)
 
     assert dividend.validate(
+        ledger_db, defaults["addresses"][0], 1, "DIVISIBLE", "BTC", current_block_index
+    ) == (None, None, ["BTC dividend output below dust threshold"], 0)
+
+    assert dividend.validate(
         ledger_db,
         defaults["addresses"][1],
         defaults["quantity"],
@@ -111,6 +116,9 @@ def test_compose(ledger_db, defaults):
         [],
         b'2\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\xa2[\xe3Kf\x01S\x08"\x06\xe4c%',
     )
+
+    with pytest.raises(exceptions.ComposeError, match="BTC dividend output below dust threshold"):
+        dividend.compose(ledger_db, defaults["addresses"][0], 1, "DIVISIBLE", "BTC")
 
 
 def test_parse_dividend(ledger_db, blockchain_mock, defaults, test_helpers, current_block_index):


### PR DESCRIPTION
### What changed
- Tracks when every candidate BTC dividend output is skipped because it is below the dust threshold.
- Reports `BTC dividend output below dust threshold` instead of the generic `zero dividend` message in that case.
- Adds unit coverage for both `validate()` and `compose()` so the user-facing compose/API path keeps the clearer error.

This is the `develop`-based version of #3347 for #958, so maintainers do not need to review the older `master`-based branch.

Closes #958.

### Verification
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m pytest counterpartycore/test/units/messages/dividend_test.py::test_validate counterpartycore/test/units/messages/dividend_test.py::test_compose -q`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/ruff format --check counterpartycore/lib/messages/dividend.py counterpartycore/test/units/messages/dividend_test.py`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/ruff check counterpartycore/lib/messages/dividend.py counterpartycore/test/units/messages/dividend_test.py`
- `git diff --check`

BTC payout address if this qualifies for a contributor/security reward: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
