### PR TITLE
Add dispenser origin routes

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/dbbuilder.py
+++ b/counterparty-core/counterpartycore/lib/api/dbbuilder.py
@@ -22,6 +22,7 @@ MIGRATIONS_AFTER_ROLLBACK = [
     "0011.create_orders_views",
     "0013.add_performance_indexes",
     "0014.add_pool_consolidated_tables",
+    "0015.add_dispenser_origin_index",
 ]
 
 ROLLBACKABLE_TABLES = [

--- a/counterparty-core/counterpartycore/lib/api/migrations/0015.add_dispenser_origin_index.py
+++ b/counterparty-core/counterpartycore/lib/api/migrations/0015.add_dispenser_origin_index.py
@@ -1,0 +1,18 @@
+#
+# file: counterpartycore/lib/api/migrations/0015.add_dispenser_origin_index.py
+#
+from yoyo import step
+
+__depends__ = {"0014.add_pool_consolidated_tables"}
+
+
+def apply(db):
+    db.execute("CREATE INDEX IF NOT EXISTS dispensers_origin_idx ON dispensers (origin)")
+
+
+def rollback(db):
+    db.execute("DROP INDEX IF EXISTS dispensers_origin_idx")
+
+
+if not __name__.startswith("apsw_"):
+    steps = [step(apply, rollback)]

--- a/counterparty-core/counterpartycore/lib/api/queries.py
+++ b/counterparty-core/counterpartycore/lib/api/queries.py
@@ -2528,6 +2528,40 @@ def get_dispensers_by_address(
     )
 
 
+def get_dispensers_by_origin(
+    state_db,
+    address: str,
+    status: DispenserStatus = "all",
+    exclude_with_oracle: bool = False,
+    cursor: int = None,
+    limit: int = 100,
+    offset: int = None,
+    sort: str = None,
+):
+    """
+    Returns the dispensers whose origin is an address
+    :param str address: The dispenser origin address to return (e.g. $ADDRESS_1)
+    :param str status: The status of the dispensers to return
+    :param bool exclude_with_oracle: Whether to exclude dispensers with an oracle
+    :param int cursor: The last index of the dispensers to return
+    :param int limit: The maximum number of dispensers to return (e.g. 5)
+    :param int offset: The number of lines to skip before returning results (overrides the `cursor` parameter)
+    :param str sort: The sort order of the dispensers to return (overrides the `cursor` parameter) (e.g. give_quantity:desc)
+    """
+    return select_rows(
+        state_db,
+        "dispensers",
+        where=prepare_dispenser_where(
+            status, {"origin": address}, exclude_with_oracle=exclude_with_oracle
+        ),
+        last_cursor=cursor,
+        limit=limit,
+        offset=offset,
+        sort=sort,
+        select=SELECT_DISPENSERS,
+    )
+
+
 def get_dispensers_by_asset(
     state_db,
     asset: str,

--- a/counterparty-core/counterpartycore/lib/api/routes.py
+++ b/counterparty-core/counterpartycore/lib/api/routes.py
@@ -102,6 +102,14 @@ ALL_ROUTES = {
         "addresses",
     ),
     "/v2/addresses/<address>/dispensers": (queries.get_dispensers_by_address, "addresses"),
+    "/v2/addresses/<address>/dispensers/source": (
+        queries.get_dispensers_by_address,
+        "addresses",
+    ),
+    "/v2/addresses/<address>/dispensers/origin": (
+        queries.get_dispensers_by_origin,
+        "addresses",
+    ),
     "/v2/addresses/<address>/dispensers/<asset>": (
         queries.get_dispenser_by_address_and_asset,
         "addresses",

--- a/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
@@ -206,6 +206,55 @@ def test_new_get_asset_info(apiv2_client):
     }
 
 
+def test_get_address_dispensers_by_source_and_origin(state_db, apiv2_client, defaults):
+    source_address = defaults["addresses"][0]
+    origin_address = defaults["addresses"][1]
+    state_db.execute(
+        "INSERT INTO assets_info (asset, divisible) VALUES (?, ?)",
+        ("ORIGINAPI", False),
+    )
+    for tx_index, tx_hash, source, origin in [
+        (9201, "f" * 64, source_address, origin_address),
+        (9202, "1" * 64, origin_address, origin_address),
+        (9203, "2" * 64, source_address, defaults["addresses"][2]),
+    ]:
+        state_db.execute(
+            """
+            INSERT INTO dispensers (
+                tx_index, tx_hash, block_index, source, asset, give_quantity,
+                escrow_quantity, satoshirate, status, give_remaining, origin,
+                dispense_count
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                tx_index,
+                tx_hash,
+                tx_index,
+                source,
+                "ORIGINAPI",
+                1,
+                1,
+                100,
+                0,
+                1,
+                origin,
+                0,
+            ),
+        )
+
+    source_response = apiv2_client.get(
+        f"/v2/addresses/{source_address}/dispensers/source?sort=block_index:asc"
+    )
+    origin_response = apiv2_client.get(
+        f"/v2/addresses/{origin_address}/dispensers/origin?sort=block_index:asc"
+    )
+
+    assert source_response.status_code == 200
+    assert origin_response.status_code == 200
+    assert [row["tx_hash"] for row in source_response.json["result"]] == ["f" * 64, "2" * 64]
+    assert [row["tx_hash"] for row in origin_response.json["result"]] == ["f" * 64, "1" * 64]
+
+
 def test_get_asset_by_longname_case_insensitive(state_db, apiv2_client):
     """Test that asset lookup by longname is case-insensitive (uses COLLATE NOCASE)."""
     # Insert a test asset with mixed-case longname directly into state_db

--- a/counterparty-core/counterpartycore/test/units/api/dbbuilder_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/dbbuilder_test.py
@@ -245,6 +245,19 @@ def test_migration_0013_rollback(state_db):
         assert index_exists(state_db, idx), f"Index {idx} should exist after re-apply"
 
 
+def test_migration_0015_rollback(state_db):
+    """Test rollback of 0015.add_dispenser_origin_index migration."""
+    assert index_exists(state_db, "dispensers_origin_idx")
+
+    dbbuilder.rollback_migration(state_db, "0015.add_dispenser_origin_index")
+
+    assert not index_exists(state_db, "dispensers_origin_idx")
+
+    dbbuilder.apply_migration(state_db, "0015.add_dispenser_origin_index")
+
+    assert index_exists(state_db, "dispensers_origin_idx")
+
+
 # =============================================================================
 # Tests for consolidated tables
 # =============================================================================

--- a/counterparty-core/counterpartycore/test/units/api/queries_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/queries_test.py
@@ -694,6 +694,52 @@ def test_get_dispensers_by_asset_prices_divisible_lots(state_db):
     assert [row["price"] for row in result.result] == [6172.5, 12345]
 
 
+def test_get_dispensers_by_origin_filters_origin_address(state_db):
+    """Test get_dispensers_by_origin returns dispensers created by an origin address."""
+    state_db.execute(
+        "INSERT INTO assets_info (asset, divisible) VALUES (?, ?)",
+        ("ORIGINFILTER", False),
+    )
+    for tx_index, tx_hash, source, origin in [
+        (9101, "c" * 64, "source1", "origin1"),
+        (9102, "d" * 64, "source2", "origin1"),
+        (9103, "e" * 64, "source3", "origin2"),
+    ]:
+        state_db.execute(
+            """
+            INSERT INTO dispensers (
+                tx_index, tx_hash, block_index, source, asset, give_quantity,
+                escrow_quantity, satoshirate, status, give_remaining, origin,
+                dispense_count
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                tx_index,
+                tx_hash,
+                tx_index,
+                source,
+                "ORIGINFILTER",
+                1,
+                1,
+                100,
+                0,
+                1,
+                origin,
+                0,
+            ),
+        )
+
+    result = queries.get_dispensers_by_origin(
+        state_db,
+        "origin1",
+        status="open",
+        sort="block_index:asc",
+    )
+
+    assert [row["source"] for row in result.result] == ["source1", "source2"]
+    assert [row["origin"] for row in result.result] == ["origin1", "origin1"]
+
+
 # =============================================================================
 # Tests for assets
 # =============================================================================


### PR DESCRIPTION
Addresses #2734.

This is a `develop`-based replacement for #3364.

Summary:
- Add `/v2/addresses/<address>/dispensers/source` as an explicit source-address dispenser route.
- Add `/v2/addresses/<address>/dispensers/origin` to return dispensers created by an origin address.
- Add an `origin` index for dispenser lookups and include rollback coverage.
- Add API route and query coverage for source-vs-origin filtering.

Tests:
- `.venv/bin/python -m pytest counterpartycore/test/units/api/apiserver_test.py::test_get_address_dispensers_by_source_and_origin counterpartycore/test/units/api/queries_test.py::test_get_dispensers_by_origin_filters_origin_address counterpartycore/test/units/api/dbbuilder_test.py::test_migration_0015_rollback -q`
- `.venv/bin/python -m pytest counterpartycore/test/units/api/apiserver_test.py counterpartycore/test/units/api/queries_test.py counterpartycore/test/units/api/dbbuilder_test.py -q`
- `.venv/bin/python -m ruff check counterpartycore/lib/api/dbbuilder.py counterpartycore/lib/api/migrations/0015.add_dispenser_origin_index.py counterpartycore/lib/api/queries.py counterpartycore/lib/api/routes.py counterpartycore/test/units/api/apiserver_test.py counterpartycore/test/units/api/dbbuilder_test.py counterpartycore/test/units/api/queries_test.py`
- `.venv/bin/python -m ruff format --check counterpartycore/lib/api/dbbuilder.py counterpartycore/lib/api/migrations/0015.add_dispenser_origin_index.py counterpartycore/lib/api/queries.py counterpartycore/lib/api/routes.py counterpartycore/test/units/api/apiserver_test.py counterpartycore/test/units/api/dbbuilder_test.py counterpartycore/test/units/api/queries_test.py`
- `git diff --check`

BTC payout address if this qualifies for a contributor/security reward: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`