### PR TITLE
Validate fairmint quantity before comparisons

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/fairmint.py
+++ b/counterparty-core/counterpartycore/lib/messages/fairmint.py
@@ -26,12 +26,16 @@ def validate(
 ):
     problems = []
 
-    if not isinstance(quantity, int):
+    invalid_quantity = not isinstance(quantity, int)
+    if invalid_quantity:
         problems.append("quantity must be an integer")
 
     fairminter = ledger.issuances.get_fairminter_by_asset(db, asset)
     if not fairminter:
         problems.append(f"fairminter not found for asset: `{asset}`")
+        return problems
+
+    if invalid_quantity:
         return problems
 
     if fairminter["status"] != "open":

--- a/counterparty-core/counterpartycore/test/units/messages/fairmint_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/fairmint_test.py
@@ -25,6 +25,13 @@ def test_validate(ledger_db, defaults):
     assert fairmint.validate(
         ledger_db,
         defaults["addresses"][1],  # source
+        "PAIDFAIRMIN",  # asset
+        "10",  # quantity
+    ) == ["quantity must be an integer"]
+
+    assert fairmint.validate(
+        ledger_db,
+        defaults["addresses"][1],  # source
         "RAIDFAIRMIN",  # asset
         11,  # quantity
     ) == ["Quantity exceeds maximum allowed per transaction"]
@@ -78,6 +85,14 @@ def test_compose(ledger_db, defaults):
             defaults["addresses"][1],  # source
             "QAIDFAIRMIN",  # asset
             35,  # quantity
+        )
+
+    with pytest.raises(exceptions.ComposeError, match="quantity must be an integer"):
+        fairmint.compose(
+            ledger_db,
+            defaults["addresses"][1],  # source
+            "PAIDFAIRMIN",  # asset
+            "10",  # quantity
         )
 
     assert fairmint.compose(


### PR DESCRIPTION
Supersedes #3388 with the same fix rebased onto the current `develop` branch.

`fairmint.validate()` recorded `quantity must be an integer` for non-integer quantities, but then continued into fairminter-specific arithmetic and comparisons when the fairminter existed. For a paid fairminter, a value like `"10"` could reach `quantity <= 0` and raise a Python `TypeError` instead of returning the compose-level validation error.

This PR stops fairmint validation before any quantity arithmetic when the quantity is not an integer.

Changes:
- Tracks invalid non-integer fairmint quantity before looking up the fairminter.
- Preserves the existing `fairminter not found` behavior when the asset is missing.
- Returns the recorded quantity validation problem before arithmetic/comparison logic for existing fairminters.
- Adds regression coverage for validate and compose paths.

Tests:
- `python -m pytest counterpartycore/test/units/messages/fairmint_test.py::test_validate counterpartycore/test/units/messages/fairmint_test.py::test_compose -q`
- `python -m pytest counterpartycore/test/units/messages/fairmint_test.py -q`
- `python -m ruff check counterpartycore/lib/messages/fairmint.py counterpartycore/test/units/messages/fairmint_test.py`
- `python -m ruff format --check counterpartycore/lib/messages/fairmint.py counterpartycore/test/units/messages/fairmint_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`