### PR TITLE
Add normalized market price field

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/verbose.py
+++ b/counterparty-core/counterpartycore/lib/api/verbose.py
@@ -401,13 +401,27 @@ def inject_normalized_quantities(result_list):
 
         if "get_quantity" in item and "give_quantity" in item and "market_dir" in item:
             if item["market_dir"] == "SELL":
-                item["market_price"] = helpers.divide(
+                market_price = helpers.divide(
                     item["get_quantity_normalized"], item["give_quantity_normalized"]
                 )
             else:
-                item["market_price"] = helpers.divide(
+                market_price = helpers.divide(
                     item["give_quantity_normalized"], item["get_quantity_normalized"]
                 )
+            item["market_price"] = market_price
+            item["market_price_normalized"] = market_price
+
+        if "forward_quantity" in item and "backward_quantity" in item and "market_dir" in item:
+            if item["market_dir"] == "SELL":
+                market_price = helpers.divide(
+                    item["backward_quantity_normalized"], item["forward_quantity_normalized"]
+                )
+            else:
+                market_price = helpers.divide(
+                    item["forward_quantity_normalized"], item["backward_quantity_normalized"]
+                )
+            item["market_price"] = market_price
+            item["market_price_normalized"] = market_price
 
         enriched_result_list.append(item)
 

--- a/counterparty-core/counterpartycore/test/units/api/verbose_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/verbose_test.py
@@ -23,6 +23,44 @@ def test_normalize_price_custom_precision():
     assert verbose.normalize_price("1.234567", precision=2) == "1.23"
 
 
+def test_inject_normalized_quantities_adds_market_price_normalized():
+    result = verbose.inject_normalized_quantities(
+        [
+            {
+                "give_quantity": 100000000,
+                "get_quantity": 50000000,
+                "give_asset_info": {"divisible": True},
+                "get_asset_info": {"divisible": True},
+                "market_dir": "SELL",
+            }
+        ]
+    )[0]
+
+    assert result["give_quantity_normalized"] == decimal.Decimal("1")
+    assert result["get_quantity_normalized"] == decimal.Decimal("0.5")
+    assert result["market_price_normalized"] == decimal.Decimal("0.5")
+    assert result["market_price"] == result["market_price_normalized"]
+
+
+def test_inject_normalized_quantities_adds_order_match_market_price_normalized():
+    result = verbose.inject_normalized_quantities(
+        [
+            {
+                "forward_quantity": 100000000,
+                "backward_quantity": 150,
+                "forward_asset_info": {"divisible": True},
+                "backward_asset_info": {"divisible": False},
+                "market_dir": "SELL",
+            }
+        ]
+    )[0]
+
+    assert result["forward_quantity_normalized"] == decimal.Decimal("1")
+    assert result["backward_quantity_normalized"] == "150"
+    assert result["market_price_normalized"] == decimal.Decimal("150")
+    assert result["market_price"] == result["market_price_normalized"]
+
+
 def test_normalize_price_does_not_leak_prec_to_caller_thread():
     """normalize_price must NOT mutate the thread-local Decimal precision
     of the caller; previously it called `decimal.getcontext().prec = 32`


### PR DESCRIPTION
Fixes #2152.

This is a `develop`-based replacement for #3361.

Changes:
- Add `market_price_normalized` to verbose order responses that already compute normalized `market_price`.
- Add the same normalized field for verbose order-match responses using `forward_quantity_normalized` and `backward_quantity_normalized`, including non-divisible asset cases.
- Keep the existing `market_price` field as a backward-compatible alias.

Tests:
- `.venv/bin/python -m pytest counterpartycore/test/units/api/verbose_test.py -q`
- `.venv/bin/python -m ruff check counterpartycore/lib/api/verbose.py counterpartycore/test/units/api/verbose_test.py`
- `.venv/bin/python -m ruff format --check counterpartycore/lib/api/verbose.py counterpartycore/test/units/api/verbose_test.py`
- `git diff --check`

BTC payout address if this qualifies for a contributor/security reward: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`