### PR TITLE
Add bootstrap-once catch-up mode

### DIFF
--- a/counterparty-core/counterpartycore/lib/cli/main.py
+++ b/counterparty-core/counterpartycore/lib/cli/main.py
@@ -426,7 +426,7 @@ CONFIG_ARGS = [
     [
         ("--catch-up",),
         {
-            "choices": ["normal", "bootstrap", "bootstrap-always"],
+            "choices": ["normal", "bootstrap", "bootstrap-once", "bootstrap-always"],
             "default": "normal",
             "help": "Catch up mode (default: normal)",
         },

--- a/counterparty-core/counterpartycore/lib/cli/server.py
+++ b/counterparty-core/counterpartycore/lib/cli/server.py
@@ -39,6 +39,14 @@ def ensure_backend_is_up():
         backend.bitcoind.getblockcount()
 
 
+def should_bootstrap_database(catch_up_mode, database_exists):
+    if catch_up_mode == "bootstrap-always":
+        return True
+    if catch_up_mode in ["bootstrap", "bootstrap-once"] and not database_exists:
+        return True
+    return False
+
+
 class AssetConservationChecker(threading.Thread):
     def __init__(self):
         threading.Thread.__init__(self, name="AssetConservationChecker")
@@ -159,9 +167,7 @@ class CounterpartyServer(threading.Thread):
             )
 
         # download bootstrap if necessary
-        if (
-            not os.path.exists(config.DATABASE) and self.args.catch_up == "bootstrap"
-        ) or self.args.catch_up == "bootstrap-always":
+        if should_bootstrap_database(self.args.catch_up, os.path.exists(config.DATABASE)):
             bootstrap.bootstrap(no_confirm=True, snapshot_url=self.args.bootstrap_url)
 
         # Initialise database

--- a/counterparty-core/counterpartycore/test/units/cli/main_test.py
+++ b/counterparty-core/counterpartycore/test/units/cli/main_test.py
@@ -51,6 +51,13 @@ def test_argparser_no_electrs_url():
     assert vars(args)["electrs_url"] is None
 
 
+def test_argparser_accepts_bootstrap_once_catch_up():
+    parser = cli.main.arg_parser(no_config_file=True, app_name="counterparty-test")
+    args = parser.parse_args(["start", "--catch-up=bootstrap-once"])
+
+    assert args.catch_up == "bootstrap-once"
+
+
 def test_argparser():
     parser = cli.main.arg_parser(no_config_file=True, app_name="counterparty-test")
     args = parser.parse_args(

--- a/counterparty-core/counterpartycore/test/units/cli/server_test.py
+++ b/counterparty-core/counterpartycore/test/units/cli/server_test.py
@@ -85,6 +85,22 @@ def test_ensure_backend_is_up_force_skips(monkeypatch):
     mock_getblockcount.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    ("catch_up_mode", "database_exists", "expected"),
+    [
+        ("normal", False, False),
+        ("bootstrap", False, True),
+        ("bootstrap", True, False),
+        ("bootstrap-once", False, True),
+        ("bootstrap-once", True, False),
+        ("bootstrap-always", False, True),
+        ("bootstrap-always", True, True),
+    ],
+)
+def test_should_bootstrap_database(catch_up_mode, database_exists, expected):
+    assert server.should_bootstrap_database(catch_up_mode, database_exists) is expected
+
+
 def test_generate_move_random_hash(monkeypatch):
     monkeypatch.setattr(server.os, "urandom", lambda n: b"\x01" * n)
 


### PR DESCRIPTION
Supersedes #3372 with the same fix rebased onto the current `develop` branch.

Fixes #2563.

This adds `bootstrap-once` as an explicit `--catch-up` mode while preserving the current `bootstrap` behavior. Both `bootstrap` and `bootstrap-once` bootstrap only when the database is missing; `bootstrap-always` still bootstraps regardless of local database state.

Details:
- Accepts `--catch-up=bootstrap-once` in the CLI parser.
- Extracts bootstrap decision logic into `should_bootstrap_database`.
- Covers normal, bootstrap, bootstrap-once, and bootstrap-always behavior for existing/missing databases.

Tests:
- `python -m pytest counterpartycore/test/units/cli/main_test.py::test_argparser_accepts_bootstrap_once_catch_up counterpartycore/test/units/cli/server_test.py::test_should_bootstrap_database -q`
- `python -m pytest counterpartycore/test/units/cli/main_test.py counterpartycore/test/units/cli/server_test.py -q`
- `python -m ruff check counterpartycore/lib/cli/main.py counterpartycore/lib/cli/server.py counterpartycore/test/units/cli/main_test.py counterpartycore/test/units/cli/server_test.py`
- `python -m ruff format --check counterpartycore/lib/cli/main.py counterpartycore/lib/cli/server.py counterpartycore/test/units/cli/main_test.py counterpartycore/test/units/cli/server_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`