### PR TITLE
Validate utxo_value parameters

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/attach.py
+++ b/counterparty-core/counterpartycore/lib/messages/attach.py
@@ -10,6 +10,7 @@ from counterpartycore.lib.utils import address
 logger = logging.getLogger(config.LOGGER_NAME)
 
 ID = 101
+MAX_BTC_OUTPUT_VALUE = 21_000_000 * config.UNIT
 
 
 def validate_asset_and_quantity(asset, quantity):
@@ -115,6 +116,8 @@ def compose(
                 value = int(utxo_value)
             except ValueError as e:
                 raise exceptions.ComposeError(["utxo_value must be an integer"]) from e
+            if value < 0 or value > MAX_BTC_OUTPUT_VALUE:
+                raise exceptions.ComposeError(["utxo_value must be a valid bitcoin output amount"])
         # else we use the source address as the destination
         destinations.append((source, value))
 

--- a/counterparty-core/counterpartycore/lib/messages/move.py
+++ b/counterparty-core/counterpartycore/lib/messages/move.py
@@ -7,6 +7,8 @@ from counterpartycore.lib.utils import address
 
 logger = logging.getLogger(config.LOGGER_NAME)
 
+MAX_BTC_OUTPUT_VALUE = 21_000_000 * config.UNIT
+
 
 def compose(db, source, destination, utxo_value=None, skip_validation=False):
     if not skip_validation:
@@ -28,6 +30,8 @@ def compose(db, source, destination, utxo_value=None, skip_validation=False):
             value = int(utxo_value)
         except ValueError as e:
             raise exceptions.ComposeError(["utxo_value must be an integer"]) from e
+        if value < 0 or value > MAX_BTC_OUTPUT_VALUE:
+            raise exceptions.ComposeError(["utxo_value must be a valid bitcoin output amount"])
 
     return (source, [(destination, value)], None)
 

--- a/counterparty-core/counterpartycore/test/units/messages/attach_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/attach_test.py
@@ -49,6 +49,16 @@ def test_compose(ledger_db, defaults):
         b"eXCP|100|",
     )
 
+    with pytest.raises(
+        exceptions.ComposeError, match="utxo_value must be a valid bitcoin output amount"
+    ):
+        attach.compose(ledger_db, address_0, "XCP", 100, -1)
+
+    with pytest.raises(
+        exceptions.ComposeError, match="utxo_value must be a valid bitcoin output amount"
+    ):
+        attach.compose(ledger_db, address_0, "XCP", 100, 21_000_000 * config.UNIT + 1)
+
     with pytest.raises(exceptions.ComposeError, match="invalid source address"):
         attach.compose(ledger_db, DUMMY_UTXO, "XCP", 100)
 

--- a/counterparty-core/counterpartycore/test/units/messages/move_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/move_test.py
@@ -1,5 +1,5 @@
 import pytest
-from counterpartycore.lib import exceptions
+from counterpartycore.lib import config, exceptions
 from counterpartycore.lib.messages import move
 
 DUMMY_UTXO = 64 * "0" + ":0"
@@ -223,3 +223,18 @@ def test_compose(ledger_db, defaults):
 
     with pytest.raises(exceptions.ComposeError, match="utxo_value must be an integer"):
         move.compose(ledger_db, utxo, defaults["addresses"][0], utxo_value="string")
+
+    with pytest.raises(
+        exceptions.ComposeError, match="utxo_value must be a valid bitcoin output amount"
+    ):
+        move.compose(ledger_db, utxo, defaults["addresses"][0], utxo_value=-1)
+
+    with pytest.raises(
+        exceptions.ComposeError, match="utxo_value must be a valid bitcoin output amount"
+    ):
+        move.compose(
+            ledger_db,
+            utxo,
+            defaults["addresses"][0],
+            utxo_value=21_000_000 * config.UNIT + 1,
+        )


### PR DESCRIPTION
Supersedes #3383 with the same fix rebased onto the current `develop` branch.

`move.compose()` and `attach.compose()` accepted `utxo_value` values outside Bitcoin's valid output amount range. The parameter is converted to `int` and then used as a destination output amount, so negative or above-21M-BTC values can flow into transaction output construction.

This PR rejects invalid `utxo_value` values before they are returned as compose destinations.

Changes:
- Rejects negative `utxo_value` in `move.compose()`.
- Rejects above-21M-BTC `utxo_value` in `move.compose()`.
- Rejects negative `utxo_value` in `attach.compose()`.
- Rejects above-21M-BTC `utxo_value` in `attach.compose()`.
- Adds regression coverage for both message types.

Tests:
- `python -m pytest counterpartycore/test/units/messages/move_test.py::test_compose counterpartycore/test/units/messages/attach_test.py::test_compose -q`
- `python -m pytest counterpartycore/test/units/messages/move_test.py counterpartycore/test/units/messages/attach_test.py -q`
- `python -m ruff check counterpartycore/lib/messages/move.py counterpartycore/lib/messages/attach.py counterpartycore/test/units/messages/move_test.py counterpartycore/test/units/messages/attach_test.py`
- `python -m ruff format --check counterpartycore/lib/messages/move.py counterpartycore/lib/messages/attach.py counterpartycore/test/units/messages/move_test.py counterpartycore/test/units/messages/attach_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`