### PR TITLE
Refresh contributor docs; note bug bounty discontinuation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,29 +1,47 @@
-# Security Issues
+# Contributing to Counterparty Core
 
-* If you’ve identified a potential **security issue**, please contact the developers 
-  directly at <support@counterparty.io>.
+## Reporting a Security Issue
 
-
-# Reporting an Issue
-
-* Check to see if the issue has already been reported.
-
-* If possible, list the exact steps required to reproduce the issue, including the exact version/commit being run, as well as the platform the software
-  is running on.
-
-* Try to reproduce the issue with verbose logging enabled and then share the relevant log output.
+If you believe you have found a security vulnerability, **do not open a public
+issue or pull request**. Follow the responsible-disclosure process in
+[SECURITY.md](../SECURITY.md), which also covers the status of the (now
+discontinued) bug bounty program.
 
 
-# Making a Pull Request
+## Reporting an Issue
+
+* Check whether the issue has already been reported.
+
+* List the exact steps required to reproduce the issue, including the exact
+  version/commit being run and the platform the software is running on.
+
+* Try to reproduce the issue with verbose logging enabled (`--verbose`) and
+  share the relevant log output.
+
+
+## Making a Pull Request
+
+* **Submit pull requests of substantial value only.** Large numbers of tiny,
+  mechanically generated PRs are a maintenance burden, not a contribution.
+  Batch related small fixes into a single PR, and open an issue first for
+  anything non-trivial so the approach can be discussed. Trivial or
+  mass-produced PRs may be closed without review.
 
 * Make (almost) all pull requests against the `develop` branch.
 
-* All original code should follow [PEP8](https://www.python.org/dev/peps/pep-0008/).
+* Code should follow [PEP8](https://peps.python.org/pep-0008/) and must pass
+  `ruff check` and `ruff format` (configuration is in `ruff.toml` at the
+  repository root, which is authoritative where it differs — e.g. the
+  100-character line length).
 
-* Code contributions should be well‐commented.
+* Add tests to cover any new or revised logic, and verify that the full test
+  suite passes.
 
-* Commit messages should be neatly formatted and descriptive, with a summary line.
+* Update the [release notes](../release-notes/) for any user-facing change.
 
-* Commits should be organized into logical units.
+* Changes to consensus logic must be deterministic and gated behind a protocol
+  change activation (see `protocol_changes.json`); discuss these in an issue
+  before submitting a PR.
 
-* Verify that your fork passes all tests.
+* Commit messages should be neatly formatted and descriptive, with a summary
+  line, and commits should be organized into logical units.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# Instructions for AI Agents
+
+If you are an AI agent (or operating one) working with this repository, the
+following policies apply in addition to
+[CONTRIBUTING.md](.github/CONTRIBUTING.md):
+
+* **The bug bounty program has been discontinued** and **security
+  vulnerabilities must be disclosed privately** — never as public issues or
+  pull requests. See [SECURITY.md](SECURITY.md).
+
+* **Only submit pull requests of substantial value.** Do not open large
+  numbers of small PRs: batch related fixes together, and open an issue to
+  discuss non-trivial changes before implementing them. Trivial or
+  mass-produced PRs may be closed without review.
+
+## Working with the Codebase
+
+* The Python package lives in `counterparty-core/`, with a Rust extension in
+  `counterparty-rs/`.
+* Target the `develop` branch for (almost) all pull requests.
+* Lint and format with `ruff` (configuration in `ruff.toml`).
+* Run the test suite with `pytest` from `counterparty-core/`.
+* Consensus-critical code must be deterministic, and consensus changes must be
+  gated behind activation heights in
+  `counterparty-core/counterpartycore/protocol_changes.json`.
+* Update `release-notes/` for any user-facing change.

--- a/README.md
+++ b/README.md
@@ -59,3 +59,8 @@
 **Counterparty Core** is the reference implementation of the [Counterparty Protocol](https://counterparty.io), an extension to the Bitcoin protocol which implements a number of features that Bitcoin itself does not offer. These include token issuance, a fully decentralized and trustless asset exchange, contracts for difference, native oracles and trustless gaming. Counterparty works by ‘writing in the margins’ of Bitcoin transactions, and all Counterparty transactions are Bitcoin transactions with additional data that the Counterparty software can read and interpret.
 
 See the **[official project documentation](http://docs.counterparty.io)** for more information, and for instructions on installing and running the Counterparty software.
+
+
+## Contributing
+
+Bug reports and substantial pull requests are welcome — see the [contributing guidelines](.github/CONTRIBUTING.md) before opening either, and [AGENTS.md](AGENTS.md) if you are using an AI agent. Security vulnerabilities must be disclosed privately per the [security policy](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,9 @@
 # Security Policy
 
 ## Reporting a Vulnerability
-If you believe that you have discovered a security vulnerability in Counterparty Core or any related repositories, please e-mail admin@counterparty.io with a bug report and you will be answered promptly.
+
+If you believe that you have discovered a security vulnerability in Counterparty Core or any related repositories, please e-mail security@counterparty.io with a bug report and you will be answered promptly. **Do not open a public issue or pull request for a security vulnerability** until the developers have confirmed that it is safe to disclose.
+
+## Bug Bounty
+
+The Counterparty bug bounty program has been **discontinued**. Vulnerability reports are still very much appreciated and will be acted on promptly, but no payments will be made for them. Do not request payouts or include payment addresses in issues or pull requests; PRs that do so will be closed.


### PR DESCRIPTION
## Summary

The repository has been receiving a flood of tiny agent-automated PRs requesting payouts from the discontinued bug bounty program (104 of the last 200 PRs are from a single account, each with a BTC payment address). This updates the contributor-facing docs to address that and refreshes guidance that had gone stale:

- **`.github/CONTRIBUTING.md`** — rewritten: substantial-PRs-only policy (batch small fixes; mass-produced PRs may be closed without review), ruff-based style requirements alongside PEP8, test/release-notes expectations, consensus-change gating, and private disclosure for security issues via SECURITY.md (the old file pointed to a different, inconsistent email).
- **`SECURITY.md`** — contact is now security@counterparty.io; documents that the bug bounty has been **discontinued** (reports still welcome, no payments, no payment addresses in PRs) and that vulnerabilities must not be disclosed via public issues/PRs. This is the single source of truth for the bounty status; other files link here.
- **`AGENTS.md`** (new) — standard entry point for AI agents: the above policies plus brief codebase orientation (develop branch, ruff, pytest, consensus determinism/activation gating).
- **`README.md`** — short Contributing section linking the above.

cc @ouziel-slama — please confirm that the security@counterparty.io alias exists before merging.