### PR TITLE
Add CLI flag to disable API cache

### DIFF
--- a/counterparty-core/counterpartycore/lib/cli/initialise.py
+++ b/counterparty-core/counterpartycore/lib/cli/initialise.py
@@ -96,6 +96,7 @@ def initialise_config(
     regtest=False,
     signet=False,
     api_limit_rows=1000,
+    disable_api_cache=False,
     backend_connect=None,
     backend_port=None,
     backend_user=None,
@@ -566,6 +567,7 @@ def initialise_config(
     config.PROFILE = profile
     config.MEMORY_PROFILE = memory_profile
     config.ENABLE_ALL_PROTOCOL_CHANGES = enable_all_protocol_changes
+    config.DISABLE_API_CACHE = disable_api_cache
 
 
 def initialise_log_and_config(args, api=False, log_stream=None):
@@ -577,6 +579,7 @@ def initialise_log_and_config(args, api=False, log_stream=None):
         "regtest": args.regtest,
         "signet": args.signet,
         "api_limit_rows": args.api_limit_rows,
+        "disable_api_cache": getattr(args, "disable_api_cache", False),
         "backend_connect": args.backend_connect,
         "backend_port": args.backend_port,
         "backend_user": args.backend_user,

--- a/counterparty-core/counterpartycore/lib/cli/main.py
+++ b/counterparty-core/counterpartycore/lib/cli/main.py
@@ -259,6 +259,10 @@ CONFIG_ARGS = [
     [("--data-dir",), {"default": None, "help": "the path to the data directory"}],
     [("--cache-dir",), {"default": None, "help": "the path to the cache directory"}],
     [
+        ("--disable-api-cache",),
+        {"action": "store_true", "default": False, "help": "disable the API response cache"},
+    ],
+    [
         ("--log-file",),
         {"nargs": "?", "const": None, "default": False, "help": "log to the specified file"},
     ],

--- a/counterparty-core/counterpartycore/test/units/cli/main_test.py
+++ b/counterparty-core/counterpartycore/test/units/cli/main_test.py
@@ -103,6 +103,7 @@ def test_argparser():
         "no_confirm": False,
         "data_dir": "datadir",
         "cache_dir": None,
+        "disable_api_cache": False,
         "log_file": False,
         "api_log_file": False,
         "no_log_files": False,
@@ -135,6 +136,13 @@ def test_argparser():
         "memory_profile": False,
         "enable_all_protocol_changes": False,
     }
+
+
+def test_argparser_disable_api_cache():
+    parser = cli.main.arg_parser(no_config_file=True, app_name="counterparty-test")
+    args = parser.parse_args(["--regtest", "--disable-api-cache", "start"])
+
+    assert vars(args)["disable_api_cache"] is True
 
 
 WELCOME_MSG_CONFIG_STUBS = [
@@ -216,6 +224,18 @@ def test_initialise_config_electrs_string_coerced_to_list(tmp_path, preserve_con
 
     assert config.ELECTRS_URLS == ["http://my-server:3000"]
     assert config.ELECTRS_URLS_IS_DEFAULT is False
+
+
+def test_initialise_config_disable_api_cache(tmp_path, preserve_config):
+    initialise.initialise_config(
+        disable_api_cache=True,
+        electrs_url=None,
+        data_dir=str(tmp_path),
+        cache_dir=str(tmp_path),
+        **INITIALISE_DEFAULTS,
+    )
+
+    assert config.DISABLE_API_CACHE is True
 
 
 def test_initialise_config_electrs_regtest_none(tmp_path, preserve_config):


### PR DESCRIPTION
Addresses #2783.

This is a `develop`-based replacement for #3363.

Summary:
- Add a `--disable-api-cache` CLI flag.
- Thread the flag through config initialization so it sets `config.DISABLE_API_CACHE`.
- Add CLI parsing and config initialization coverage.

Tests:
- `.venv/bin/python -m pytest counterpartycore/test/units/cli/main_test.py counterpartycore/test/units/api/apiserver_test.py::test_is_cachable -q`
- `.venv/bin/python -m ruff check counterpartycore/lib/cli/main.py counterpartycore/lib/cli/initialise.py counterpartycore/test/units/cli/main_test.py`
- `.venv/bin/python -m ruff format --check counterpartycore/lib/cli/main.py counterpartycore/lib/cli/initialise.py counterpartycore/test/units/cli/main_test.py`
- `git diff --check`

BTC payout address if this qualifies for a contributor/security reward: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`