### PR TITLE
Skip call price checks after callability parameter removal

### DIFF
--- a/counterparty-core/counterpartycore/lib/messages/issuance.py
+++ b/counterparty-core/counterpartycore/lib/messages/issuance.py
@@ -130,20 +130,19 @@ def validate(
             (not protocol.enabled("cip03", block_index)) or (not reset)
         ):
             problems.append("cannot change divisibility")
-        if (not protocol.enabled("issuance_callability_parameters_removal", block_index)) and bool(
-            last_issuance["callable"]
-        ) != bool(callable_):
-            problems.append("cannot change callability")
-        if last_issuance["call_date"] > call_date and (
-            call_date != 0
-            or (
-                not protocol.enabled("default_values_for_callable")
-                and not protocol.is_test_network()
-            )
-        ):
-            problems.append("cannot advance call date")
-        if last_issuance["call_price"] > call_price:
-            problems.append("cannot reduce call price")
+        if not protocol.enabled("issuance_callable_lock_fix", block_index):
+            if bool(last_issuance["callable"]) != bool(callable_):
+                problems.append("cannot change callability")
+            if last_issuance["call_date"] > call_date and (
+                call_date != 0
+                or (
+                    not protocol.enabled("default_values_for_callable")
+                    and not protocol.is_test_network()
+                )
+            ):
+                problems.append("cannot advance call date")
+            if last_issuance["call_price"] > call_price:
+                problems.append("cannot reduce call price")
         if issuance_locked and quantity:
             problems.append("locked asset and non‐zero quantity")
         if issuance_locked and reset:

--- a/counterparty-core/counterpartycore/protocol_changes.json
+++ b/counterparty-core/counterpartycore/protocol_changes.json
@@ -1410,5 +1410,14 @@
         "testnet3_block_index": 4961300,
         "testnet4_block_index": 136300,
         "signet_block_index": 310300
+    },
+    "issuance_callable_lock_fix": {
+        "minimum_version_major": 11,
+        "minimum_version_minor": 1,
+        "minimum_version_revision": 0,
+        "block_index": 952800,
+        "testnet3_block_index": 4961300,
+        "testnet4_block_index": 136300,
+        "signet_block_index": 310300
     }
 }

--- a/counterparty-core/counterpartycore/test/units/messages/issuance_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/issuance_test.py
@@ -5,6 +5,7 @@ import cbor2
 import pytest
 from counterpartycore.lib import config, exceptions
 from counterpartycore.lib.api import apiwatcher
+from counterpartycore.lib.ledger.currentstate import CurrentState
 from counterpartycore.lib.messages import issuance
 from counterpartycore.test.mocks.counterpartydbs import ProtocolChangesDisabled
 
@@ -195,6 +196,68 @@ def test_validate(ledger_db, defaults, current_block_index):
         None,
         current_block_index,
     ) == (0, "abc", ["call_price must be a float"], 0, "", True, None, None)
+
+    ledger_db.execute(
+        """
+        INSERT INTO issuances (
+            tx_index, tx_hash, msg_index, block_index, asset, quantity,
+            divisible, source, issuer, transfer, callable, call_date,
+            call_price, description, fee_paid, locked, reset, status,
+            asset_longname
+        ) VALUES (
+            999999, 'test_hash_callable_lock', 0, 310000, 'OLDCALLABLE', 1000,
+            1, ?, ?, 0, 1, 1409401723,
+            1.5, 'Old callable asset', 0, 0, 0, 'valid',
+            NULL
+        )
+        """,
+        (defaults["addresses"][0], defaults["addresses"][0]),
+    )
+
+    def validate_callable_lock_at(block_index):
+        return issuance.validate(
+            ledger_db,
+            defaults["addresses"][0],
+            "OLDCALLABLE",
+            0,
+            True,
+            True,
+            False,
+            False,
+            0,
+            0.0,
+            "",
+            None,
+            None,
+            block_index,
+        )[2]
+
+    current_state = CurrentState()
+    original_block_index = current_state.current_block_index()
+    original_network = (config.REGTEST, config.TESTNET3, config.TESTNET4, config.SIGNET)
+    try:
+        config.REGTEST = False
+        config.TESTNET3 = False
+        config.TESTNET4 = False
+        config.SIGNET = False
+
+        current_state.set_current_block_index(952799)
+        assert validate_callable_lock_at(952799) == [
+            "cannot change callability",
+            "cannot reduce call price",
+        ]
+
+        current_state.set_current_block_index(952800)
+        assert validate_callable_lock_at(952800) == []
+    finally:
+        config.REGTEST, config.TESTNET3, config.TESTNET4, config.SIGNET = original_network
+        current_state.set_current_block_index(original_block_index)
+
+    with ProtocolChangesDisabled(["issuance_callable_lock_fix"]):
+        assert validate_callable_lock_at(952800) == [
+            "cannot change callability",
+            "cannot reduce call price",
+        ]
 
     assert issuance.validate(
         ledger_db,


### PR DESCRIPTION
## Summary

- add a new `issuance_callable_lock_fix` protocol change at the current 11.1.0 activation batch
- gate the relaxed callable/call date/call price reissuance checks behind that future activation
- cover pre-activation, post-activation, and disabled-gate behavior for the old callable asset case

## Context

This is a `develop`-based replacement for the earlier `master` PR:

- Supersedes: https://github.com/CounterpartyXCP/counterparty-core/pull/3340
- Related issue: https://github.com/CounterpartyXCP/counterparty-core/issues/1338

The earlier review confirmed the bug but requested a new future protocol gate to avoid a retroactive consensus change. This version keeps that gate and the activation boundary test on current `develop`.

## Verification

- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m pytest counterpartycore/test/units/messages/issuance_test.py::test_validate -q`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m pytest counterpartycore/test/units/messages/issuance_test.py -q`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m ruff check counterpartycore/lib/messages/issuance.py counterpartycore/test/units/messages/issuance_test.py`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m ruff format --check counterpartycore/lib/messages/issuance.py counterpartycore/test/units/messages/issuance_test.py`
- `/Users/cayd/Documents/btc/work/counterparty-core/counterparty-core/.venv/bin/python -m json.tool counterpartycore/protocol_changes.json`
- `git diff --check`

## Payout

If this qualifies for a contributor or bug-fix reward, please send BTC to:

`bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
