### PR TITLE
Fix empty address-transaction endpoints on normalized Ledger DB

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/queries.py
+++ b/counterparty-core/counterpartycore/lib/api/queries.py
@@ -220,6 +220,14 @@ _MESSAGES_QUALIFY_M_FIELDS = frozenset({"block_index", "tx_index", "rowid", "mes
 # ``all_transactions_with_status`` is omitted on purpose: it counts over
 # ``mempool_transactions UNION ALL transactions`` and there is no single
 # underlying table to substitute.
+#
+# ``source``/``destination`` are deliberately NOT listed as safe columns: the
+# view exposes them as the decoded address *string* while the underlying
+# ``transactions`` table stores the compact integer ``address_id``. A WHERE
+# filter on those columns (resolved against the view as a string -- see
+# ``_INDEX_RESOLVING_VIEWS``) would compare a string against an integer id on
+# the base table and count zero, making the count inconsistent with the rows.
+# Omitting them falls the COUNT back to the view itself (string == string).
 _COUNT_FROM_OVERRIDE = {
     "transactions_with_status": (
         "transactions",
@@ -229,8 +237,6 @@ _COUNT_FROM_OVERRIDE = {
                 "tx_hash",
                 "block_index",
                 "block_time",
-                "source",
-                "destination",
                 "btc_amount",
                 "fee",
                 "data",
@@ -241,6 +247,26 @@ _COUNT_FROM_OVERRIDE = {
         ),
     ),
 }
+
+# Views that already resolve the compact ``asset_index``/``address_id`` foreign
+# keys back to the asset *name* / address *string* in their own definition
+# (every index-typed column they expose is wrapped in a
+# ``(SELECT ... FROM assets/address_list WHERE ...)`` subquery). A WHERE/ORDER BY
+# filter on those columns must therefore stay a plain string comparison: the
+# name->index / string->id subquery rewrite that ``select_rows`` applies to
+# *base* Ledger DB tables would compare the view's decoded string against an
+# integer index and silently match nothing. ``_is_asset_index_col`` /
+# ``_is_address_index_col`` consult this set to suppress the rewrite. Keep it in
+# sync with the index-decoding ``CREATE VIEW`` statements in
+# ``ledger.migration_data.compact_hash_schema`` (``VIEWS_AFTER_REWRITE``).
+_INDEX_RESOLVING_VIEWS = frozenset(
+    {
+        "all_transactions",
+        "transactions_with_status",
+        "all_transactions_with_status",
+        "all_holders",
+    }
+)
 
 
 def _hash_fk_public_columns(db, table):
@@ -706,7 +732,11 @@ def select_rows(
     _assets_index_table = _resolve_local_index_table(db, "main.assets", _ASSETS_INDEX_TABLE_CACHE)
 
     def _is_asset_index_col(field):
-        return _assets_index_table is not None and field in database.ASSET_INDEX_COLUMN_NAMES
+        return (
+            _assets_index_table is not None
+            and table not in _INDEX_RESOLVING_VIEWS
+            and field in database.ASSET_INDEX_COLUMN_NAMES
+        )
 
     # Address columns are stored as the compact integer ``address_id`` on Ledger
     # DB tables, while the State DB consolidated tables keep the string. Detect a
@@ -718,7 +748,11 @@ def select_rows(
     )
 
     def _is_address_index_col(field):
-        return _address_index_table is not None and field in database.ADDRESS_INDEX_COLUMN_NAMES
+        return (
+            _address_index_table is not None
+            and table not in _INDEX_RESOLVING_VIEWS
+            and field in database.ADDRESS_INDEX_COLUMN_NAMES
+        )
 
     or_where = []
     for where_dict in where:

--- a/counterparty-core/counterpartycore/test/units/api/queries_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/queries_test.py
@@ -626,23 +626,66 @@ def test_get_transactions_by_block_with_valid_filter(ledger_db, current_block_in
 
 def test_get_transactions_by_address_with_valid_filter(ledger_db, defaults):
     """Test get_transactions_by_address with valid filter (line 521)."""
+    address = defaults["addresses"][0]
     result = queries.get_transactions_by_address(
         ledger_db,
-        address=defaults["addresses"][0],
+        address=address,
         valid=True,
     )
     assert result is not None
+    # Every returned transaction must actually be sourced from the queried
+    # address: the address-string -> ``address_id`` WHERE rewrite must not fire
+    # against the ``transactions_with_status`` view (which already exposes
+    # ``source`` as a decoded string), otherwise the rows come back empty.
+    assert all(row["source"] == address for row in result.result)
 
 
 def test_get_transactions_by_addresses_with_valid_filter(ledger_db, defaults):
     """Test get_transactions_by_addresses with valid filter (line 556)."""
-    addresses = f"{defaults['addresses'][0]},{defaults['addresses'][1]}"
+    addr1, addr2 = defaults["addresses"][0], defaults["addresses"][1]
     result = queries.get_transactions_by_addresses(
         ledger_db,
-        addresses=addresses,
+        addresses=f"{addr1},{addr2}",
         valid=True,
     )
     assert result is not None
+    assert all(row["source"] in (addr1, addr2) for row in result.result)
+
+
+def test_get_transactions_by_address_returns_matching_rows_and_consistent_count(ledger_db):
+    """Regression (compact-hash normalization): on a migrated Ledger DB the
+    ``transactions_with_status`` view exposes ``source``/``destination`` as the
+    decoded address *string*, so ``select_rows`` must NOT apply its
+    address-string -> ``address_id`` WHERE rewrite to it. When it did, the row
+    query compared a string column against an integer id and returned ZERO rows,
+    while ``result_count`` -- counted off the base ``transactions`` table via
+    ``_COUNT_FROM_OVERRIDE`` where ``source`` is the integer id -- stayed
+    non-zero: empty results paired with an inconsistent count. Endpoints
+    affected: ``/v2/addresses/<address>/transactions`` (+ the multi-address
+    variant) and ``/v2/addresses/<address>/transactions/counts``.
+    """
+    # Derive the busiest source address from the fixture itself so the test is
+    # independent of the default-address layout and is never trivially empty.
+    busiest = ledger_db.execute(
+        "SELECT source, COUNT(*) AS c FROM transactions_with_status "
+        "WHERE source IS NOT NULL GROUP BY source ORDER BY c DESC, source LIMIT 1"
+    ).fetchone()
+    address, expected_count = busiest["source"], busiest["c"]
+    assert expected_count > 0  # sanity: the fixture has source-attributed txs
+
+    result = queries.get_transactions_by_address(
+        ledger_db, address=address, limit=expected_count + 10
+    )
+    # Rows are returned (the bug returned []), every row matches the address, and
+    # the total count agrees with the rows (the bug left count != len(rows)).
+    assert len(result.result) == expected_count
+    assert all(row["source"] == address for row in result.result)
+    assert result.result_count == expected_count
+
+    # The per-type counts endpoint sums back to the same total (it returned no
+    # groups at all under the bug).
+    type_counts = queries.get_transaction_types_count_by_address(ledger_db, address=address)
+    assert sum(row["count"] for row in type_counts.result) == expected_count
 
 
 def test_transaction_queries_return_zero_btc_amount_for_null(ledger_db, current_block_index):


### PR DESCRIPTION
## Problem

The compact-hash normalization (migration `0010`) stores `source`/`destination` as the integer `address_id` on base tables, and `select_rows` rewrites address-string `WHERE`/`ORDER BY` filters into a `string -> address_id` subquery on Ledger DB connections.

But the `transactions_with_status`, `all_transactions_with_status`, `all_transactions` and `all_holders` views already decode those columns back to strings in their own definition (`(SELECT address FROM address_list WHERE address_id = ...) AS source`). So the rewrite compared a **decoded string** column against an **integer id** and matched nothing.

Result — on a normalized Ledger DB these endpoints returned **zero rows** while `result_count` (counted off the base `transactions` table via `_COUNT_FROM_OVERRIDE`, where `source` is the integer id) stayed non-zero, i.e. empty results paired with an inconsistent count:

- `GET /v2/addresses/<address>/transactions`
- `GET /v2/addresses/transactions` (multi-address)
- `GET /v2/addresses/<address>/transactions/counts`

CI was green because the only tests asserted `result is not None`, which is true for an empty-but-present result.

## Fix

- Add `_INDEX_RESOLVING_VIEWS` and make `_is_asset_index_col` / `_is_address_index_col` return `False` for those views, so the index `WHERE`/`ORDER BY` rewrite is suppressed and the filter stays a plain string comparison (correct against the decoded view columns).
- Drop `source`/`destination` from the `transactions_with_status` `_COUNT_FROM_OVERRIDE` so the `COUNT` falls back to the view (`string == string`) and stays consistent with the rows. Other safe columns (`tx_hash` BLOB, `block_index`, …) keep the fast base-table count.

## Tests

- New regression test `test_get_transactions_by_address_returns_matching_rows_and_consistent_count`: derives the busiest source address from the fixture, then asserts rows are returned, every row matches the address, `result_count == len(rows)`, and the `/counts` endpoint sums to the same total. **Fails on the previous code** (`assert 0 == 40`), passes with the fix.
- Strengthened the two existing address-transaction tests to assert row content instead of only `result is not None`.

`queries_test.py` (150) and `apiserver_test.py` (57) pass; Ruff clean.