### PR TITLE
Support multisig UTXO addresses

### DIFF
--- a/counterparty-core/counterpartycore/lib/backend/bitcoind.py
+++ b/counterparty-core/counterpartycore/lib/backend/bitcoind.py
@@ -21,8 +21,8 @@ from requests.exceptions import (  # pylint: disable=redefined-builtin
 
 from counterpartycore.lib import config, exceptions
 from counterpartycore.lib.ledger.currentstate import CurrentState
-from counterpartycore.lib.parser import deserialize, utxosinfo
-from counterpartycore.lib.utils import script
+from counterpartycore.lib.parser import deserialize, p2sh, protocol, utxosinfo
+from counterpartycore.lib.utils import multisig, script
 
 logger = logging.getLogger(config.LOGGER_NAME)
 
@@ -363,9 +363,27 @@ def get_utxo_address_and_value(utxo, no_retry=False):
         raise exceptions.InvalidUTXOError(f"Could not find UTXO {utxo}") from e
     if vout >= len(transaction["vout"]):
         raise exceptions.InvalidUTXOError("vout index out of range")
-    if "address" not in transaction["vout"][vout]["scriptPubKey"]:
+    script_pub_key = transaction["vout"][vout]["scriptPubKey"]
+    address = script_pub_key.get("address")
+    if address is None and protocol.enabled("multisig_utxo_addresses"):
+        address = get_multisig_address_from_script_pub_key(script_pub_key)
+    if address is None:
         raise exceptions.InvalidUTXOError("vout does not have an address")
-    return transaction["vout"][vout]["scriptPubKey"]["address"], transaction["vout"][vout]["value"]
+    return address, transaction["vout"][vout]["value"]
+
+
+def get_multisig_address_from_script_pub_key(script_pub_key):
+    if "hex" not in script_pub_key:
+        return None
+    try:
+        if script.get_output_type(script_pub_key["hex"]) != "P2MS":
+            return None
+        asm = script.script_to_asm(script_pub_key["hex"])
+        pubkeys = asm[1:-2]
+        pubkeyhashes = [p2sh.pubkey_to_pubkeyhash(pubkey) for pubkey in pubkeys]
+        return multisig.construct_array(asm[0], pubkeyhashes, asm[-2])
+    except (exceptions.DecodeError, exceptions.MultiSigAddressError):
+        return None
 
 
 def safe_get_utxo_address(utxo):

--- a/counterparty-core/counterpartycore/protocol_changes.json
+++ b/counterparty-core/counterpartycore/protocol_changes.json
@@ -1410,5 +1410,14 @@
         "testnet3_block_index": 4961300,
         "testnet4_block_index": 136300,
         "signet_block_index": 310300
+    },
+    "multisig_utxo_addresses": {
+        "minimum_version_major": 11,
+        "minimum_version_minor": 1,
+        "minimum_version_revision": 0,
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     }
 }

--- a/counterparty-core/counterpartycore/test/units/backend/bitcoind_test.py
+++ b/counterparty-core/counterpartycore/test/units/backend/bitcoind_test.py
@@ -4,11 +4,34 @@ import time
 from unittest.mock import patch
 
 import pytest
-from counterpartycore.lib import exceptions
+from bitcoinutils.transactions import Script
+from counterpartycore.lib import config, exceptions
 from counterpartycore.lib.backend import bitcoind
 from counterpartycore.lib.utils import helpers
 from counterpartycore.test.fixtures import decodedtxs
 from counterpartycore.test.mocks.bitcoind import original_get_vin_info
+from counterpartycore.test.mocks.counterpartydbs import ProtocolChangesDisabled
+
+ORIGINAL_GET_UTXO_ADDRESS_AND_VALUE = bitcoind.get_utxo_address_and_value
+MULTISIG_PUBKEYS = [
+    "0427db4059d24bab05df3f6bcc768fb01bd976b973f93e72cce2dfbfbed5a32056c9040a2c2ea4c10c812a54fed7ff2e6a917dbc843362d398f6ace4000fafa5c6",
+    "043e12a6cb1c7c156f789110abf8397b714047414b5a32c742f17ccf93ff23bdf3128f946207086bcef012558240cd16182c741123e93ed18327c4cd6ebac668a9",
+    "04e4168c172283c7dfaa85d2004f763a28bf6d0f1602fc1452ccec62a7c8a66e422af1410fbf24a47355ddc43dfe3491cb1b806574ccd1c434680466dcff926f01",
+]
+MULTISIG_ADDRESS = "2_16KsHvVQj6aGvVQpAUgRcfpVug3regjiUs_17yjtboB7RjK2BoQ78k51NtJ4cDQGYZQyb_1NNXBUF3rqXtFbWhK5nujSpvt9yApsRUT7_3"
+
+
+def multisig_script_pub_key():
+    return {
+        "asm": f"2 {' '.join(MULTISIG_PUBKEYS)} 3 OP_CHECKMULTISIG",
+        "hex": Script([2, *MULTISIG_PUBKEYS, 3, "OP_CHECKMULTISIG"]).to_hex(),
+        "type": "multisig",
+    }
+
+
+def clear_get_utxo_address_and_value_cache():
+    if hasattr(ORIGINAL_GET_UTXO_ADDRESS_AND_VALUE, "cache_clear"):
+        ORIGINAL_GET_UTXO_ADDRESS_AND_VALUE.cache_clear()
 
 
 class MockResponse:
@@ -579,6 +602,52 @@ def test_reset_caches_clears_dicts():
 
     assert "sentinel_tx" not in bitcoind.TRANSACTIONS_CACHE
     assert 123 not in bitcoind.BLOCKS_CACHE
+
+
+def test_get_multisig_address_from_script_pub_key():
+    old_address_version = config.ADDRESSVERSION
+    config.ADDRESSVERSION = config.ADDRESSVERSION_MAINNET
+    try:
+        address = bitcoind.get_multisig_address_from_script_pub_key(multisig_script_pub_key())
+    finally:
+        config.ADDRESSVERSION = old_address_version
+
+    assert address == MULTISIG_ADDRESS
+
+
+def test_get_utxo_address_and_value_supports_multisig_when_protocol_enabled(monkeypatch):
+    def mock_getrawtransaction(*args, **kwargs):
+        return {"vout": [{"scriptPubKey": multisig_script_pub_key(), "value": 0.001}]}
+
+    old_address_version = config.ADDRESSVERSION
+    config.ADDRESSVERSION = config.ADDRESSVERSION_MAINNET
+    clear_get_utxo_address_and_value_cache()
+    monkeypatch.setattr(bitcoind, "getrawtransaction", mock_getrawtransaction)
+    try:
+        assert ORIGINAL_GET_UTXO_ADDRESS_AND_VALUE("multisig-txid:0") == (
+            MULTISIG_ADDRESS,
+            0.001,
+        )
+    finally:
+        clear_get_utxo_address_and_value_cache()
+        config.ADDRESSVERSION = old_address_version
+
+
+def test_get_utxo_address_and_value_rejects_multisig_when_protocol_disabled(monkeypatch):
+    def mock_getrawtransaction(*args, **kwargs):
+        return {"vout": [{"scriptPubKey": multisig_script_pub_key(), "value": 0.001}]}
+
+    old_address_version = config.ADDRESSVERSION
+    config.ADDRESSVERSION = config.ADDRESSVERSION_MAINNET
+    clear_get_utxo_address_and_value_cache()
+    monkeypatch.setattr(bitcoind, "getrawtransaction", mock_getrawtransaction)
+    try:
+        with ProtocolChangesDisabled(["multisig_utxo_addresses"]):
+            with pytest.raises(exceptions.InvalidUTXOError, match="vout does not have an address"):
+                ORIGINAL_GET_UTXO_ADDRESS_AND_VALUE("legacy-multisig-txid:0")
+    finally:
+        clear_get_utxo_address_and_value_cache()
+        config.ADDRESSVERSION = old_address_version
 
 
 def test_reset_caches_handles_missing_lru_cache_clear(monkeypatch):


### PR DESCRIPTION
## Summary

- add a `multisig_utxo_addresses` protocol gate for resolving P2MS scriptPubKeys without an `address` field
- derive Counterparty multisig addresses from raw P2MS pubkeys when the gate is enabled
- preserve the legacy `vout does not have an address` error when the protocol change is disabled or the script is unsupported

## Context

This is a `develop`-based replacement for the earlier `master` PR:

- Supersedes: https://github.com/CounterpartyXCP/counterparty-core/pull/3343
- Related issue: https://github.com/CounterpartyXCP/counterparty-core/issues/2963

The earlier review requested a protocol-change gate. This version includes that gate and tests both enabled and disabled behavior.

## Verification

- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m pytest counterpartycore/test/units/backend/bitcoind_test.py::test_get_multisig_address_from_script_pub_key -q`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m pytest counterpartycore/test/units/backend/bitcoind_test.py -q`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m ruff check counterpartycore/lib/backend/bitcoind.py counterpartycore/test/units/backend/bitcoind_test.py`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m ruff format --check counterpartycore/lib/backend/bitcoind.py counterpartycore/test/units/backend/bitcoind_test.py`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m json.tool counterpartycore/protocol_changes.json`
- `git diff --check`

## Payout

If this qualifies for a contributor or bug-fix reward, please send BTC to:

`bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
