### PR TITLE
Don't report shutdown DB interrupts as processing errors

### DIFF
--- a/counterparty-core/counterpartycore/lib/parser/follow.py
+++ b/counterparty-core/counterpartycore/lib/parser/follow.py
@@ -330,6 +330,16 @@ class BlockchainWatcher:
         try:
             self.receive_message(topic, body, seq)
         except Exception as e:  # pylint: disable=broad-except
+            # A shutdown interrupt (stop() -> RawMempoolParser.stop() ->
+            # db.interrupt() on the connection shared with this watcher)
+            # aborts whatever query parse_tx is running, surfacing here as
+            # apsw.InterruptError -> ParseTransactionError("interrupted").
+            # That's expected teardown noise, not a processing failure: log
+            # it quietly and exit without paging Sentry or re-raising to
+            # force a "fail loud" restart of an already-stopping process.
+            if self.stop_event.is_set():
+                logger.debug("Watcher interrupted during shutdown: %s", e)
+                return
             # Re-raise after logging + Sentry so the outer handle() loop
             # can stop() the watcher: any failure while *processing* a
             # message (vs. receiving it) is not safely retriable here -- it

--- a/counterparty-core/counterpartycore/test/units/parser/follow_test.py
+++ b/counterparty-core/counterpartycore/test/units/parser/follow_test.py
@@ -1148,6 +1148,68 @@ def test_receive_multipart_message_processing_error():
     asyncio.run(run_test())
 
 
+def test_receive_multipart_swallows_interrupt_during_shutdown():
+    """When stop() has interrupted the shared DB connection mid-parse, the
+    resulting ParseTransactionError("interrupted") must be treated as expected
+    teardown noise: logged at debug, NOT sent to Sentry, and NOT re-raised
+    (which would force a spurious "fail loud" restart of an already-stopping
+    process). Pins the stop_event guard in receive_multipart."""
+
+    async def run_test():
+        with mock.patch("counterpartycore.lib.backend.bitcoind") as mock_bitcoind:
+            mock_bitcoind.get_zmq_notifications.return_value = [
+                {"type": "pubrawtx", "address": "tcp://127.0.0.1:28332"},
+                {"type": "pubhashtx", "address": "tcp://127.0.0.1:28332"},
+                {"type": "pubsequence", "address": "tcp://127.0.0.1:28332"},
+                {"type": "pubrawblock", "address": "tcp://127.0.0.1:28333"},
+            ]
+
+            original_backend_connect = config.BACKEND_CONNECT
+            original_no_mempool = config.NO_MEMPOOL
+            config.BACKEND_CONNECT = "127.0.0.1"
+            config.NO_MEMPOOL = True
+
+            try:
+                with mock.patch("counterpartycore.lib.monitors.sentry.init"):
+                    with mock.patch("zmq.asyncio.Context"):
+                        with mock.patch("asyncio.new_event_loop"):
+                            with mock.patch("asyncio.set_event_loop"):
+                                with mock.patch("counterpartycore.lib.parser.follow.CurrentState"):
+                                    with mock.patch(
+                                        "counterpartycore.lib.parser.follow.capture_exception"
+                                    ) as mock_capture:
+                                        db = mock.MagicMock()
+                                        watcher = follow.BlockchainWatcher(db)
+                                        # Simulate shutdown already in progress.
+                                        watcher.stop_event.set()
+
+                                        mock_socket = mock.AsyncMock()
+                                        mock_socket.recv_multipart.return_value = (
+                                            b"rawblock",
+                                            b"body",
+                                            b"\x01\x00\x00\x00",
+                                        )
+
+                                        with mock.patch.object(
+                                            watcher,
+                                            "receive_message",
+                                            side_effect=exceptions.ParseTransactionError(
+                                                "interrupted"
+                                            ),
+                                        ):
+                                            # MUST NOT raise during shutdown...
+                                            await watcher.receive_multipart(
+                                                mock_socket, "rawblock"
+                                            )
+                                            # ...and MUST NOT page Sentry.
+                                            mock_capture.assert_not_called()
+            finally:
+                config.BACKEND_CONNECT = original_backend_connect
+                config.NO_MEMPOOL = original_no_mempool
+
+    asyncio.run(run_test())
+
+
 # ============================================================================
 # Tests for receive_rawblock generic exception handler (lines 189-190)
 # ============================================================================

--- a/counterparty-core/counterpartycore/test/units/parser/follow_test.py
+++ b/counterparty-core/counterpartycore/test/units/parser/follow_test.py
@@ -1198,9 +1198,7 @@ def test_receive_multipart_swallows_interrupt_during_shutdown():
                                             ),
                                         ):
                                             # MUST NOT raise during shutdown...
-                                            await watcher.receive_multipart(
-                                                mock_socket, "rawblock"
-                                            )
+                                            await watcher.receive_multipart(mock_socket, "rawblock")
                                             # ...and MUST NOT page Sentry.
                                             mock_capture.assert_not_called()
             finally:

--- a/release-notes/release-notes-v11.1.1.md
+++ b/release-notes/release-notes-v11.1.1.md
@@ -60,6 +60,7 @@ The activation block height is not yet set (placeholder `9999999`):
 - Fix MPMA sends: correct per-asset balance accumulation, byte-accurate text-memo length encoding, require a destination per asset, and reject duplicate asset/destination pairs
 - Fix holder/supply consolidation that skipped deduplication (`id` used instead of the record key)
 - Default a missing bet `target_value` to zero and clarify BTC dividend "below dust" errors
+- Stop reporting shutdown interrupts as errors: when the server is stopping, `RawMempoolParser.stop()` calls `db.interrupt()` on the connection shared with the blockchain watcher, aborting any in-flight parse as `ParseTransactionError("interrupted")`; the watcher now treats this as expected teardown noise (logged at debug) instead of logging an error, paging Sentry, and forcing a "fail loud" restart
 
 - Expose a unique `credit_index` / `debit_index` field on `credits` / `debits` rows. Identical rows can be written within a single transaction (e.g. an MPMA send or a dividend crediting the same address+asset more than once), making them byte-identical and indistinguishable to API consumers; the new field carries the row's stable unique id so they can be told apart (#3320)
 


### PR DESCRIPTION
## Problem

Sentry issue [API-SERVER-8G](https://unspendablelabs.sentry.io/issues/7556192417): `Error processing message: ParseTransactionError('interrupted')` in production.

`ParseTransactionError('interrupted')` is an `apsw.InterruptError` (whose `str()` is exactly `"interrupted"`) wrapped at [blocks.py:260](../blob/develop/counterparty-core/counterpartycore/lib/parser/blocks.py#L260). It is triggered by a `db.interrupt()` that aborts an in-flight SQLite query.

### Chain

1. `RawMempoolParser` shares the **same** DB connection as the watcher (`RawMempoolParser(self.db)`).
2. On shutdown, `BlockchainWatcher.stop()` → `mempool_parser.stop()` → `db.interrupt()` on that shared connection.
3. If the watcher is mid-parse inside `receive_message` (`receive_rawblock`/`receive_rawtx` → `parse_tx`), the query is aborted → `InterruptError("interrupted")` → `ParseTransactionError("interrupted")`.
4. `receive_multipart` logged it as an error, sent it to Sentry, and re-raised to force a "fail loud" restart — of a process that was already stopping.

This is benign teardown noise: no block/tx is corrupted (the supervisor restarts `catch_up()` from scratch anyway).

## Fix

Guard the `receive_multipart` exception handler with `stop_event`: during shutdown, log the interrupt at `debug` and return quietly instead of paging Sentry / re-raising. The fail-loud path is preserved for genuine processing failures (when `stop_event` is not set).

## Tests

- New `test_receive_multipart_swallows_interrupt_during_shutdown`: with `stop_event` set, a `ParseTransactionError("interrupted")` is neither re-raised nor sent to Sentry.
- Existing `test_receive_multipart_message_processing_error` still asserts the fail-loud re-raise when not shutting down.

Release notes updated in `release-notes/release-notes-v11.1.1.md`.