### PR TITLE
fix: indexed base-table filter for address-transaction queries (16s full scan → indexed)

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/queries.py
+++ b/counterparty-core/counterpartycore/lib/api/queries.py
@@ -275,15 +275,29 @@ _INDEX_RESOLVING_VIEWS = frozenset(
 # address. Rewrite such a filter into ``tx_index IN (SELECT tx_index FROM <base>
 # WHERE source/destination = <resolved id>)`` so the base table's integer index
 # (``transactions_source_idx`` etc.) is used and only the matching page is
-# decoded. Mapping: view -> tuple of (base_table, keeps_text_address). The
-# transient ``mempool_transactions`` is excluded from address normalization (see
-# migration 0010) and keeps TEXT ``source``/``destination``, so its leg matches
-# the raw string; the normalized ``transactions`` leg resolves to ``address_id``.
+# decoded. Mapping: view -> tuple of legs ``(base_table, keeps_text_address,
+# confirmed_guard)``. The transient ``mempool_transactions`` is excluded from
+# address normalization (see migration 0010) and keeps TEXT ``source``/
+# ``destination``, so its leg matches the raw string; the normalized
+# ``transactions`` leg resolves to ``address_id``.
+#
+# ``confirmed_guard`` disambiguates a leg on the view's ``confirmed`` flag and is
+# REQUIRED whenever a view unions two base tables that share the ``tx_index``
+# space. ``all_transactions_with_status`` is ``mempool_transactions UNION ALL
+# transactions``: a mempool tx_index is assigned as ``max(last_mempool,
+# last_confirmed) + 1`` and a lingering mempool tx is never re-indexed, so a
+# *later* confirmed tx of a different address reuses that ``tx_index``. A bare
+# ``tx_index IN (mempool_leg UNION ALL transactions_leg)`` would then cross-match
+# the other leg's row on such a collision (a foreign address's tx leaking into
+# the result). Gating each leg on ``confirmed`` keeps a leg's ``tx_index`` set
+# from matching the other leg's rows. The single-base ``transactions_with_status``
+# needs no guard (``tx_index`` is unique in ``transactions``) and has no
+# ``confirmed`` column, so its guard is ``None``.
 _TX_VIEW_ADDRESS_FILTER_BASES = {
-    "transactions_with_status": (("transactions", False),),
+    "transactions_with_status": (("transactions", False, None),),
     "all_transactions_with_status": (
-        ("transactions", False),
-        ("mempool_transactions", True),
+        ("transactions", False, "confirmed"),
+        ("mempool_transactions", True, "NOT confirmed"),
     ),
 }
 # The only address columns the transaction views (and their base tables) expose.
@@ -790,22 +804,28 @@ def select_rows(
         into an indexed ``tx_index IN (...)`` subquery against the base table(s).
         ``field`` is ``source``/``destination`` (a constant column name, not user
         input); ``values`` is the list of address strings. Returns
-        ``(sql_clause, extra_bindings)``."""
+        ``(sql_clause, extra_bindings)``. When a view unions two base tables that
+        share the ``tx_index`` space (``all_transactions_with_status``), each leg
+        is gated on the view's ``confirmed`` flag so a ``tx_index`` collision
+        between a lingering mempool tx and a confirmed tx of a different address
+        cannot cross-match (see ``_TX_VIEW_ADDRESS_FILTER_BASES``)."""
         placeholders = ",".join(["?"] * len(values))
-        legs = []
+        clauses = []
         extra = []
-        for base_table, keeps_text_address in _TX_VIEW_ADDRESS_FILTER_BASES[table]:
+        for base_table, keeps_text_address, confirmed_guard in _TX_VIEW_ADDRESS_FILTER_BASES[table]:
             if keeps_text_address:
-                legs.append(
-                    f"SELECT tx_index FROM {base_table} WHERE {field} IN ({placeholders})"  # noqa: S608  # nosec B608
-                )
+                subquery = f"SELECT tx_index FROM {base_table} WHERE {field} IN ({placeholders})"  # noqa: S608  # nosec B608
             else:
-                legs.append(
+                subquery = (
                     f"SELECT tx_index FROM {base_table} WHERE {field} IN "  # noqa: S608  # nosec B608
                     f"(SELECT address_id FROM {_address_index_table} WHERE address IN ({placeholders}))"
                 )
             extra += values
-        return f"tx_index IN ({' UNION ALL '.join(legs)})", extra
+            if confirmed_guard is None:
+                clauses.append(f"tx_index IN ({subquery})")
+            else:
+                clauses.append(f"({confirmed_guard} AND tx_index IN ({subquery}))")
+        return f"({' OR '.join(clauses)})", extra
 
     or_where = []
     for where_dict in where:

--- a/counterparty-core/counterpartycore/lib/api/queries.py
+++ b/counterparty-core/counterpartycore/lib/api/queries.py
@@ -268,6 +268,27 @@ _INDEX_RESOLVING_VIEWS = frozenset(
     }
 )
 
+# Resolving *transaction* views expose ``source``/``destination`` as the decoded
+# address *string* (a correlated ``(SELECT address FROM address_list ...)`` in the
+# view definition). A WHERE filter on that string cannot use an index, so it scans
+# the whole ``transactions`` table and decodes every row -- ~16s for a busy
+# address. Rewrite such a filter into ``tx_index IN (SELECT tx_index FROM <base>
+# WHERE source/destination = <resolved id>)`` so the base table's integer index
+# (``transactions_source_idx`` etc.) is used and only the matching page is
+# decoded. Mapping: view -> tuple of (base_table, keeps_text_address). The
+# transient ``mempool_transactions`` is excluded from address normalization (see
+# migration 0010) and keeps TEXT ``source``/``destination``, so its leg matches
+# the raw string; the normalized ``transactions`` leg resolves to ``address_id``.
+_TX_VIEW_ADDRESS_FILTER_BASES = {
+    "transactions_with_status": (("transactions", False),),
+    "all_transactions_with_status": (
+        ("transactions", False),
+        ("mempool_transactions", True),
+    ),
+}
+# The only address columns the transaction views (and their base tables) expose.
+_TX_VIEW_ADDRESS_COLUMNS = frozenset({"source", "destination"})
+
 
 def _hash_fk_public_columns(db, table):
     """Return the list of column names to expose to the API for a table
@@ -754,6 +775,38 @@ def select_rows(
             and field in database.ADDRESS_INDEX_COLUMN_NAMES
         )
 
+    def _is_tx_view_address_col(field):
+        # Only on a Ledger DB (``_address_index_table`` probe) do the transaction
+        # views decode the id; on a State DB their ``source``/``destination`` are
+        # plain indexed TEXT and the default equality clause is already fast.
+        return (
+            _address_index_table is not None
+            and table in _TX_VIEW_ADDRESS_FILTER_BASES
+            and field in _TX_VIEW_ADDRESS_COLUMNS
+        )
+
+    def _tx_view_address_clause(field, values):
+        """Rewrite an address equality/IN filter on a resolving transaction view
+        into an indexed ``tx_index IN (...)`` subquery against the base table(s).
+        ``field`` is ``source``/``destination`` (a constant column name, not user
+        input); ``values`` is the list of address strings. Returns
+        ``(sql_clause, extra_bindings)``."""
+        placeholders = ",".join(["?"] * len(values))
+        legs = []
+        extra = []
+        for base_table, keeps_text_address in _TX_VIEW_ADDRESS_FILTER_BASES[table]:
+            if keeps_text_address:
+                legs.append(
+                    f"SELECT tx_index FROM {base_table} WHERE {field} IN ({placeholders})"  # noqa: S608  # nosec B608
+                )
+            else:
+                legs.append(
+                    f"SELECT tx_index FROM {base_table} WHERE {field} IN "  # noqa: S608  # nosec B608
+                    f"(SELECT address_id FROM {_address_index_table} WHERE address IN ({placeholders}))"
+                )
+            extra += values
+        return f"tx_index IN ({' UNION ALL '.join(legs)})", extra
+
     or_where = []
     for where_dict in where:
         where_field = []
@@ -807,6 +860,14 @@ def select_rows(
                     # ``_COUNT_FROM_OVERRIDE`` gate sees the actual schema
                     # column rather than the legacy hex hash alias.
                     field = new_field
+                elif _is_tx_view_address_col(field):
+                    clause, extra = _tx_view_address_clause(field, list(value))
+                    where_field.append(clause)
+                    bindings += extra
+                    # The emitted clause filters on ``tx_index``; record that so
+                    # the ``_COUNT_FROM_OVERRIDE`` gate can count from the base
+                    # table (``tx_index`` is a safe column) instead of the view.
+                    field = "tx_index"
                 elif _is_asset_index_col(field):
                     where_field.append(
                         f"{_qualify(field)} IN (SELECT asset_index FROM {_assets_index_table} "  # noqa: S608  # nosec B608
@@ -859,6 +920,15 @@ def select_rows(
                     # ``dispenser_tx_hash``); record the *resolved* FK column
                     # name so the override gate sees the actual schema column.
                     field = new_field
+                elif _is_tx_view_address_col(key):
+                    values = value.split(",") if isinstance(value, str) else [value]
+                    clause, extra = _tx_view_address_clause(key, values)
+                    where_field.append(clause)
+                    bindings += extra
+                    # The emitted clause filters on ``tx_index``; record that so
+                    # the ``_COUNT_FROM_OVERRIDE`` gate can count from the base
+                    # table (``tx_index`` is a safe column) instead of the view.
+                    field = "tx_index"
                 elif _is_address_index_col(key):
                     # Ledger DB: address columns store the compact ``address_id``;
                     # rewrite the (possibly comma-separated) address value(s) to

--- a/counterparty-core/counterpartycore/test/units/api/queries_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/queries_test.py
@@ -116,6 +116,74 @@ def test_get_transactions_by_address_matches_naive_view_filter(ledger_db, defaul
     assert fast.result_count == len(naive_tx_indexes)
 
 
+def test_get_transactions_by_address_show_unconfirmed_ignores_tx_index_collision(
+    ledger_db, defaults
+):
+    """``all_transactions_with_status`` (``show_unconfirmed``) is
+    ``mempool_transactions UNION ALL transactions`` -- the two share the
+    ``tx_index`` space: a mempool ``tx_index`` is ``max(last_mempool,
+    last_confirmed) + 1`` and a lingering mempool tx is never re-indexed, so a
+    *later* confirmed tx of a different address reuses it. The indexed rewrite
+    must gate each leg on the view's ``confirmed`` flag; a bare
+    ``tx_index IN (mempool_leg UNION ALL transactions_leg)`` would cross-match
+    and leak a foreign address's row. Regression for that collision."""
+    address_a = defaults["addresses"][0]
+    address_b = defaults["addresses"][1]
+
+    # A confirmed tx of A whose ``tx_index`` we deliberately reuse for a (fake)
+    # still-pending mempool tx belonging to B -- the collision the guard must
+    # neutralise.
+    confirmed_a = queries.get_transactions_by_address(ledger_db, address_a, limit=1)
+    assert confirmed_a.result, "fixture address must have confirmed transactions"
+    colliding_tx_index = confirmed_a.result[0]["tx_index"]
+    assert confirmed_a.result[0]["source"] == address_a
+
+    # ``mempool_transactions`` keeps a TEXT ``source`` (address string): the
+    # transient rows are re-inserted after the rowtracer decoded the id.
+    ledger_db.execute(
+        """INSERT INTO mempool_transactions (
+               tx_index, tx_hash, block_index, block_hash, block_time,
+               source, destination, btc_amount, fee, data, supported,
+               utxos_info, transaction_type
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            colliding_tx_index,
+            hashcodec.hash_to_db("ff" * 32),
+            config.MEMPOOL_BLOCK_INDEX,
+            config.MEMPOOL_BLOCK_HASH,
+            0,
+            address_b,
+            None,
+            0,
+            0,
+            None,
+            1,
+            "",
+            None,
+        ),
+    )
+
+    # Querying A must NOT leak B's pending tx that collides on ``tx_index``,
+    # while still returning the genuine confirmed tx at that index.
+    result_a = queries.get_transactions_by_address(
+        ledger_db, address_a, show_unconfirmed=True, limit=10000
+    )
+    assert all(row["source"] == address_a for row in result_a.result)
+    assert colliding_tx_index in {row["tx_index"] for row in result_a.result}
+
+    # Querying B must return B's pending tx (matched by the mempool leg) but NOT
+    # A's confirmed tx that shares the ``tx_index``.
+    result_b = queries.get_transactions_by_address(
+        ledger_db, address_b, show_unconfirmed=True, limit=10000
+    )
+    assert all(row["source"] == address_b for row in result_b.result)
+    b_collision_rows = [row for row in result_b.result if row["tx_index"] == colliding_tx_index]
+    assert len(b_collision_rows) == 1
+    assert b_collision_rows[0]["confirmed"] is False
+    # Row/count consistency holds through the guarded rewrite.
+    assert result_b.result_count == len(result_b.result)
+
+
 def test_select_rows_with_cursor_asc_order(ledger_db):
     """Test select_rows with cursor and ASC order (lines 247-250)."""
     # First get some results

--- a/counterparty-core/counterpartycore/test/units/api/queries_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/queries_test.py
@@ -62,6 +62,62 @@ def test_select_rows_with_comma_separated_addresses(ledger_db, defaults):
         assert row["address"] in [addr1, addr2]
 
 
+def test_get_transactions_by_address_uses_indexed_base_filter(ledger_db, defaults):
+    """Address-filtered transaction queries must resolve the address to its
+    integer ``address_id`` and filter the indexed base ``transactions.source``
+    instead of scanning the decoding ``transactions_with_status`` view (whose
+    per-row ``(SELECT address FROM address_list ...)`` cannot use an index and
+    turned ``/addresses/<addr>/transactions`` into a ~16s full scan for a busy
+    address). Regression for the v11.2.0 Load API failure."""
+    address = defaults["addresses"][0]
+
+    executed = []
+    ledger_db.setexectrace(lambda cursor, sql, bindings: (executed.append(sql) or True))
+    try:
+        result = queries.get_transactions_by_address(ledger_db, address, limit=50)
+    finally:
+        ledger_db.setexectrace(None)
+
+    # Correctness: assert row CONTENT and row/``result_count`` consistency,
+    # never just ``result is not None`` (which stays true for an empty result).
+    assert result.result_count is not None
+    assert len(result.result) == min(result.result_count, 50)
+    for row in result.result:
+        assert row["source"] == address
+
+    # Performance: the row query rewrites the address filter into an indexed
+    # ``tx_index IN (SELECT tx_index FROM transactions WHERE source ...)`` lookup
+    # rather than comparing the view's decoded ``source`` string per row.
+    row_query = next(
+        s for s in executed if "transactions_with_status" in s and "COUNT(*)" not in s
+    )
+    normalized = " ".join(row_query.split())
+    assert "tx_index IN (SELECT tx_index FROM transactions WHERE source IN" in normalized
+    assert "address_list WHERE address IN" in normalized
+
+
+def test_get_transactions_by_address_matches_naive_view_filter(ledger_db, defaults):
+    """The indexed rewrite must return exactly the rows a naive filter on the
+    decoding view returns -- same correctness, without the full scan."""
+    address = defaults["addresses"][0]
+
+    fast = queries.get_transactions_by_address(ledger_db, address, limit=10000, offset=0)
+    fast_tx_indexes = sorted(row["tx_index"] for row in fast.result)
+
+    naive_rows = (
+        ledger_db.cursor()
+        .execute(
+            "SELECT tx_index FROM transactions_with_status WHERE source = ?",
+            (address,),
+        )
+        .fetchall()
+    )
+    naive_tx_indexes = sorted(row["tx_index"] for row in naive_rows)
+
+    assert fast_tx_indexes == naive_tx_indexes
+    assert fast.result_count == len(naive_tx_indexes)
+
+
 def test_select_rows_with_cursor_asc_order(ledger_db):
     """Test select_rows with cursor and ASC order (lines 247-250)."""
     # First get some results

--- a/counterparty-core/counterpartycore/test/units/api/queries_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/queries_test.py
@@ -88,9 +88,7 @@ def test_get_transactions_by_address_uses_indexed_base_filter(ledger_db, default
     # Performance: the row query rewrites the address filter into an indexed
     # ``tx_index IN (SELECT tx_index FROM transactions WHERE source ...)`` lookup
     # rather than comparing the view's decoded ``source`` string per row.
-    row_query = next(
-        s for s in executed if "transactions_with_status" in s and "COUNT(*)" not in s
-    )
+    row_query = next(s for s in executed if "transactions_with_status" in s and "COUNT(*)" not in s)
     normalized = " ".join(row_query.split())
     assert "tx_index IN (SELECT tx_index FROM transactions WHERE source IN" in normalized
     assert "address_list WHERE address IN" in normalized


### PR DESCRIPTION
## Problem

The v11.2.0 Load API integration test ([PR #3447](https://github.com/CounterpartyXCP/counterparty-core/pull/3447)) fails with a single `ConnectionResetError(104, 'Connection reset by peer')` on an incidental in-flight request (`/v2/blocks/<b>/fairminters`). The fairminters endpoint is **not** the cause.

The run's slowest request by far is `/v2/addresses/1JDog…/transactions` at **16 150 ms**. That breaches gunicorn's `timeout: 10`, the worker is recycled, and the co-located keep-alive request is reset → `num_failures == 1` → test fails.

Root cause: `get_transactions_by_address` / `get_transactions_by_addresses` filter `{"source": address}` on the `transactions_with_status` **view**, whose `source`/`destination` are decoded per row via a correlated `(SELECT address FROM address_list WHERE address_id = t.source)`. `WHERE source = '<addr>'` therefore **cannot use `transactions_source_idx`** and does a full scan + per-row subquery — ~16s for a busy address.

Confirmed regression: the Load test passed on `626c4c850` (the `hashes` normalization merge — address-transactions returned empty=fast, the pre-#3448 bug) and failed on `6d28cb221`, i.e. after #3448's correctness fix made it correct-but-slow.

## Fix

`select_rows` now rewrites a `source`/`destination` filter on the resolving transaction views into an indexed lookup:

```sql
WHERE tx_index IN (
  SELECT tx_index FROM transactions
  WHERE source IN (SELECT address_id FROM address_list WHERE address IN (?))
)
```

- Uses `transactions_source_idx`; only the returned page is decoded (by the existing rowtracer, so output is byte-identical).
- `all_transactions_with_status` gets a second `UNION ALL` leg over the transient `mempool_transactions` (kept TEXT by migration 0010 → matched as a raw string).
- The address key records `field="tx_index"` so `_COUNT_FROM_OVERRIDE` counts from the base `transactions` table instead of the view.
- Gated on a Ledger DB connection (`_address_index_table is not None`); State DB / pre-normalization schemas keep the plain indexed-TEXT clause.
- No view/migration change → applies to already-normalized nodes too.

## Validation

- `EXPLAIN QUERY PLAN` on a synthetic normalized DB: old = `SCAN t`, new = `SEARCH … USING INDEX transactions_source_idx`.
- Result/count equality across source, destination, multi-address, and the mempool leg.
- Real `get_transactions_by_address` path (source eq / `__in` / unconfirmed two-leg): correct rows, decoding, counts.
- Guard verified against the real pre-normalization mainnet DB: rewrite disabled, `source = ?` preserved.
- Regression tests added in `queries_test.py` asserting the indexed rewrite + naive-view equivalence (row content and row/`result_count` consistency, not just `result is not None` — the gap that masked #3448 in CI).

> Note: the full pytest suite could not be run locally (hatch env missing `apsw`/`zmq`/`pygit2`, rebuild needs unpublished `counterparty-rs==11.2.0`). CI must confirm on the real `ledger_db` fixture.

The Load-test fragility itself (worker recycle resetting a keep-alive connection) is a separate concern, not addressed here.