### PR TITLE
Reject unknown v2 API parameters

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/apiserver.py
+++ b/counterparty-core/counterpartycore/lib/api/apiserver.py
@@ -177,6 +177,12 @@ def return_result(
 
 def prepare_args(route, **kwargs):
     function_args = dict(kwargs)
+    request_params = query_params()
+    allowed_args = {arg["name"] for arg in route["args"]}
+    unknown_args = sorted(set(request_params) - allowed_args)
+    if unknown_args:
+        raise ValueError(f"Unrecognized parameter(s): {', '.join(unknown_args)}")
+
     # inject args from request.args
     for arg in route["args"]:
         arg_name = arg["name"]
@@ -185,7 +191,7 @@ def prepare_args(route, **kwargs):
         if arg_name in function_args:
             continue
 
-        str_arg = query_params().get(arg_name)
+        str_arg = request_params.get(arg_name)
         if str_arg is not None and isinstance(str_arg, str) and str_arg.lower() in ["none", "null"]:
             str_arg = None
         if str_arg is None and arg["required"]:

--- a/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
@@ -413,6 +413,20 @@ def test_get_transactions(apiv2_client, monkeypatch):
     assert result[0]["unpacked_data"]["error"] == "Could not unpack data"
 
 
+def test_rejects_unknown_query_parameters(apiv2_client):
+    response = apiv2_client.get("/v2/transactions?limit=1&unknown_param=1&another_bad=2")
+
+    assert response.status_code == 400
+    assert response.json["error"] == "Unrecognized parameter(s): another_bad, unknown_param"
+
+
+def test_verbose_query_parameter_is_still_allowed(apiv2_client):
+    response = apiv2_client.get("/v2/transactions?limit=1&verbose=true")
+
+    assert response.status_code == 200
+    assert "unpacked_data" in response.json["result"][0]
+
+
 def test_get_all_transactions_verbose(apiv2_client):
     url = "/v2/transactions?verbose=true&show_unconfirmed=true"
     result = apiv2_client.get(url).json["result"]


### PR DESCRIPTION
Fixes #2164.

This is a `develop`-based replacement for #3367.

Summary:
- Reject unrecognized v2 API query parameters before route arguments are coerced.
- Reuse the parsed request query parameters while preparing route args.
- Keep allowed parameters such as `verbose` working.
- Add regression coverage for both unknown-parameter rejection and the allowed `verbose` path.

Tests:
- `.venv/bin/python -m pytest counterpartycore/test/units/api/apiserver_test.py -q`
- `.venv/bin/python -m ruff check counterpartycore/lib/api/apiserver.py counterpartycore/test/units/api/apiserver_test.py`
- `.venv/bin/python -m ruff format --check counterpartycore/lib/api/apiserver.py counterpartycore/test/units/api/apiserver_test.py`
- `git diff --check`

BTC payout address if this qualifies for a contributor/security reward: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`