### PR TITLE
Validate UTXO vout range

### DIFF
--- a/counterparty-core/counterpartycore/lib/parser/utxosinfo.py
+++ b/counterparty-core/counterpartycore/lib/parser/utxosinfo.py
@@ -1,3 +1,6 @@
+MAX_VOUT = 0xFFFFFFFF
+
+
 def is_utxo_format(value):
     if not isinstance(value, str):
         return False
@@ -6,7 +9,10 @@ def is_utxo_format(value):
         return False
     if not values[1].isnumeric():
         return False
-    if str(int(values[1])) != values[1]:
+    vout = int(values[1])
+    if str(vout) != values[1]:
+        return False
+    if vout > MAX_VOUT:
         return False
     try:
         int(values[0], 16)

--- a/counterparty-core/counterpartycore/test/units/parser/utxosinfo_test.py
+++ b/counterparty-core/counterpartycore/test/units/parser/utxosinfo_test.py
@@ -1,0 +1,10 @@
+from counterpartycore.lib.parser import utxosinfo
+
+TXID = "0" * 64
+
+
+def test_is_utxo_format_rejects_vout_above_uint32():
+    assert utxosinfo.is_utxo_format(f"{TXID}:0")
+    assert utxosinfo.is_utxo_format(f"{TXID}:4294967295")
+    assert not utxosinfo.is_utxo_format(f"{TXID}:4294967296")
+    assert not utxosinfo.is_utxo_format(f"{TXID}:999999999999999999999")


### PR DESCRIPTION
Supersedes #3385 with the same fix rebased onto the current `develop` branch.

`utxosinfo.is_utxo_format()` accepted UTXO strings with `vout` above the uint32 outpoint index range. That allowed impossible values such as `4294967296` to pass initial validation and fail later during transaction-input serialization.

This PR rejects outpoint indexes outside the valid uint32 range at the parser boundary.

Changes:
- Adds `MAX_UINT32 = 2**32 - 1`.
- Rejects UTXO strings where `vout` is above that limit.
- Adds regression coverage for the upper-bound behavior.

Tests:
- `python -m pytest counterpartycore/test/units/parser/utxosinfo_test.py counterpartycore/test/units/api/composer_test.py::test_prepare_inputs_set -q`
- `python -m ruff check counterpartycore/lib/parser/utxosinfo.py counterpartycore/test/units/parser/utxosinfo_test.py`
- `python -m ruff format --check counterpartycore/lib/parser/utxosinfo.py counterpartycore/test/units/parser/utxosinfo_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`