### PR TITLE
Reject duplicate inputs_set UTXOs

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/composer.py
+++ b/counterparty-core/counterpartycore/lib/api/composer.py
@@ -619,6 +619,7 @@ def complete_unspent_list(unspent_list):
 def prepare_inputs_set(inputs_set):
     unspent_list = []
     utxos_list = inputs_set.split(",")
+    seen_utxos = set()
     if len(utxos_list) > MAX_INPUTS_SET:
         raise exceptions.ComposeError(
             f"too many UTXOs in inputs_set (max. {MAX_INPUTS_SET}): {len(utxos_list)}"
@@ -639,6 +640,10 @@ def prepare_inputs_set(inputs_set):
 
         if not utxosinfo.is_utxo_format(f"{txid}:{vout}"):
             raise exceptions.ComposeError(f"invalid UTXOs: {utxo} (invalid format)")
+        utxo_id = f"{txid}:{vout}"
+        if utxo_id in seen_utxos:
+            raise exceptions.ComposeError(f"invalid UTXOs: {utxo} (duplicate UTXO)")
+        seen_utxos.add(utxo_id)
 
         unspent = {
             "txid": txid,

--- a/counterparty-core/counterpartycore/test/units/api/composer_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/composer_test.py
@@ -599,6 +599,17 @@ def test_prepare_inputs_set(defaults):
             "ae241be7be83ebb14902757ad94854f787d9730fc553d6f695346c9375c0d8c1:0:100:aagh"
         )
 
+    with pytest.raises(
+        exceptions.ComposeError,
+        match=re.escape(
+            "invalid UTXOs: ae241be7be83ebb14902757ad94854f787d9730fc553d6f695346c9375c0d8c1:0:100:aa00 (duplicate UTXO)"
+        ),
+    ):
+        composer.prepare_inputs_set(
+            "ae241be7be83ebb14902757ad94854f787d9730fc553d6f695346c9375c0d8c1:0:100:aa00,"
+            "ae241be7be83ebb14902757ad94854f787d9730fc553d6f695346c9375c0d8c1:0:100:aa00"
+        )
+
     # Test case 6: Valid single input
     assert composer.prepare_inputs_set(
         "ae241be7be83ebb14902757ad94854f787d9730fc553d6f695346c9375c0d8c1:0:100:aa00"


### PR DESCRIPTION
Supersedes #3386 with the same fix rebased onto the current `develop` branch.

`prepare_inputs_set()` accepted duplicate UTXOs in the caller-provided `inputs_set` list. The duplicated entries are returned as separate inputs, so later input selection can count the same UTXO value more than once and build a transaction with duplicate outpoints.

This PR rejects duplicate UTXOs while parsing `inputs_set`.

Changes:
- Tracks seen `<txid>:<vout>` identifiers while parsing `inputs_set`.
- Rejects repeated UTXOs with a clear `ComposeError`.
- Adds regression coverage for duplicate explicit inputs.

Tests:
- `python -m pytest counterpartycore/test/units/api/composer_test.py::test_prepare_inputs_set -q`
- `python -m pytest counterpartycore/test/units/api/composer_test.py -q`
- `python -m ruff check counterpartycore/lib/api/composer.py counterpartycore/test/units/api/composer_test.py`
- `python -m ruff format --check counterpartycore/lib/api/composer.py counterpartycore/test/units/api/composer_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`