### PR TITLE
Validate v2 API boolean parameters

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/apiserver.py
+++ b/counterparty-core/counterpartycore/lib/api/apiserver.py
@@ -132,6 +132,15 @@ def set_cors_headers(response):
         response.headers["Access-Control-Allow-Methods"] = "*"
 
 
+def parse_bool_arg(arg_name, str_arg):
+    value = str_arg.lower()
+    if value in ["true", "1"]:
+        return True
+    if value in ["false", "0"]:
+        return False
+    raise ValueError(f"Invalid boolean: {arg_name}")
+
+
 def return_result(
     http_code,
     result=None,
@@ -181,6 +190,11 @@ def prepare_args(route, **kwargs):
     for arg in route["args"]:
         arg_name = arg["name"]
         if arg_name in ["verbose"] and "compose" not in route["function"].__name__:
+            str_arg = query_params().get(arg_name)
+            if str_arg is not None:
+                if isinstance(str_arg, list):
+                    str_arg = str_arg[0]
+                parse_bool_arg(arg_name, str_arg)
             continue
         if arg_name in function_args:
             continue
@@ -197,7 +211,7 @@ def prepare_args(route, **kwargs):
         if str_arg is None:
             function_args[arg_name] = arg["default"]
         elif arg["type"] == "bool":
-            function_args[arg_name] = str_arg.lower() in ["true", "1"]
+            function_args[arg_name] = parse_bool_arg(arg_name, str_arg)
         elif arg["type"] == "int":
             try:
                 function_args[arg_name] = int(str_arg)

--- a/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
@@ -769,6 +769,17 @@ def test_limit_param_negative_rejected(apiv2_client):
     assert response.status_code != 200 or "error" in response.json
 
 
+def test_invalid_bool_param_rejected(apiv2_client):
+    """Boolean route arguments must reject unsupported values instead of coercing to false."""
+    response = apiv2_client.get("/v2/transactions?show_unconfirmed=maybe")
+    assert response.status_code == 400
+    assert "Invalid boolean: show_unconfirmed" in response.json["error"]
+
+    response = apiv2_client.get("/v2/transactions?verbose=maybe")
+    assert response.status_code == 400
+    assert "Invalid boolean: verbose" in response.json["error"]
+
+
 def test_limit_param_unlimited_when_zero(apiv2_client, monkeypatch):
     """When config.API_LIMIT_ROWS == 0 the cap is disabled."""
     monkeypatch.setattr(config, "API_LIMIT_ROWS", 0)


### PR DESCRIPTION
Supersedes #3378 with the same fix rebased onto the current `develop` branch.

This validates v2 API boolean query parameters instead of silently coercing unsupported values to `false`.

Currently, `prepare_args()` parses booleans with `str_arg.lower() in ["true", "1"]`, so any unsupported value becomes `False`. For example, `/v2/transactions?show_unconfirmed=maybe` can be accepted instead of returning a clear parameter error.

Details:
- Accepts only `true`, `1`, `false`, and `0` for boolean route arguments.
- Returns the existing API 400 error path for unsupported boolean values.
- Validates the shared non-compose `verbose` query parameter before route execution.

Tests:
- `python -m pytest counterpartycore/test/units/api/apiserver_test.py::test_invalid_bool_param_rejected -q`
- `python -m pytest counterpartycore/test/units/api/apiserver_test.py -q`
- `python -m ruff check counterpartycore/lib/api/apiserver.py counterpartycore/test/units/api/apiserver_test.py`
- `python -m ruff format --check counterpartycore/lib/api/apiserver.py counterpartycore/test/units/api/apiserver_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`