### PR TITLE
Validate more_outputs values

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/composer.py
+++ b/counterparty-core/counterpartycore/lib/api/composer.py
@@ -35,6 +35,7 @@ from counterpartycore.lib.parser import deserialize, messagetype, utxosinfo
 from counterpartycore.lib.utils import helpers, multisig, script
 
 MAX_INPUTS_SET = 100
+MAX_BTC_OUTPUT_VALUE = 21_000_000 * config.UNIT
 
 logger = logging.getLogger(config.LOGGER_NAME)
 
@@ -503,6 +504,8 @@ def prepare_more_outputs(more_outputs, unspent_list, construct_params):
             value = int(value)
         except ValueError as e:
             raise exceptions.ComposeError(f"Invalid value for output: {':'.join(output)}") from e
+        if value < 0 or value > MAX_BTC_OUTPUT_VALUE:
+            raise exceptions.ComposeError(f"Invalid value for output: {':'.join(output)}")
         # create output
         tx_output = create_tx_output(value, address_or_script, unspent_list, construct_params)
         outputs.append(tx_output)

--- a/counterparty-core/counterpartycore/test/units/api/composer_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/composer_test.py
@@ -464,6 +464,15 @@ def test_prepare_more_outputs(defaults):
         ]
     )
 
+    with pytest.raises(exceptions.ComposeError, match="Invalid value for output: -1:00aaff"):
+        composer.prepare_more_outputs("-1:00aaff", [], {})
+
+    too_large_value = 21_000_000 * config.UNIT + 1
+    with pytest.raises(
+        exceptions.ComposeError, match=f"Invalid value for output: {too_large_value}:00aaff"
+    ):
+        composer.prepare_more_outputs(f"{too_large_value}:00aaff", [], {})
+
 
 def test_prepare_outputs(ledger_db, defaults):
     # Test case 1 & 2: Simple OP_RETURN output


### PR DESCRIPTION
Supersedes #3379 with the same fix rebased onto the current `develop` branch.

`prepare_more_outputs()` accepted `more_outputs` values outside Bitcoin's valid output amount range. Negative values were converted to `int` and passed directly into `TxOutput`, where `-1` can serialize as `0xffffffffffffffff` satoshis. Values above the 21M BTC money supply limit were also accepted during composition.

This PR adds an explicit BTC output value bound check before creating the transaction output.

Changes:
- Adds `MAX_BTC_OUTPUT_VALUE = 21_000_000 * config.UNIT`.
- Rejects `more_outputs` values below 0 or above the BTC output limit.
- Adds regression coverage for negative and too-large `more_outputs` values.

Tests:
- `python -m pytest counterpartycore/test/units/api/composer_test.py::test_prepare_more_outputs -q`
- `python -m pytest counterpartycore/test/units/api/composer_test.py -q`
- `python -m ruff check counterpartycore/lib/api/composer.py counterpartycore/test/units/api/composer_test.py`
- `python -m ruff format --check counterpartycore/lib/api/composer.py counterpartycore/test/units/api/composer_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`