### PR TITLE
Set v11.2.0 protocol change activation blocks (~2026-08-03)

### DIFF
--- a/counterparty-core/counterpartycore/protocol_changes.json
+++ b/counterparty-core/counterpartycore/protocol_changes.json
@@ -1413,74 +1413,74 @@
     },
     "sweep_skip_zero_balances": {
         "minimum_version_major": 11,
-        "minimum_version_minor": 1,
-        "minimum_version_revision": 1,
-        "block_index": 9999999,
-        "testnet3_block_index": 9999999,
-        "testnet4_block_index": 9999999,
-        "signet_block_index": 9999999
+        "minimum_version_minor": 2,
+        "minimum_version_revision": 0,
+        "block_index": 960000,
+        "testnet3_block_index": 5057500,
+        "testnet4_block_index": 146200,
+        "signet_block_index": 315100
     },
     "fix_fairminter_commission_minimum": {
         "minimum_version_major": 11,
-        "minimum_version_minor": 1,
-        "minimum_version_revision": 1,
-        "block_index": 9999999,
-        "testnet3_block_index": 9999999,
-        "testnet4_block_index": 9999999,
-        "signet_block_index": 9999999
+        "minimum_version_minor": 2,
+        "minimum_version_revision": 0,
+        "block_index": 960000,
+        "testnet3_block_index": 5057500,
+        "testnet4_block_index": 146200,
+        "signet_block_index": 315100
     },
     "multisig_utxo_addresses": {
         "minimum_version_major": 11,
-        "minimum_version_minor": 1,
-        "minimum_version_revision": 1,
-        "block_index": 9999999,
-        "testnet3_block_index": 9999999,
-        "testnet4_block_index": 9999999,
-        "signet_block_index": 9999999
+        "minimum_version_minor": 2,
+        "minimum_version_revision": 0,
+        "block_index": 960000,
+        "testnet3_block_index": 5057500,
+        "testnet4_block_index": 146200,
+        "signet_block_index": 315100
     },
     "issuance_callable_lock_fix": {
         "minimum_version_major": 11,
-        "minimum_version_minor": 1,
-        "minimum_version_revision": 1,
-        "block_index": 9999999,
-        "testnet3_block_index": 9999999,
-        "testnet4_block_index": 9999999,
-        "signet_block_index": 9999999
+        "minimum_version_minor": 2,
+        "minimum_version_revision": 0,
+        "block_index": 960000,
+        "testnet3_block_index": 5057500,
+        "testnet4_block_index": 146200,
+        "signet_block_index": 315100
     },
     "fairmint_pool": {
         "minimum_version_major": 11,
-        "minimum_version_minor": 1,
+        "minimum_version_minor": 2,
         "minimum_version_revision": 0,
-        "block_index": 9999999,
-        "testnet3_block_index": 9999999,
-        "testnet4_block_index": 9999999,
+        "block_index": 960000,
+        "testnet3_block_index": 5057500,
+        "testnet4_block_index": 146200,
         "signet_block_index": 0
     },
     "fix_pool_best_price_routing": {
         "minimum_version_major": 11,
-        "minimum_version_minor": 1,
-        "minimum_version_revision": 1,
-        "block_index": 9999999,
-        "testnet3_block_index": 9999999,
-        "testnet4_block_index": 9999999,
-        "signet_block_index": 9999999
+        "minimum_version_minor": 2,
+        "minimum_version_revision": 0,
+        "block_index": 960000,
+        "testnet3_block_index": 5057500,
+        "testnet4_block_index": 146200,
+        "signet_block_index": 315100
     },
     "fix_pool_deposit_product_overflow": {
         "minimum_version_major": 11,
-        "minimum_version_minor": 1,
-        "minimum_version_revision": 1,
-        "block_index": 9999999,
-        "testnet3_block_index": 9999999,
-        "testnet4_block_index": 9999999,
-        "signet_block_index": 9999999
+        "minimum_version_minor": 2,
+        "minimum_version_revision": 0,
+        "block_index": 960000,
+        "testnet3_block_index": 5057500,
+        "testnet4_block_index": 146200,
+        "signet_block_index": 315100
     },
     "enforce_utxo_vout_max": {
         "minimum_version_major": 11,
-        "minimum_version_minor": 1,
-        "minimum_version_revision": 1,
-        "block_index": 9999999,
-        "testnet3_block_index": 9999999,
-        "testnet4_block_index": 9999999,
-        "signet_block_index": 9999999
+        "minimum_version_minor": 2,
+        "minimum_version_revision": 0,
+        "block_index": 960000,
+        "testnet3_block_index": 5057500,
+        "testnet4_block_index": 146200,
+        "signet_block_index": 315100
     }
 }

--- a/counterparty-core/counterpartycore/protocol_changes.json
+++ b/counterparty-core/counterpartycore/protocol_changes.json
@@ -1415,72 +1415,72 @@
         "minimum_version_major": 11,
         "minimum_version_minor": 2,
         "minimum_version_revision": 0,
-        "block_index": 960000,
-        "testnet3_block_index": 5057500,
-        "testnet4_block_index": 146200,
-        "signet_block_index": 315100
+        "block_index": 961100,
+        "testnet3_block_index": 5064400,
+        "testnet4_block_index": 147200,
+        "signet_block_index": 316200
     },
     "fix_fairminter_commission_minimum": {
         "minimum_version_major": 11,
         "minimum_version_minor": 2,
         "minimum_version_revision": 0,
-        "block_index": 960000,
-        "testnet3_block_index": 5057500,
-        "testnet4_block_index": 146200,
-        "signet_block_index": 315100
+        "block_index": 961100,
+        "testnet3_block_index": 5064400,
+        "testnet4_block_index": 147200,
+        "signet_block_index": 316200
     },
     "multisig_utxo_addresses": {
         "minimum_version_major": 11,
         "minimum_version_minor": 2,
         "minimum_version_revision": 0,
-        "block_index": 960000,
-        "testnet3_block_index": 5057500,
-        "testnet4_block_index": 146200,
-        "signet_block_index": 315100
+        "block_index": 961100,
+        "testnet3_block_index": 5064400,
+        "testnet4_block_index": 147200,
+        "signet_block_index": 316200
     },
     "issuance_callable_lock_fix": {
         "minimum_version_major": 11,
         "minimum_version_minor": 2,
         "minimum_version_revision": 0,
-        "block_index": 960000,
-        "testnet3_block_index": 5057500,
-        "testnet4_block_index": 146200,
-        "signet_block_index": 315100
+        "block_index": 961100,
+        "testnet3_block_index": 5064400,
+        "testnet4_block_index": 147200,
+        "signet_block_index": 316200
     },
     "fairmint_pool": {
         "minimum_version_major": 11,
         "minimum_version_minor": 2,
         "minimum_version_revision": 0,
-        "block_index": 960000,
-        "testnet3_block_index": 5057500,
-        "testnet4_block_index": 146200,
+        "block_index": 961100,
+        "testnet3_block_index": 5064400,
+        "testnet4_block_index": 147200,
         "signet_block_index": 0
     },
     "fix_pool_best_price_routing": {
         "minimum_version_major": 11,
         "minimum_version_minor": 2,
         "minimum_version_revision": 0,
-        "block_index": 960000,
-        "testnet3_block_index": 5057500,
-        "testnet4_block_index": 146200,
-        "signet_block_index": 315100
+        "block_index": 961100,
+        "testnet3_block_index": 5064400,
+        "testnet4_block_index": 147200,
+        "signet_block_index": 316200
     },
     "fix_pool_deposit_product_overflow": {
         "minimum_version_major": 11,
         "minimum_version_minor": 2,
         "minimum_version_revision": 0,
-        "block_index": 960000,
-        "testnet3_block_index": 5057500,
-        "testnet4_block_index": 146200,
-        "signet_block_index": 315100
+        "block_index": 961100,
+        "testnet3_block_index": 5064400,
+        "testnet4_block_index": 147200,
+        "signet_block_index": 316200
     },
     "enforce_utxo_vout_max": {
         "minimum_version_major": 11,
         "minimum_version_minor": 2,
         "minimum_version_revision": 0,
-        "block_index": 960000,
-        "testnet3_block_index": 5057500,
-        "testnet4_block_index": 146200,
-        "signet_block_index": 315100
+        "block_index": 961100,
+        "testnet3_block_index": 5064400,
+        "testnet4_block_index": 147200,
+        "signet_block_index": 316200
     }
 }

--- a/release-notes/release-notes-v11.2.0.md
+++ b/release-notes/release-notes-v11.2.0.md
@@ -41,7 +41,7 @@ The Ledger DB is automatically compacted on first start of v11.2.0 (migration `0
 
 ## Protocol Changes
 
-The activation block heights are `960000` (mainnet), `5057500` (testnet3), `146200` (testnet4) and `315100` (signet) — targeting roughly 2026-07-27; the one exception is `fairmint_pool`, which is also active on signet from genesis (`signet_block_index: 0`) for testing:
+The activation block heights are `961100` (mainnet), `5064400` (testnet3), `147200` (testnet4) and `316200` (signet) — targeting roughly 2026-08-03; the one exception is `fairmint_pool`, which is also active on signet from genesis (`signet_block_index: 0`) for testing:
 
 - `sweep_skip_zero_balances`: sweeps no longer include zero-quantity balances, the anti-spam fee is computed only over the balances/ownerships selected by the sweep `flags`, and an empty sweep is no longer charged the legacy flat fee.
 - `issuance_callable_lock_fix`: removes the obsolete "cannot change callability / advance call date / reduce call price" reissuance restrictions (the `issuance_callability_parameters_removal` guard is preserved).

--- a/release-notes/release-notes-v11.2.0.md
+++ b/release-notes/release-notes-v11.2.0.md
@@ -1,4 +1,4 @@
-# Release Notes - Counterparty Core v11.2.0 (2026-07-03)
+# Release Notes - Counterparty Core v11.2.0 (2026-07-07)
 
 
 # Upgrading
@@ -41,7 +41,7 @@ The Ledger DB is automatically compacted on first start of v11.2.0 (migration `0
 
 ## Protocol Changes
 
-The activation block height is not yet set (placeholder `9999999`); the one exception is `fairmint_pool`, which is currently also active on signet from genesis (`signet_block_index: 0`) for testing:
+The activation block heights are `960000` (mainnet), `5057500` (testnet3), `146200` (testnet4) and `315100` (signet) — targeting roughly 2026-07-27; the one exception is `fairmint_pool`, which is also active on signet from genesis (`signet_block_index: 0`) for testing:
 
 - `sweep_skip_zero_balances`: sweeps no longer include zero-quantity balances, the anti-spam fee is computed only over the balances/ownerships selected by the sweep `flags`, and an empty sweep is no longer charged the legacy flat fee.
 - `issuance_callable_lock_fix`: removes the obsolete "cannot change callability / advance call date / reduce call price" reissuance restrictions (the `issuance_callability_parameters_removal` guard is preserved).


### PR DESCRIPTION
Replace the 9999999 placeholders for the eight v11.2.0 protocol changes
with real activation heights, targeting ~4 weeks out (~2026-08-03):

  mainnet   961100
  testnet3  5064400
  testnet4  147200
  signet    316200

fairmint_pool keeps signet_block_index: 0 (already active on signet for
testing). Update the v11.2.0 release notes to list the actual heights.
