### PR TITLE
Fix balance asset sorting with subasset longnames

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/queries.py
+++ b/counterparty-core/counterpartycore/lib/api/queries.py
@@ -324,7 +324,9 @@ def select_rows(
                 sort_order = "ASC"
             if sort_order.upper() not in ["ASC", "DESC"]:
                 sort_order = "ASC"
-            if sort_name in SUPPORTED_SORT_FIELDS.get(table, []):
+            if table == "balances" and sort_name == "asset":
+                order_by.append(f"COALESCE(asset_longname, asset) {sort_order.upper()}")
+            elif sort_name in SUPPORTED_SORT_FIELDS.get(table, []):
                 order_by.append(f"{sort_name} {sort_order.upper()}")
     elif table == "all_transactions_with_status":
         order_by.append("confirmed ASC")

--- a/counterparty-core/counterpartycore/test/units/api/queries_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/queries_test.py
@@ -137,6 +137,47 @@ def test_select_rows_with_sort_invalid_order(state_db):
     assert result is not None
 
 
+def test_select_rows_balances_sort_asset_uses_asset_longname(state_db):
+    cursor = state_db.cursor()
+    address = "mnTESTBalanceSortAddress"
+    cursor.executemany(
+        """
+        INSERT INTO balances (address, asset, asset_longname, quantity)
+        VALUES (?, ?, ?, ?)
+        """,
+        [
+            (address, "MYASSET", None, 1),
+            (address, "A999999999999999999", "MYASSET.CHILD", 1),
+            (address, "A888888888888888888", "ANOTHER.CHILD", 1),
+        ],
+    )
+
+    result = queries.select_rows(
+        state_db,
+        "balances",
+        where={"address": address},
+        sort="asset",
+        limit=10,
+    )
+
+    assert [row["asset"] for row in result.result] == [
+        "A888888888888888888",
+        "MYASSET",
+        "A999999999999999999",
+    ]
+
+
+def test_select_rows_non_balance_asset_sort_uses_asset_field(state_db):
+    result = queries.select_rows(
+        state_db,
+        "dispensers",
+        sort="asset",
+        limit=10,
+    )
+
+    assert result is not None
+
+
 def test_select_rows_with_unsupported_sort_field(state_db):
     """Test select_rows with unsupported sort field (line 310-311)."""
     result = queries.select_rows(


### PR DESCRIPTION
Supersedes #3342 with the same fix rebased onto the current `develop` branch.

Fixes #3021.

This restores the intended coalesced asset sorting for balances now that the API balances table includes `asset_longname`. When clients request `sort=asset` on balances, the query orders by `COALESCE(asset_longname, asset)`, so named assets and subassets sort by the user-visible asset name.

The special ordering is scoped to the `balances` table so other tables that support `sort=asset` but do not have `asset_longname` keep using their `asset` column.

Tests:
- `python -m pytest counterpartycore/test/units/api/queries_test.py::test_select_rows_balances_sort_asset_uses_asset_longname counterpartycore/test/units/api/queries_test.py::test_select_rows_non_balance_asset_sort_uses_asset_field -q`
- `python -m pytest counterpartycore/test/units/api/queries_test.py -q`
- `python -m ruff check counterpartycore/lib/api/queries.py counterpartycore/test/units/api/queries_test.py`
- `python -m ruff format --check counterpartycore/lib/api/queries.py counterpartycore/test/units/api/queries_test.py`
- `git diff --check`

Bounty payment address (BTC): `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`