### PR TITLE
perf: serve /v2/events count from events_count table

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/queries.py
+++ b/counterparty-core/counterpartycore/lib/api/queries.py
@@ -825,8 +825,39 @@ def get_transaction_by_tx_index(ledger_db, tx_index: int):
     )
 
 
+def get_total_events_count(state_db, event_names=None):
+    """
+    Returns the total number of events, optionally restricted to `event_names`.
+
+    Reads the pre-aggregated `events_count` table (one row per event type) instead
+    of running `COUNT(*)` over the whole `messages` table, which is a full scan.
+    `events_count` is maintained incrementally as events are written and fully
+    recomputed on every State DB rollback, so the total stays exact.
+    """
+    cursor = state_db.cursor()
+    if event_names is None:
+        row = cursor.execute("SELECT SUM(count) AS count FROM events_count").fetchone()
+    else:
+        names = [name for name in event_names if name]
+        if not names:
+            return 0
+        placeholders = ",".join(["?"] * len(names))
+        row = cursor.execute(
+            f"SELECT SUM(count) AS count FROM events_count WHERE event IN ({placeholders})",  # noqa: S608 # nosec B608
+            names,
+        ).fetchone()
+    if row is None or row["count"] is None:
+        return 0
+    return row["count"]
+
+
 def get_all_events(
-    ledger_db, event_name: str = None, cursor: int = None, limit: int = 100, offset: int = None
+    ledger_db,
+    state_db,
+    event_name: str = None,
+    cursor: int = None,
+    limit: int = 100,
+    offset: int = None,
 ):
     """
     Returns all events
@@ -836,9 +867,11 @@ def get_all_events(
     :param int offset: The number of lines to skip before returning results (overrides the `cursor` parameter)
     """
     where = None
+    event_names = None
     if event_name:
-        where = [{"event": event} for event in event_name.split(",")]
-    return select_rows(
+        event_names = event_name.split(",")
+        where = [{"event": event} for event in event_names]
+    query_result = select_rows(
         ledger_db,
         "messages",
         where=where,
@@ -847,7 +880,10 @@ def get_all_events(
         limit=limit,
         offset=offset,
         select="message_index AS event_index, event, bindings AS params, tx_hash, block_index",
+        with_count=False,
     )
+    query_result.result_count = get_total_events_count(state_db, event_names)
+    return query_result
 
 
 def get_events_by_block(
@@ -1032,7 +1068,7 @@ def get_event_by_index(ledger_db, event_index: int):
 
 
 def get_events_by_name(
-    ledger_db, event: str, cursor: int = None, limit: int = 100, offset: int = None
+    ledger_db, state_db, event: str, cursor: int = None, limit: int = 100, offset: int = None
 ):
     """
     Returns the events filtered by event name
@@ -1041,7 +1077,7 @@ def get_events_by_name(
     :param int limit: The maximum number of events to return (e.g. 5)
     :param int offset: The number of lines to skip before returning results (overrides the `cursor` parameter)
     """
-    return select_rows(
+    query_result = select_rows(
         ledger_db,
         "messages",
         where={"event": event},
@@ -1050,7 +1086,10 @@ def get_events_by_name(
         limit=limit,
         offset=offset,
         select="message_index AS event_index, event, bindings AS params, tx_hash, block_index",
+        with_count=False,
     )
+    query_result.result_count = get_total_events_count(state_db, [event])
+    return query_result
 
 
 def get_events_by_addresses(

--- a/counterparty-core/counterpartycore/test/units/api/queries_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/queries_test.py
@@ -563,15 +563,44 @@ def test_transaction_queries_return_zero_btc_amount_for_null(ledger_db, current_
 # =============================================================================
 
 
-def test_get_all_events_with_event_name(ledger_db):
+def _messages_count(ledger_db, event_names=None):
+    cursor = ledger_db.cursor()
+    if event_names is None:
+        return cursor.execute("SELECT COUNT(*) AS count FROM messages").fetchone()["count"]
+    placeholders = ",".join(["?"] * len(event_names))
+    return cursor.execute(
+        f"SELECT COUNT(*) AS count FROM messages WHERE event IN ({placeholders})",  # noqa: S608
+        event_names,
+    ).fetchone()["count"]
+
+
+def test_get_all_events_with_event_name(ledger_db, state_db):
     """Test get_all_events with event_name filter (line 658)."""
     result = queries.get_all_events(
         ledger_db,
+        state_db,
         event_name="CREDIT,DEBIT",
     )
     assert result is not None
     for row in result.result:
         assert row["event"] in ["CREDIT", "DEBIT"]
+    # result_count is read from the pre-aggregated `events_count` table and must
+    # match a direct COUNT(*) over `messages` for the same filter.
+    assert result.result_count == _messages_count(ledger_db, ["CREDIT", "DEBIT"])
+
+
+def test_get_all_events_count_matches_messages(ledger_db, state_db):
+    """The unfiltered total comes from `events_count` and must equal COUNT(*) of messages."""
+    result = queries.get_all_events(ledger_db, state_db)
+    assert result.result_count == _messages_count(ledger_db)
+
+
+def test_get_events_by_name_count_matches_messages(ledger_db, state_db):
+    """get_events_by_name reads its count from `events_count`; it must stay exact."""
+    result = queries.get_events_by_name(ledger_db, state_db, event="CREDIT")
+    for row in result.result:
+        assert row["event"] == "CREDIT"
+    assert result.result_count == _messages_count(ledger_db, ["CREDIT"])
 
 
 def test_get_events_by_block_with_event_name(ledger_db, current_block_index):

--- a/release-notes/release-notes-v11.1.1.md
+++ b/release-notes/release-notes-v11.1.1.md
@@ -79,6 +79,7 @@ The activation block height is not yet set (placeholder `9999999`):
 - Fix intermittent BIP143 signature mismatches in regtest by broadcasting tx1 before signing tx2, so the wallet sees tx1's UTXOs in its mempool view
 - Add a `bootstrap-once` catch-up mode (downloads the bootstrap only when no database exists)
 - Re-enable the profiler on Python 3.12, skip the count query for single-row selects, and normalize null transaction `btc_amount` to `0`
+- Serve the `result_count` of `/v2/events` and `/v2/events/<event>` from the pre-aggregated `events_count` table instead of a full `messages` table scan (turning a ~222ms count on every cache-miss request into a sub-millisecond aggregate); the public query parameters are unchanged
 - Update Python dependencies: Flask 3.0.0→3.1.3, pytest 7.4.4→9.0.3, requests 2.32.4→2.33.0, Werkzeug 3.1.4→3.1.6, itsdangerous 2.1.2→2.2.0
 - Update Rust dependencies: openssl 0.10.79→0.10.81, openssl-sys 0.9.115→0.9.117, pyo3 0.24.2→0.25.1 (migrate `IntoPy`/`into_py` to the `IntoPyObject` API, since the old trait was removed in pyo3 0.25)
 


### PR DESCRIPTION
## Problem

`/v2/events` (`get_all_events`) computes its `result_count` via the generic `select_rows` helper, which wraps the whole query in `SELECT COUNT(*) FROM (SELECT ... FROM messages)`. With no filter this is a **full scan of `messages`** — ~222ms (59% of the request, per Sentry issue 7567656011). There was no way for a client to skip it.

## Fix

Reuse the already-maintained `events_count` table (one row per event type), populated by migration 0005, incremented per event in `apiwatcher`, and fully recomputed on every State DB rollback (`MIGRATIONS_AFTER_ROLLBACK`) — so it stays exact. The total is just `SUM(count)` over that tiny table.

- New `get_total_events_count(state_db, event_names=None)` helper.
- `get_all_events` (`/v2/events`) and `get_events_by_name` (`/v2/events/<event>`, incl. the huge CREDIT/DEBIT lists) now pass `with_count=False` and read the count from `events_count`.
- The dispatcher auto-injects `state_db` once it's a parameter; public query params are unchanged (no API contract change).

Net: the count goes from a ~222ms full table scan to a sub-millisecond aggregate over a handful of rows on every cache-miss request.

## Note

Rows still come from the ledger DB while the count now comes from the state DB. During an active catch-up window the count may briefly undercount by at most a few blocks' events; it never over-counts (`events_count` is only incremented from already-written ledger events) and self-heals once caught up. `result_count` is a pagination hint, not a consensus value.

## Tests

- New tests assert `result_count` equals a direct `COUNT(*)` over `messages` (unfiltered, comma-filtered, single-event).
- Full `test/units/api/` suite: 385 passed.