### PR TITLE
Recover BTC-only transaction info without prevouts

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/compose.py
+++ b/counterparty-core/counterpartycore/lib/api/compose.py
@@ -12,7 +12,8 @@ from counterpartycore.lib.api import composer
 from counterpartycore.lib.ledger.currentstate import CurrentState
 from counterpartycore.lib.messages import gas
 from counterpartycore.lib.messages.attach import ID as UTXO_ID
-from counterpartycore.lib.parser import deserialize, gettxinfo, messagetype
+from counterpartycore.lib.parser import deserialize, gettxinfo, messagetype, p2sh
+from counterpartycore.lib.utils import script
 
 D = decimal.Decimal
 
@@ -667,6 +668,104 @@ def info_by_tx_hash(db, tx_hash: str):
     return info(db, rawtransaction)
 
 
+def _get_first_witness_stack(decoded_tx):
+    witness_stacks = decoded_tx.get("vtxinwit") or []
+    if len(witness_stacks) == 0:
+        return []
+    first_stack = witness_stacks[0]
+    if isinstance(first_stack, list | tuple):
+        return first_stack
+    return witness_stacks
+
+
+def _get_p2wpkh_source_from_witness(decoded_tx):
+    witness_stack = _get_first_witness_stack(decoded_tx)
+    if len(witness_stack) < 2:
+        return None
+
+    pubkey = witness_stack[-1]
+    if isinstance(pubkey, str):
+        try:
+            pubkey = binascii.unhexlify(pubkey)
+        except (binascii.Error, TypeError):
+            return None
+    if not isinstance(pubkey, bytes):
+        return None
+    if len(pubkey) not in (33, 65) or pubkey[0] not in (2, 3, 4):
+        return None
+
+    try:
+        return script.script_to_address(b"\x00\x14" + p2sh.hash160(pubkey))
+    except exceptions.DecodeError:
+        return None
+
+
+def _get_p2wpkh_source_from_script_sig(decoded_tx):
+    for vin in decoded_tx.get("vin", []):
+        script_sig = vin.get("script_sig")
+        if isinstance(script_sig, str):
+            try:
+                script_sig = binascii.unhexlify(script_sig)
+            except (binascii.Error, TypeError):
+                continue
+        if not isinstance(script_sig, bytes):
+            continue
+
+        if len(script_sig) == 22 and script_sig[0] == 0 and script_sig[1] == 20:
+            source_script = script_sig
+        elif (
+            len(script_sig) == 23
+            and script_sig[0] == 22
+            and script_sig[1] == 0
+            and script_sig[2] == 20
+        ):
+            source_script = script_sig[1:]
+        else:
+            continue
+
+        try:
+            return script.script_to_address(source_script)
+        except exceptions.DecodeError:
+            continue
+
+    return None
+
+
+def _get_p2wpkh_source_from_input(decoded_tx):
+    return _get_p2wpkh_source_from_script_sig(decoded_tx) or _get_p2wpkh_source_from_witness(
+        decoded_tx
+    )
+
+
+def _get_btc_only_info_from_decoded_tx(decoded_tx):
+    source = _get_p2wpkh_source_from_input(decoded_tx)
+    addressable_outputs = []
+
+    for vout in decoded_tx.get("vout", []):
+        script_pub_key = vout.get("script_pub_key")
+        if not script_pub_key:
+            continue
+        try:
+            address = script.script_to_address(script_pub_key)
+        except exceptions.DecodeError:
+            continue
+        addressable_outputs.append((address, vout.get("value")))
+
+    if len(addressable_outputs) == 0:
+        return source, None, None, None, None
+
+    payment_outputs = [
+        (address, value)
+        for address, value in addressable_outputs
+        if source is None or address != source
+    ]
+    if len(payment_outputs) == 0:
+        payment_outputs = addressable_outputs
+
+    destination, btc_amount = payment_outputs[0]
+    return source, destination, btc_amount, None, None
+
+
 def info(db, rawtransaction: str, block_index: int = None):
     """
     Returns Counterparty information from a raw transaction in hex format.
@@ -691,7 +790,7 @@ def info(db, rawtransaction: str, block_index: int = None):
             )
         )
     except exceptions.BitcoindRPCError:
-        source, destination, btc_amount, fee, data = None, None, None, None, None
+        source, destination, btc_amount, fee, data = _get_btc_only_info_from_decoded_tx(decoded_tx)
 
     result = {
         "source": source,

--- a/counterparty-core/counterpartycore/test/units/api/compose_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/compose_test.py
@@ -2,6 +2,7 @@ import pytest
 from counterpartycore.lib import exceptions, ledger
 from counterpartycore.lib.api import compose
 from counterpartycore.lib.messages import pooldeposit
+from counterpartycore.lib.utils import script
 from counterpartycore.test.mocks.counterpartydbs import ProtocolChangesDisabled
 
 # ============================================================================
@@ -1695,3 +1696,31 @@ def test_info_rawtransaction_without_data(apiv2_client):
     result = apiv2_client.get(f"/v2/transactions/info?rawtransaction={simple_tx}")
     # This should parse but return None for data
     assert result.status_code in [200, 400]
+
+
+def test_info_btc_only_rawtransaction_without_prevout(ledger_db, monkeypatch):
+    """BTC-only raw transactions should still expose output info if prevouts are unavailable."""
+    rawtransaction = (
+        "02000000000101bfbeaeb997dcc7b5038687e03b378ed69dd708629a13f915c9bed670f6fc83f3"
+        "01000000160014dfc964bf32517b3ca8fea9227c5756c887e911c3ffffffff02e80300000000"
+        "00001600146fe470998ced5d0f475546787d5cfefdfb7365b7d547000000000000160014df"
+        "c964bf32517b3ca8fea9227c5756c887e911c302000000000000"
+    )
+
+    def get_tx_info_raises(*args, **kwargs):
+        raise exceptions.BitcoindRPCError("prevout not available")
+
+    monkeypatch.setattr(compose.gettxinfo, "get_tx_info", get_tx_info_raises)
+
+    result = compose.info(ledger_db, rawtransaction, block_index=800000)
+
+    assert result["source"] == script.script_to_address(
+        "0014dfc964bf32517b3ca8fea9227c5756c887e911c3"
+    )
+    assert result["destination"] == script.script_to_address(
+        "00146fe470998ced5d0f475546787d5cfefdfb7365b7"
+    )
+    assert result["btc_amount"] == 1000
+    assert result["fee"] is None
+    assert result["data"] is None
+    assert result["unpacked_data"] is None


### PR DESCRIPTION
Fixes #2117.

This is a `develop`-based replacement for #3345.

When `/v2/transactions/info` receives a BTC-only raw transaction and bitcoind cannot provide the prevout, the current fallback clears `source`, `destination`, and `btc_amount` even though the decoded raw transaction can still expose useful address/output information.

This PR adds a narrow fallback for the `BitcoindRPCError` path that:
- derives P2WPKH sources from an input witness program or witness pubkey when available
- derives addressable outputs from the decoded vouts
- treats the first non-source output as the BTC payment output
- keeps `fee` and Counterparty `data` unset because the prevout value/data path is still unavailable

Added a regression test using the raw transaction from #2117.

Tests:
- `.venv/bin/python -m pytest counterpartycore/test/units/api/compose_test.py::test_info_btc_only_rawtransaction_without_prevout counterpartycore/test/units/api/compose_test.py -k info -q`
- `.venv/bin/python -m pytest counterpartycore/test/units/api/compose_test.py -q`
- `.venv/bin/python -m ruff format --check counterpartycore/lib/api/compose.py counterpartycore/test/units/api/compose_test.py`
- `.venv/bin/python -m ruff check counterpartycore/lib/api/compose.py counterpartycore/test/units/api/compose_test.py`
- `git diff --check`

BTC payout address if this qualifies for a contributor/security reward: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`