### PR TITLE
Validate fairminter integer parameters before comparisons

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/fairminter.py
+++ b/counterparty-core/counterpartycore/lib/messages/fairminter.py
@@ -45,6 +45,7 @@ def validate(
         problems.append(f"`{asset}` can't be fairminted.")
 
     # check integer parameters
+    invalid_integer_parameter = False
     for param_name, param_value in {
         "price": price,
         "quantity_by_price": quantity_by_price,
@@ -60,10 +61,13 @@ def validate(
         if param_value != 0:
             if not isinstance(param_value, int):
                 problems.append(f"`{param_name}` must be an integer")
+                invalid_integer_parameter = True
             elif param_value < 0:
                 problems.append(f"`{param_name}` must be >= 0.")
             elif param_value > config.MAX_INT:
                 problems.append(f"`{param_name}` exceeds maximum value")
+    if invalid_integer_parameter:
+        return problems
     if quantity_by_price < 1:
         problems.append("quantity_by_price must be >= 1")
     # check boolean parameters

--- a/counterparty-core/counterpartycore/test/units/messages/fairminter_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/fairminter_test.py
@@ -100,6 +100,16 @@ def test_validate(ledger_db, defaults):
         "FAIRMINTED",  # asset
         "",  # asset_parent,
         0,  # price=0,
+        "1",  # quantity_by_price,
+        10,  # max_mint_per_tx,
+    ) == ["`quantity_by_price` must be an integer"]
+
+    assert fairminter.validate(
+        ledger_db,
+        defaults["addresses"][1],  # source
+        "FAIRMINTED",  # asset
+        "",  # asset_parent,
+        0,  # price=0,
         1,  # quantity_by_price,
         -10,  # max_mint_per_tx,
         0,  # max_mint_per_address,
@@ -398,6 +408,17 @@ def test_compose(ledger_db, defaults):
         [],
         b"Z\x93\x1b\x00\x00\x18\xc0\xfd\xcd\xeb_\x00\x00\x01\n\x00\x00\x00\x00\x00\x00\x00\x00\xf4\xf4\xf4\xf5`@",
     )
+
+    with pytest.raises(exceptions.ComposeError, match="quantity_by_price.*integer"):
+        fairminter.compose(
+            ledger_db,
+            defaults["addresses"][1],  # source
+            "FAIRMINTED",  # asset
+            "",  # asset_parent,
+            0,  # price=0,
+            "1",  # quantity_by_price,
+            10,  # max_mint_per_tx,
+        )
 
     assert fairminter.compose(
         ledger_db,


### PR DESCRIPTION
Supersedes #3389 with the same fix rebased onto the current `develop` branch.

`fairminter.validate()` records non-integer numeric parameters such as `quantity_by_price`, but it continued into numeric comparisons afterward. For example, `quantity_by_price="1"` is recorded as invalid and then reaches `quantity_by_price < 1`, raising a Python `TypeError` instead of returning the compose-level validation error.

This PR stops fairminter validation before numeric comparison logic when any numeric fairminter parameter is not an integer.

Changes:
- Tracks whether any fairminter integer parameter failed type validation.
- Returns those validation errors before later numeric comparisons.
- Adds regression coverage for validate and compose paths.

Tests:
- `python -m pytest counterpartycore/test/units/messages/fairminter_test.py::test_validate counterpartycore/test/units/messages/fairminter_test.py::test_compose -q`
- `python -m pytest counterpartycore/test/units/messages/fairminter_test.py -q`
- `python -m ruff check counterpartycore/lib/messages/fairminter.py counterpartycore/test/units/messages/fairminter_test.py`
- `python -m ruff format --check counterpartycore/lib/messages/fairminter.py counterpartycore/test/units/messages/fairminter_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`