### PR TITLE
fix: halt instead of silently dropping a tx when VIN resolution fails

### DIFF
--- a/counterparty-core/counterpartycore/lib/backend/bitcoind.py
+++ b/counterparty-core/counterpartycore/lib/backend/bitcoind.py
@@ -125,8 +125,13 @@ def rpc_call(payload, retry=0):
                 raise exceptions.BitcoindRPCError(
                     f"Authorization error connecting to {clean_url_for_log(url)}: {response.status_code} {response.reason}"
                 )
-            if response.status_code == 503:
-                raise ConnectionError("Received 503 error from backend")
+            if response.status_code in (502, 503, 504):
+                # Transient gateway errors (commonly emitted by a reverse proxy
+                # or SSH tunnel sitting in front of the backend when it is
+                # briefly unreachable/overloaded). Route them through the
+                # connection-retry path instead of raising, so catch-up waits
+                # and retries rather than mis-resolving a VIN.
+                raise ConnectionError(f"Received {response.status_code} error from backend")
             if response.status_code == 429:
                 # Rate limited - retry with exponential backoff
                 backoff_time = min(2**tries, 60)  # Max 60 seconds
@@ -655,12 +660,35 @@ def get_vin_info_legacy(vin, no_retry=False):
             script.is_segwit_output(vout["script_pub_key"]),
         )
     except exceptions.BitcoindRPCError as e:
-        logger.warning(
-            "Failed to lookup parent transaction %s for VIN resolution. "
-            "This transaction will be skipped. Is `txindex` enabled in Bitcoin Core?",
-            vin["hash"],
-        )
-        raise exceptions.DecodeError("vin not found") from e
+        # While parsing the mempool the parent transaction may legitimately be
+        # unavailable (e.g. not yet relayed). Skipping the *unconfirmed* tx is
+        # safe: it will be re-evaluated once it confirms.
+        if CurrentState().parsing_mempool():
+            logger.warning(
+                "Failed to lookup parent transaction %s for VIN resolution. "
+                "Skipping unconfirmed (mempool) transaction.",
+                vin["hash"],
+            )
+            raise exceptions.DecodeError("vin not found") from e
+        # During catch-up the parent of a *confirmed* transaction must exist.
+        # A failure here is an infrastructure error (unhealthy/overloaded
+        # backend, a transient gateway 5xx, missing `txindex`, ...), NOT
+        # evidence that the transaction is non-Counterparty. Silently treating
+        # it as BTC-only would drop a real Counterparty transaction and
+        # permanently fork the ledger from consensus (this is exactly what
+        # happened at block 510556). Halt instead: the surrounding block is
+        # rolled back atomically and retried on the next run, so a transient
+        # blip never corrupts the ledger.
+        if CurrentState().stopping():
+            # A clean shutdown interrupted the lookup; propagate the original
+            # (shutdown) error rather than the consensus-corruption warning.
+            raise
+        raise exceptions.BitcoindRPCError(
+            f"Failed to resolve parent transaction {vin['hash']} for VIN resolution "
+            "while parsing a confirmed block. Refusing to silently skip a confirmed "
+            "transaction, which would corrupt consensus. Is `txindex` enabled and the "
+            "backend healthy?"
+        ) from e
 
 
 def get_transaction(tx_hash: str, result_format: str = "json"):

--- a/counterparty-core/counterpartycore/test/units/backend/bitcoind_test.py
+++ b/counterparty-core/counterpartycore/test/units/backend/bitcoind_test.py
@@ -515,24 +515,37 @@ def test_get_vin_info_legacy(monkeypatch):
     )
 
 
-def test_get_vin_info_legacy_error(monkeypatch):
+def test_get_vin_info_legacy_error_halts_during_catchup(monkeypatch):
+    """During catch-up (a confirmed block) a failure to resolve the parent
+    transaction must HALT (raise), never be swallowed into a silent skip.
+    Silently skipping a confirmed Counterparty tx forks the ledger -- this is
+    the regression that caused the block 510556 divergence. The diagnostic must
+    point operators at the cause (parent txid + `txindex`)."""
+
+    def raise_error(*args, **kwargs):
+        raise exceptions.BitcoindRPCError("No such mempool or blockchain transaction")
+
+    monkeypatch.setattr(bitcoind, "get_decoded_transaction", raise_error)
+    monkeypatch.setattr(bitcoind.CurrentState, "parsing_mempool", lambda self: False)
+    monkeypatch.setattr(bitcoind.CurrentState, "stopping", lambda self: False)
+
+    parent_txid = "fba2aa8d334a6c74eaa8b0998be6c29477ff4d927449e9a07efa0ec374fc73bf"
+    with pytest.raises(exceptions.BitcoindRPCError, match="Refusing to silently skip") as exc:
+        bitcoind.get_vin_info_legacy({"hash": parent_txid, "n": 1})
+    assert parent_txid in str(exc.value)
+    assert "txindex" in str(exc.value)
+
+
+def test_get_vin_info_legacy_error_skips_in_mempool(monkeypatch):
+    """While parsing the mempool an unresolvable parent is acceptable: the
+    *unconfirmed* tx is skipped (DecodeError) and a warning is logged. It is
+    re-evaluated once it confirms."""
+
     def raise_error(*args, **kwargs):
         raise exceptions.BitcoindRPCError
 
     monkeypatch.setattr(bitcoind, "get_decoded_transaction", raise_error)
-
-    with pytest.raises(exceptions.DecodeError, match="vin not found"):
-        bitcoind.get_vin_info_legacy({"hash": "hash", "n": 0})
-
-
-def test_get_vin_info_legacy_error_logs_warning(monkeypatch):
-    """When a parent transaction cannot be found, a warning must be logged
-    so operators can diagnose why a Counterparty transaction was skipped."""
-
-    def raise_error(*args, **kwargs):
-        raise exceptions.BitcoindRPCError
-
-    monkeypatch.setattr(bitcoind, "get_decoded_transaction", raise_error)
+    monkeypatch.setattr(bitcoind.CurrentState, "parsing_mempool", lambda self: True)
 
     parent_txid = "fba2aa8d334a6c74eaa8b0998be6c29477ff4d927449e9a07efa0ec374fc73bf"
     with patch.object(bitcoind.logger, "warning") as mock_warning:
@@ -542,7 +555,6 @@ def test_get_vin_info_legacy_error_logs_warning(monkeypatch):
     mock_warning.assert_called_once()
     logged_message = mock_warning.call_args[0][0] % mock_warning.call_args[0][1:]
     assert parent_txid in logged_message
-    assert "txindex" in logged_message
 
 
 def test_get_vin_info_falls_back_to_legacy(monkeypatch):
@@ -570,26 +582,25 @@ def test_get_vin_info_falls_back_to_legacy(monkeypatch):
     assert is_segwit is False
 
 
-def test_get_vin_info_fallback_also_fails(monkeypatch):
-    """When Rust VIN info is None AND the legacy fallback also fails,
-    a warning is logged and DecodeError is raised. This is the scenario
-    that caused a transaction to be silently skipped on a user's server."""
+def test_get_vin_info_fallback_halts_during_catchup(monkeypatch):
+    """When Rust VIN info is None AND the legacy fallback also fails during
+    catch-up, the node must HALT rather than silently skip the confirmed
+    transaction. This is the scenario that silently forked a user's ledger at
+    block 510556."""
 
     def raise_error(*args, **kwargs):
         raise exceptions.BitcoindRPCError("No such mempool or blockchain transaction")
 
     monkeypatch.setattr(bitcoind, "get_decoded_transaction", raise_error)
+    monkeypatch.setattr(bitcoind.CurrentState, "parsing_mempool", lambda self: False)
+    monkeypatch.setattr(bitcoind.CurrentState, "stopping", lambda self: False)
 
     parent_txid = "01f38776b07990118cb3720b9143adbde3725af12e0394cdd02c36458c6b3a03"
     vin_without_info = {"hash": parent_txid, "n": 1, "info": None}
 
-    with patch.object(bitcoind.logger, "warning") as mock_warning:
-        with pytest.raises(exceptions.DecodeError, match="vin not found"):
-            original_get_vin_info(vin_without_info)
-
-    mock_warning.assert_called_once()
-    logged_message = mock_warning.call_args[0][0] % mock_warning.call_args[0][1:]
-    assert parent_txid in logged_message
+    with pytest.raises(exceptions.BitcoindRPCError, match="Refusing to silently skip") as exc:
+        original_get_vin_info(vin_without_info)
+    assert parent_txid in str(exc.value)
 
 
 def test_reset_caches_clears_dicts():

--- a/counterparty-core/tools/compareledger.py
+++ b/counterparty-core/tools/compareledger.py
@@ -6,6 +6,107 @@ import sys
 import apsw
 
 
+def normalize_hash(value):
+    """Normalize a hash value to a canonical hex string.
+
+    The `hashes` branch stores some hashes as raw BLOBs while the legacy
+    database stores them as hex TEXT. Convert both to lowercase hex so that
+    identical hashes compare equal regardless of storage representation.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.hex()
+    return value.lower()
+
+
+def normalize_value(value):
+    """Render a column value for comparison, BLOBs as hex.
+
+    The `hashes` branch stores tx hashes, block hashes, etc. as raw BLOBs while
+    the legacy database stores them as hex TEXT. Hex-encoding BLOBs makes both
+    representations comparable.
+    """
+    if isinstance(value, bytes):
+        return value.hex()
+    return str(value)
+
+
+def is_normalized_schema(db):
+    """The `hashes` branch adds an `address_list` lookup table to resolve FKs."""
+    return bool(
+        db.cursor()
+        .execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='address_list'")
+        .fetchone()
+    )
+
+
+def ledger_selects(db):
+    """Return (credit_select, debit_select) without a WHERE clause, yielding
+    comparable (table_name, block_index, address, asset, quantity, fn, event)
+    rows regardless of whether `db` uses the normalized (hashes-branch) schema.
+
+    On the normalized schema, address/asset are integer FKs, so resolve them
+    back to TEXT via address_list/assets to match the legacy schema.
+    """
+    if is_normalized_schema(db):
+        # `assets` also has a block_index column, so always qualify with alias `t`.
+        credit = """SELECT 'credit', t.block_index, al.address, a.asset_name, t.quantity,
+                           t.calling_function, t.event
+                    FROM credits t
+                    LEFT JOIN address_list al ON al.address_id = t.address
+                    LEFT JOIN assets a ON a.asset_index = t.asset"""
+        debit = """SELECT 'debit', t.block_index, al.address, a.asset_name, t.quantity,
+                          t.action, t.event
+                   FROM debits t
+                   LEFT JOIN address_list al ON al.address_id = t.address
+                   LEFT JOIN assets a ON a.asset_index = t.asset"""
+    else:
+        credit = """SELECT 'credit', t.block_index, t.address, t.asset, t.quantity,
+                           t.calling_function, t.event
+                    FROM credits t"""
+        debit = """SELECT 'debit', t.block_index, t.address, t.asset, t.quantity,
+                          t.action, t.event
+                   FROM debits t"""
+    return credit, debit
+
+
+TX_COLUMNS = [
+    "tx_index",
+    "tx_hash",
+    "block_index",
+    "block_hash",
+    "block_time",
+    "source",
+    "destination",
+    "btc_amount",
+    "fee",
+    "data",
+    "supported",
+    "utxos_info",
+    "transaction_type",
+]
+
+
+def tx_relation_columns(db):
+    """Pick a transactions relation and its columns.
+
+    Prefer the `transactions_with_status` view, which on the normalized schema
+    resolves source/destination/block_hash back to TEXT; fall back to the raw
+    `transactions` table.
+    """
+    cursor = db.cursor()
+    relation = (
+        "transactions_with_status"
+        if cursor.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='view' AND name='transactions_with_status'"
+        ).fetchone()
+        else "transactions"
+    )
+    columns = {row[1] for row in cursor.execute(f"PRAGMA table_info({relation})")}
+    return relation, columns
+
+
 def compare_strings(string1, string2):
     """Compare strings diff-style."""
     diff = list(difflib.unified_diff(string1.splitlines(1), string2.splitlines(1), n=0))
@@ -16,46 +117,26 @@ def compare_strings(string1, string2):
     return len(diff)
 
 
+def block_ledger_str(db, where, params):
+    credit, debit = ledger_selects(db)
+    cursor = db.cursor()
+    rows = cursor.execute(f"{credit} WHERE {where}", params).fetchall()  # noqa: S608 # nosec B608
+    rows += cursor.execute(f"{debit} WHERE {where}", params).fetchall()  # noqa: S608 # nosec B608
+    # Sort so that order differences within a block don't show as spurious diffs.
+    return "\n".join(sorted(", ".join(normalize_value(x) for x in row) for row in rows))
+
+
 def get_ledger(database_file):
     db = apsw.Connection(database_file, flags=apsw.SQLITE_OPEN_READONLY)
-    cursor = db.cursor()
-
-    credit_fields = "block_index, address, asset, quantity, calling_function, event"
-    debit_fields = "block_index, address, asset, quantity, action, event"
-    query = f"""SELECT 'credit' as table_name, {credit_fields} FROM credits WHERE block_index < {LAST_BLOCK}
-            UNION ALL
-            SELECT 'debits' as table_name, {debit_fields} FROM debits WHERE block_index < {LAST_BLOCK}
-            ORDER BY block_index DESC
-            """  # noqa: S608 # nosec B608
-
-    cursor.execute(query)
-
-    rows = []
-    for row in cursor:
-        rows.append(", ".join([str(x) for x in row]))
-    rows_str = "\n".join(rows)
-
+    rows_str = block_ledger_str(db, "t.block_index < ?", (LAST_BLOCK,))
     return f"{database_file}\n{rows_str}"
 
 
 def compare_block_ledger(database_file_1, database_file_2, block_index):
     db1 = apsw.Connection(database_file_1, flags=apsw.SQLITE_OPEN_READONLY)
-    cursor1 = db1.cursor()
-
     db2 = apsw.Connection(database_file_2, flags=apsw.SQLITE_OPEN_READONLY)
-    cursor2 = db2.cursor()
-
-    credit_fields = "block_index, address, asset, quantity, calling_function, event"
-    debit_fields = "block_index, address, asset, quantity, action, event"
-    query = f"""SELECT 'credit' as table_name, {credit_fields} FROM credits WHERE block_index = ?
-            UNION ALL
-            SELECT 'debits' as table_name, {debit_fields} FROM debits WHERE block_index = ?
-            ORDER BY block_index DESC
-            """  # noqa: S608 # nosec B608
-    movements1 = cursor1.execute(query, (block_index, block_index)).fetchall()
-    movements2 = cursor2.execute(query, (block_index, block_index)).fetchall()
-    block1_str = "\n".join([", ".join([str(x) for x in mvnt]) for mvnt in movements1])
-    block2_str = "\n".join([", ".join([str(x) for x in mvnt]) for mvnt in movements2])
+    block1_str = block_ledger_str(db1, "t.block_index = ?", (block_index,))
+    block2_str = block_ledger_str(db2, "t.block_index = ?", (block_index,))
     print(f"Block {block_index}")
     print(f"----------------{database_file_1}---------------------")
     print(block1_str)
@@ -65,19 +146,25 @@ def compare_block_ledger(database_file_1, database_file_2, block_index):
     compare_strings(block1_str, block2_str)
 
 
+def txlist_str(db, relation, columns, block_index):
+    cursor = db.cursor()
+    fields = ", ".join(columns)
+    rows = cursor.execute(
+        f"SELECT {fields} FROM {relation} WHERE block_index = ? ORDER BY tx_index",  # noqa: S608 # nosec B608
+        (block_index,),
+    ).fetchall()
+    return "\n".join(", ".join(normalize_value(x) for x in row) for row in rows)
+
+
 def compare_txlist(database_file_1, database_file_2, block_index):
     db1 = apsw.Connection(database_file_1, flags=apsw.SQLITE_OPEN_READONLY)
-    cursor1 = db1.cursor()
-
     db2 = apsw.Connection(database_file_2, flags=apsw.SQLITE_OPEN_READONLY)
-    cursor2 = db2.cursor()
-
-    query = f"""SELECT * FROM transactions WHERE block_index = {block_index} ORDER BY tx_index"""  # noqa: S608 # nosec B608
-
-    liste1 = cursor1.execute(query).fetchall()
-    liste2 = cursor2.execute(query).fetchall()
-    block1_str = "\n".join([", ".join([str(x) for x in mvnt]) for mvnt in liste1])
-    block2_str = "\n".join([", ".join([str(x) for x in mvnt]) for mvnt in liste2])
+    relation1, cols1 = tx_relation_columns(db1)
+    relation2, cols2 = tx_relation_columns(db2)
+    # Compare only the columns both schemas expose (e.g. legacy `block_hash`).
+    columns = [c for c in TX_COLUMNS if c in cols1 and c in cols2]
+    block1_str = txlist_str(db1, relation1, columns, block_index)
+    block2_str = txlist_str(db2, relation2, columns, block_index)
     print(f"Block {block_index}")
     print(f"----------------{database_file_1}---------------------")
     print(block1_str)
@@ -102,7 +189,7 @@ def check_hashes(database_file_1, database_file_2, hash_name="ledger_hash"):
             f"SELECT block_index, {hash_name} FROM blocks WHERE block_index = ?",  # noqa: S608 # nosec B608
             (block1[0],),  # noqa: S608 # nosec B608
         ).fetchone()
-        if block1[1] != block2[1]:
+        if normalize_hash(block1[1]) != normalize_hash(block2[1]):
             print(block1[0], block1[1], block2[1])
             if hash_name == "ledger_hash":
                 compare_block_ledger(database_file_1, database_file_2, block1[0])
@@ -149,7 +236,7 @@ def get_last_block(database_file_1, database_file_2):
 database_file_1 = sys.argv[1]
 database_file_2 = sys.argv[2]
 
-LAST_BLOCK = 939011
+LAST_BLOCK = 600000
 # compare_ledger(database_file_1, database_file_2)
 check_hashes(database_file_1, database_file_2, "txlist_hash")
 # get_checkpoints(database_file_1)

--- a/counterparty-rs/src/indexer/rpc_client.rs
+++ b/counterparty-rs/src/indexer/rpc_client.rs
@@ -175,7 +175,21 @@ impl BatchRpcClient {
 
         let responses: Vec<RpcResponse> = response.json()?;
 
-        for (txid, response) in uncached_txids.iter().zip(responses.into_iter()) {
+        // JSON-RPC 2.0 does not guarantee that batch responses are returned in
+        // request order, so match each response to its request by `id` (the
+        // index into `uncached_txids`) rather than by position. Zipping by
+        // position silently mis-resolves prevouts -- assigning one input's
+        // parent transaction to another input -- whenever the backend reorders
+        // the batch, which corrupts VIN resolution for multi-input transactions.
+        let mut responses_by_id: HashMap<u64, RpcResponse> =
+            responses.into_iter().map(|r| (r.id, r)).collect();
+
+        for (i, txid) in uncached_txids.iter().enumerate() {
+            let response = responses_by_id.remove(&(i as u64)).ok_or_else(|| {
+                BatchRpcError::InvalidResponse(format!(
+                    "Missing batch response for id {i} (txid {txid})"
+                ))
+            })?;
             let tx = match response {
                 RpcResponse {
                     result: Some(value),


### PR DESCRIPTION
## Problem

A normalized (hashes-branch) database diverged from the legacy reference at **block 510556** — the **only** divergent block across 600k. Two valid OP_RETURN Counterparty transactions were silently dropped at listing:

| tx_index | tx_hash | type | parent (prevout) |
|---|---|---|---|
| 1198843 | `2c04a287…` | order | block 510465 — listed ✓ |
| 1198844 | `d1f518e8…` | order | block 509496 — **dropped** ✗ |
| 1198845 | `aadc58f1…` | enhanced_send | block 510556 (in-block) — **dropped** ✗ |

Because two txs were dropped, `tx_index` shifts by +2 for every later block, so all subsequent `txlist_hash` values diverge.

## Root cause

When the parent transaction of a confirmed tx can't be resolved, `get_vin_info_legacy` raised `DecodeError("vin not found")`, which `get_tx_info` swallows → the transaction was silently treated as **BTC-only** and skipped. A failure to fetch a parent transaction is an **infrastructure error** (transient gateway 5xx from a proxy/SSH-tunnelled backend, overloaded node, missing `txindex`…), **not** evidence that the tx is non-Counterparty. Treating it as such permanently forks the ledger from consensus with only a warning log (which is easily lost to log rotation).

The current code+binary parses all three transactions correctly (reproduced via the real Rust `Deserializer.parse_block` + `get_tx_info` against the live backend), confirming the drop was transient/environmental — but the code turned that transient blip into a **permanent silent divergence**.

A prior occurrence of this exact scenario already had a regression test (`test_get_vin_info_fallback_also_fails`), but it had only been "fixed" by adding a warning log; the tx was still silently skipped.

## Changes

- **`bitcoind.get_vin_info_legacy`** — during catch-up (a *confirmed* block) a parent-tx resolution failure now **halts** instead of silently skipping. The block rolls back atomically (`with db:`) and is retried on the next run, so a transient blip never alters consensus. Mempool parsing still skips the *unconfirmed* tx (it's re-evaluated once it confirms). A clean shutdown propagates the original error.
- **`bitcoind.rpc_call`** — retry transient gateway `502`/`504` like `503`, so a brief proxy/tunnel hiccup self-heals via the existing retry loop instead of reaching the halt.
- **`rpc_client.rs` `get_transactions`** — match batch JSON-RPC responses by `id` instead of position. JSON-RPC 2.0 does not guarantee response ordering; zipping by position silently mis-resolves prevouts for **multi-input** transactions if the backend reorders the batch. *(Requires a `counterparty_rs` rebuild to take effect.)*
- **`tools/compareledger.py`** — support comparing a normalized (hashes-branch) db against a legacy reference db (the workflow that surfaced this).

## Tests

- Replaced the tests that asserted the old silent-skip behavior with `test_get_vin_info_legacy_error_halts_during_catchup`, `test_get_vin_info_legacy_error_skips_in_mempool`, and `test_get_vin_info_fallback_halts_during_catchup`.
- `backend` (97) + `parser/gettxinfo` + `parser/mempool` (25) suites pass; `cargo check` passes.

## Operator note

Nodes whose ledger already diverged from such a drop must `rollback <block>` and re-sync — `reparse` alone will not re-list transactions absent from the `transactions` table.
