### PR TITLE
Bound Bitcoin backend RPC retries to prevent API worker exhaustion (#3459)

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/apiserver.py
+++ b/counterparty-core/counterpartycore/lib/api/apiserver.py
@@ -451,6 +451,14 @@ def handle_route(**kwargs):
         # call the function
         try:
             result = execute_api_function(rule, route, function_args)
+        except exceptions.BitcoindRPCError as e:
+            # The Bitcoin backend is unavailable or degraded. This is transient
+            # and not the client's fault, so return a retryable 503 rather than a
+            # 400 (which clients treat as a permanent error).
+            error = str(e)
+            set_sentry_api_response_context(503, error)
+            logger.warning("Backend unavailable while serving API request: %s", error)
+            return return_result(503, error=error, start_time=start_time, query_args=query_args)
         except (
             exceptions.JSONRPCInvalidRequest,
             flask.wrappers.BadRequest,
@@ -458,7 +466,6 @@ def handle_route(**kwargs):
             exceptions.BalanceError,
             exceptions.UnknownPubKeyError,
             exceptions.AssetNameError,
-            exceptions.BitcoindRPCError,
             exceptions.ComposeError,
             exceptions.UnpackError,
             CBitcoinAddressError,

--- a/counterparty-core/counterpartycore/lib/backend/bitcoind.py
+++ b/counterparty-core/counterpartycore/lib/backend/bitcoind.py
@@ -35,6 +35,10 @@ TRANSACTIONS_CACHE_MAX_SIZE = 10000
 
 URL_USERNAMEPASS_REGEX = re.compile(".+://(.+)@")
 
+# os-backed RNG for retry-backoff jitter; avoids flagging the module-level
+# pseudo-random generator (Bandit B311) even though this is not security-sensitive.
+_JITTER_RNG = random.SystemRandom()
+
 
 def clean_url_for_log(url):
     m = URL_USERNAMEPASS_REGEX.match(url)
@@ -97,7 +101,7 @@ def retry_backoff(tries):
     cap = getattr(config, "BACKEND_RETRY_MAX_SLEEP", 30)
     ceiling = min(cap, base * (2 ** min(tries, 10)))
     # full jitter: sleep uniformly in [base, ceiling]
-    return random.uniform(min(base, ceiling), ceiling)  # noqa: S311
+    return _JITTER_RNG.uniform(min(base, ceiling), ceiling)
 
 
 def interruptible_sleep(duration, check_interval=0.5):

--- a/counterparty-core/counterpartycore/lib/backend/bitcoind.py
+++ b/counterparty-core/counterpartycore/lib/backend/bitcoind.py
@@ -2,6 +2,7 @@ import binascii
 import functools
 import json
 import logging
+import random
 import re
 import time
 from collections import OrderedDict
@@ -63,6 +64,42 @@ def should_retry():
     return True
 
 
+def request_timeout():
+    """Timeout passed to ``requests``. When a distinct connect timeout is
+    configured, return a ``(connect, read)`` tuple so a stalled/unreachable
+    backend fails the TCP connect quickly instead of hanging for the full
+    read timeout. Falls back to the single read timeout otherwise."""
+    connect_timeout = getattr(config, "BACKEND_CONNECT_TIMEOUT", None)
+    if connect_timeout:
+        return (connect_timeout, config.REQUESTS_TIMEOUT)
+    return config.REQUESTS_TIMEOUT
+
+
+def skip_rpc_retry(no_retry=False):
+    """Whether an RPC call must fail fast instead of entering the unbounded
+    connection-retry loop.
+
+    True for synchronous public API requests (which must never pin a Waitress/
+    Gunicorn worker while a degraded backend retries) and whenever the caller
+    explicitly opts out of retries. False for the parser/indexing path, which
+    must keep retrying to preserve consensus correctness (a skipped VIN would
+    fork the ledger)."""
+    return no_retry or is_api_request()
+
+
+def retry_backoff(tries):
+    """Jittered backoff (seconds) for the parser connection-retry loop.
+
+    Exponential growth capped at ``BACKEND_RETRY_MAX_SLEEP`` with full jitter,
+    so many independent nodes recovering from the same backend outage do not
+    reconnect in lockstep (a synchronized retry storm)."""
+    base = getattr(config, "BACKEND_RETRY_BASE_SLEEP", 1)
+    cap = getattr(config, "BACKEND_RETRY_MAX_SLEEP", 30)
+    ceiling = min(cap, base * (2 ** min(tries, 10)))
+    # full jitter: sleep uniformly in [base, ceiling]
+    return random.uniform(min(base, ceiling), ceiling)  # noqa: S311
+
+
 def interruptible_sleep(duration, check_interval=0.5):
     """Sleep for duration seconds, but check for stop condition every check_interval seconds."""
     elapsed = 0.0
@@ -113,7 +150,7 @@ def rpc_call(payload, retry=0):
                 data=json.dumps(payload),
                 headers=_rpc_headers(),
                 verify=(not config.BACKEND_SSL_NO_VERIFY),
-                timeout=config.REQUESTS_TIMEOUT,
+                timeout=request_timeout(),
                 auth=("__cookie__", config.BACKEND_COOKIE) if config.BACKEND_COOKIE else None,
             )
 
@@ -152,13 +189,23 @@ def rpc_call(payload, retry=0):
                 raise exceptions.BitcoindRPCError(str(response.status_code) + " " + response.reason)
             break
         except (Timeout, ReadTimeout, ConnectionError, ChunkedEncodingError) as e:
+            # A synchronous public API request must never enter this unbounded
+            # loop and pin a worker; fail fast so the caller returns a bounded,
+            # retryable error. The parser path keeps retrying (consensus
+            # correctness) with jittered backoff to avoid a retry storm.
+            if is_api_request():
+                raise exceptions.BitcoindRPCError(
+                    f"Could not connect to backend at `{clean_url_for_log(url)}`: {e}"
+                ) from e
+            backoff = retry_backoff(tries)
             logger.warning(
-                "Could not connect to backend at `%s`. (Attempt: %s)",
+                "Could not connect to backend at `%s`. Retrying in %.1fs. (Attempt: %s)",
                 clean_url_for_log(url),
+                backoff,
                 tries,
                 stack_info=config.VERBOSE > 0,
             )
-            if not interruptible_sleep(5):
+            if not interruptible_sleep(backoff):
                 raise exceptions.BitcoindRPCError(
                     "Shutdown requested during connection retry"
                 ) from e
@@ -223,7 +270,7 @@ def is_api_request():
 
 
 def rpc(method, params, no_retry=False):
-    if is_api_request() or no_retry:
+    if skip_rpc_retry(no_retry):
         return safe_rpc(method, params)
 
     payload = {
@@ -244,7 +291,7 @@ def safe_rpc_payload(payload):
             data=json.dumps(payload),
             headers=_rpc_headers(),
             verify=(not config.BACKEND_SSL_NO_VERIFY),
-            timeout=config.REQUESTS_TIMEOUT,
+            timeout=request_timeout(),
             auth=("__cookie__", config.BACKEND_COOKIE) if config.BACKEND_COOKIE else None,
         )
         if response is None:
@@ -329,7 +376,11 @@ def getrawtransaction_batch(tx_hashes, verbose=False, return_dict=False, no_retr
             for j, tx_hash in enumerate(batch)
         ]
 
-        if no_retry:
+        # Mirror the single-call dispatcher in rpc(): API requests (and explicit
+        # no_retry callers) must fail fast via safe_rpc_payload rather than enter
+        # rpc_call's unbounded retry loop, which would otherwise pin an API worker
+        # while a degraded backend retries forever.
+        if skip_rpc_retry(no_retry):
             batch_results = safe_rpc_payload(payload)
         else:
             batch_results = rpc_call(payload)

--- a/counterparty-core/counterpartycore/lib/cli/initialise.py
+++ b/counterparty-core/counterpartycore/lib/cli/initialise.py
@@ -119,6 +119,7 @@ def initialise_config(
     api_no_allow_cors=False,
     force=False,
     requests_timeout=config.DEFAULT_REQUESTS_TIMEOUT,
+    backend_connect_timeout=config.DEFAULT_BACKEND_CONNECT_TIMEOUT,
     rpc_batch_size=config.DEFAULT_RPC_BATCH_SIZE,
     skip_asset_conservation_check=False,
     backend_ssl_verify=None,
@@ -527,6 +528,7 @@ def initialise_config(
     # Misc
     config.P2SH_DUST_RETURN_PUBKEY = p2sh_dust_return_pubkey
     config.REQUESTS_TIMEOUT = requests_timeout
+    config.BACKEND_CONNECT_TIMEOUT = backend_connect_timeout
     config.CHECK_ASSET_CONSERVATION = not skip_asset_conservation_check
     config.UTXO_LOCKS_MAX_ADDRESSES = utxo_locks_max_addresses
     config.UTXO_LOCKS_MAX_AGE = utxo_locks_max_age
@@ -609,6 +611,9 @@ def initialise_log_and_config(args, api=False, log_stream=None):
         "api_password": args.api_password,
         "api_no_allow_cors": args.api_no_allow_cors,
         "requests_timeout": args.requests_timeout,
+        "backend_connect_timeout": getattr(
+            args, "backend_connect_timeout", config.DEFAULT_BACKEND_CONNECT_TIMEOUT
+        ),
         "rpc_batch_size": args.rpc_batch_size,
         "skip_asset_conservation_check": args.skip_asset_conservation_check,
         "force": args.force,

--- a/counterparty-core/counterpartycore/lib/cli/main.py
+++ b/counterparty-core/counterpartycore/lib/cli/main.py
@@ -241,7 +241,16 @@ CONFIG_ARGS = [
         {
             "type": int,
             "default": config.DEFAULT_REQUESTS_TIMEOUT,
-            "help": "timeout value (in seconds) used for all HTTP requests (default: 5)",
+            "help": "read timeout (in seconds) used for all HTTP requests (default: 20)",
+        },
+    ],
+    [
+        ("--backend-connect-timeout",),
+        {
+            "type": int,
+            "default": config.DEFAULT_BACKEND_CONNECT_TIMEOUT,
+            "help": "TCP connect timeout (in seconds) for backend RPC requests, so an "
+            "unreachable backend fails fast instead of pinning an API worker (default: 5)",
         },
     ],
     [

--- a/counterparty-core/counterpartycore/lib/config.py
+++ b/counterparty-core/counterpartycore/lib/config.py
@@ -220,6 +220,13 @@ DEFAULT_FEE_FRACTION_PROVIDED = 0.01  # 1.00%
 
 
 DEFAULT_REQUESTS_TIMEOUT = 20  # 20 seconds
+# Separate (shorter) TCP connect timeout so an unreachable/stalled backend
+# fails the connect quickly instead of hanging for the full read timeout.
+DEFAULT_BACKEND_CONNECT_TIMEOUT = 5  # 5 seconds
+# Jittered exponential backoff for the parser connection-retry loop, so many
+# nodes recovering from the same backend outage do not reconnect in lockstep.
+BACKEND_RETRY_BASE_SLEEP = 1  # 1 second
+BACKEND_RETRY_MAX_SLEEP = 30  # cap between retries
 DEFAULT_RPC_BATCH_SIZE = 20  # A 1 MB block can hold about 4200 transactions.
 MAX_RPC_BATCH_SIZE = 100  # Maximum number of transactions to send in a single RPC call.
 

--- a/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
@@ -2,7 +2,7 @@ import json
 from unittest.mock import Mock
 
 import pytest
-from counterpartycore.lib import config, ledger
+from counterpartycore.lib import config, exceptions, ledger
 from counterpartycore.lib.api import apiserver, apiwatcher, blockcache, composer
 from counterpartycore.lib.api.routes import ALL_ROUTES, ROUTES
 from counterpartycore.lib.messages import dispense, dividend, sweep
@@ -646,6 +646,21 @@ def test_sentry_context_includes_http_error_returned_to_user(apiv2_client, monke
     assert response.json["error"] == "Unknown error"
     assert len(captured) == 1
     assert isinstance(captured[0], RuntimeError)
+
+
+def test_bitcoind_rpc_error_returns_retryable_503(apiv2_client, monkeypatch):
+    """A degraded Bitcoin backend surfaced as a BitcoindRPCError must return a
+    retryable 503, not a 400 that clients treat as permanent (issue #3459)."""
+
+    def execute_api_function_mock(_rule, _route, _function_args):
+        raise exceptions.BitcoindRPCError("Could not connect to backend")
+
+    monkeypatch.setattr(apiserver, "execute_api_function", execute_api_function_mock)
+
+    response = apiv2_client.get("/v2/transactions?limit=1")
+
+    assert response.status_code == 503
+    assert "Could not connect to backend" in response.json["error"]
 
 
 def test_sentry_context_includes_outer_http_error_returned_to_user(apiv2_client, monkeypatch):

--- a/counterparty-core/counterpartycore/test/units/backend/bitcoind_test.py
+++ b/counterparty-core/counterpartycore/test/units/backend/bitcoind_test.py
@@ -4,6 +4,7 @@ import time
 from unittest.mock import patch
 
 import pytest
+import requests
 from bitcoinutils.transactions import Script
 from counterpartycore.lib import config, exceptions
 from counterpartycore.lib.backend import bitcoind
@@ -710,3 +711,155 @@ def test_reset_caches_handles_missing_lru_cache_clear(monkeypatch):
     assert not hasattr(fake_func, "cache_clear")
 
     bitcoind.reset_caches()
+
+
+# ---------------------------------------------------------------------------
+# Bounded backend RPC retries / overload protection (issue #3459)
+# ---------------------------------------------------------------------------
+
+
+def make_failing_post(fail_times, call_log, exc=requests.exceptions.ConnectionError):
+    """Return a ``requests.post`` replacement that raises ``exc`` for the first
+    ``fail_times`` calls, then returns a valid response. Records every call in
+    ``call_log`` so tests can assert the number of attempts."""
+
+    def _post(*args, **kwargs):
+        call_log.append(1)
+        if len(call_log) <= fail_times:
+            raise exc("backend unavailable")
+        payload = json.loads(kwargs["data"])
+        if isinstance(payload, list):
+            return MockResponse(
+                200, [{"id": item["id"], "result": {"txid": "ok"}} for item in payload]
+            )
+        return MockResponse(200, {"result": "ok"})
+
+    return _post
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout],
+    ids=["connection_refused", "slow_response"],
+)
+def test_rpc_api_request_fails_fast(monkeypatch, exc):
+    """A synchronous API request must fail fast (single attempt) instead of
+    entering the unbounded connection-retry loop that would pin a worker."""
+    monkeypatch.setattr(bitcoind, "is_api_request", lambda: True)
+    calls = []
+    monkeypatch.setattr("requests.post", make_failing_post(1_000, calls, exc=exc))
+
+    with pytest.raises(exceptions.BitcoindRPCError):
+        bitcoind.rpc("getblockcount", [])
+
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout],
+    ids=["connection_refused", "slow_response"],
+)
+def test_getrawtransaction_batch_api_request_fails_fast(monkeypatch, exc):
+    """Regression for issue #3459: the batch RPC path used to ignore
+    is_api_request() and always call rpc_call(), retrying forever and pinning
+    the API worker. It must now fail fast for API requests, exactly like the
+    single-call dispatcher."""
+    monkeypatch.setattr(bitcoind, "is_api_request", lambda: True)
+    calls = []
+    monkeypatch.setattr("requests.post", make_failing_post(1_000, calls, exc=exc))
+
+    with pytest.raises(exceptions.BitcoindRPCError):
+        bitcoind.getrawtransaction_batch(["deadbeef"], verbose=True)
+
+    assert len(calls) == 1
+
+
+def test_getrawtransaction_batch_no_retry_flag_fails_fast(monkeypatch):
+    """Explicit no_retry=True (e.g. mempool parsing) must also fail fast even
+    outside an API context."""
+    monkeypatch.setattr(bitcoind, "is_api_request", lambda: False)
+    calls = []
+    monkeypatch.setattr("requests.post", make_failing_post(1_000, calls))
+
+    with pytest.raises(exceptions.BitcoindRPCError):
+        bitcoind.getrawtransaction_batch(["deadbeef"], verbose=True, no_retry=True)
+
+    assert len(calls) == 1
+
+
+def test_rpc_call_parser_retries_then_recovers(monkeypatch):
+    """The parser/indexing path keeps retrying a transiently-failing backend
+    (consensus correctness) and succeeds once the backend recovers."""
+    monkeypatch.setattr(bitcoind, "is_api_request", lambda: False)
+    # don't actually sleep between retries
+    monkeypatch.setattr(bitcoind, "interruptible_sleep", lambda *a, **k: True)
+    calls = []
+    monkeypatch.setattr("requests.post", make_failing_post(3, calls))
+
+    result = bitcoind.rpc("getblockcount", [])
+
+    assert result == "ok"
+    assert len(calls) == 4  # 3 transient failures + 1 success
+
+
+def test_batch_parser_retries_then_recovers(monkeypatch):
+    """Same intermittent-recovery guarantee for the batch path on the parser
+    side."""
+    monkeypatch.setattr(bitcoind, "is_api_request", lambda: False)
+    monkeypatch.setattr(bitcoind, "interruptible_sleep", lambda *a, **k: True)
+    calls = []
+    monkeypatch.setattr("requests.post", make_failing_post(2, calls))
+
+    result = bitcoind.getrawtransaction_batch(["deadbeef"], verbose=True, return_dict=True)
+
+    assert result == {"deadbeef": {"txid": "ok"}}
+    assert len(calls) == 3  # 2 transient failures + 1 success
+
+
+def test_request_timeout_uses_connect_tuple(monkeypatch):
+    """request_timeout() returns a (connect, read) tuple when a connect timeout
+    is configured, so an unreachable backend fails the connect quickly."""
+    monkeypatch.setattr(config, "BACKEND_CONNECT_TIMEOUT", 5)
+    monkeypatch.setattr(config, "REQUESTS_TIMEOUT", 20)
+    assert bitcoind.request_timeout() == (5, 20)
+
+    monkeypatch.setattr(config, "BACKEND_CONNECT_TIMEOUT", None)
+    assert bitcoind.request_timeout() == 20
+
+
+def test_rpc_passes_connect_timeout_to_requests(monkeypatch):
+    """The connect timeout must actually reach requests.post."""
+    monkeypatch.setattr(bitcoind, "is_api_request", lambda: False)
+    monkeypatch.setattr(config, "BACKEND_CONNECT_TIMEOUT", 3)
+    captured = {}
+
+    def _post(*args, **kwargs):
+        captured["timeout"] = kwargs["timeout"]
+        return MockResponse(200, {"result": "ok"})
+
+    monkeypatch.setattr("requests.post", _post)
+    bitcoind.rpc("getblockcount", [])
+    assert captured["timeout"] == (3, config.REQUESTS_TIMEOUT)
+
+
+def test_retry_backoff_is_bounded_and_jittered(monkeypatch):
+    """Backoff grows with the attempt count but stays within [base, cap], and
+    is randomized so recovering nodes do not reconnect in lockstep."""
+    monkeypatch.setattr(config, "BACKEND_RETRY_BASE_SLEEP", 1)
+    monkeypatch.setattr(config, "BACKEND_RETRY_MAX_SLEEP", 30)
+    values = set()
+    for tries in range(1, 60):
+        backoff = bitcoind.retry_backoff(tries)
+        assert 1 <= backoff <= 30
+        values.add(backoff)
+    # jitter should produce a spread of distinct values, not a constant
+    assert len(values) > 1
+
+
+def test_skip_rpc_retry(monkeypatch):
+    monkeypatch.setattr(bitcoind, "is_api_request", lambda: False)
+    assert bitcoind.skip_rpc_retry(no_retry=False) is False
+    assert bitcoind.skip_rpc_retry(no_retry=True) is True
+    monkeypatch.setattr(bitcoind, "is_api_request", lambda: True)
+    assert bitcoind.skip_rpc_retry(no_retry=False) is True

--- a/counterparty-core/counterpartycore/test/units/cli/main_test.py
+++ b/counterparty-core/counterpartycore/test/units/cli/main_test.py
@@ -106,6 +106,7 @@ def test_argparser():
         "api_password": None,
         "api_no_allow_cors": False,
         "requests_timeout": 20,
+        "backend_connect_timeout": 5,
         "force": False,
         "no_confirm": False,
         "data_dir": "datadir",

--- a/release-notes/release-notes-v11.2.1.md
+++ b/release-notes/release-notes-v11.2.1.md
@@ -1,0 +1,49 @@
+# Release Notes - Counterparty Core v11.2.1 (2026-07-??)
+
+Counterparty Core v11.2.1 is an operational hardening release addressing the root causes of the 2026-07-15 production incident, in which a small number of expensive public API requests against a degraded Bitcoin backend exhausted the API worker pools. There are **no protocol changes** and no database migration; the upgrade is a plain restart.
+
+# Upgrading
+
+**This is not a protocol upgrade.** There is no activation block and no reparse or migration.
+
+To upgrade, download the latest version of `counterparty-core` and restart `counterparty-server`.
+
+With Docker Compose:
+
+```bash
+cd counterparty-core
+git pull
+docker compose stop counterparty-core
+docker compose --profile mainnet up -d
+```
+
+or use `ctrl-c` to interrupt the server:
+
+```bash
+cd counterparty-core
+git pull
+cd counterparty-rs
+pip install -e .
+cd ../counterparty-core
+pip install -e .
+counterparty-server start
+```
+
+# ChangeLog
+
+## API Changes
+
+- A slow or unreachable Bitcoin backend now surfaces to API clients as a retryable **HTTP 503** (`BitcoindRPCError`, previously `400`) (#3459).
+
+## Security / Hardening
+
+- **Bound Bitcoin backend RPC retries** (#3459). `getrawtransaction_batch()` bypassed the no-retry guard used for API requests and fell through to an unbounded `while True` retry loop, so a degraded backend made compose and v1 requests retry forever, pinning worker threads until the pool was exhausted (the `(Attempt: N)` log lines from the incident). The retry decision is now centralized in `skip_rpc_retry()` and applied to both the single-call and batch paths, so API requests never enter the unbounded loop; `rpc_call` also bails out defensively in an API context. A configurable connect timeout fails an unreachable backend's TCP connect quickly instead of hanging for the full read timeout, and the parser's flat retry sleep is replaced with jittered exponential backoff so many nodes recovering from the same outage don't reconnect in lockstep. **The parser/indexing path is unchanged** — it still retries an unavailable backend indefinitely, because skipping a VIN would fork the ledger.
+
+## Configuration
+
+- `--backend-connect-timeout` / `BACKEND_CONNECT_TIMEOUT` (default `5` seconds) — TCP connect timeout for backend RPC (#3459).
+
+# Credits
+
+- Ouziel Slama
+- Adam Krellenstein


### PR DESCRIPTION
Closes #3459.

## Problem

A slow or unreachable Bitcoin backend could exhaust every Counterparty API worker. The single-call dispatcher `rpc()` already routes API requests to the no-retry `safe_rpc` path via `is_api_request()`, but **`getrawtransaction_batch()` bypassed that guard** — it only used the no-retry path when `no_retry=True` was passed *explicitly*, otherwise it went straight to `rpc_call()`'s unbounded `while True` retry loop.

The compose flow (`api/composer.py`) and the legacy v1 API (`api/apiv1.py`) call the batch function **without** `no_retry`, so a degraded backend made those requests retry forever — the `Could not connect to backend ... (Attempt: 108)` seen in the 2026-07-15 incident (v11.2.0). Retrying requests stayed attached to worker threads until the pool was exhausted, at which point even `/v2/healthz` could not obtain a thread and both API replicas went unready.

The `(Attempt: N)` log line is emitted only by `rpc_call`, which is how you can tell a request took the unbounded path rather than the guarded `safe_rpc` one.

## Changes

- **Root cause:** centralize the retry decision in `skip_rpc_retry(no_retry) = no_retry or is_api_request()` and apply it to **both** the single-call (`rpc`) and batch (`getrawtransaction_batch`) paths, so API requests never enter the unbounded retry loop.
- **Defense in depth:** `rpc_call`'s connection-retry handler now bails out (raises) when `is_api_request()`, so an API request can't be pinned even if it reaches `rpc_call` directly.
- **Configurable connect timeout:** new `--backend-connect-timeout` / `BACKEND_CONNECT_TIMEOUT` (default 5s); `request_timeout()` returns a `(connect, read)` tuple so an unreachable backend fails the TCP connect quickly instead of hanging for the full read timeout.
- **No retry storm on recovery:** the flat 5s parser retry sleep is replaced with jittered exponential backoff (`retry_backoff`, base 1s, capped at 30s) so many nodes recovering from the same outage don't reconnect in lockstep.
- **Retryable status:** `BitcoindRPCError` now maps to a **503** at the API layer (was 400), which clients can safely retry.

The **parser/indexing path is unchanged** — it keeps retrying an unavailable backend indefinitely (`is_api_request()` is False in the parser process). Skipping a VIN would fork the ledger, so that behavior must be preserved.

## Acceptance criteria

- ✅ A stalled Bitcoin backend cannot hold an API worker indefinitely.
- ✅ Public API requests fail within a bounded, configurable interval.
- ✅ Recovery does not generate a synchronized retry storm (jittered backoff on the parser path).
- ✅ Parser correctness is preserved when the backend is temporarily unavailable.
- ✅ Tests cover connection refusal, slow responses, intermittent recovery, and API-context fail-fast.

## Tests

New unit tests: batch fail-fast in API context (regression for this bug), connection refusal, slow response (`ReadTimeout`), intermittent recovery on the parser path, explicit `no_retry` fail-fast, connect-timeout tuple, bounded/jittered backoff, `skip_rpc_retry`, and the 503 mapping at the HTTP layer.

Verified green: `backend`, `api/apiserver`, `cli`, `compose`/`composer`, and `parser/mempool` unit suites; ruff lint + format clean.

## Deferred (follow-ups)

A cross-process **circuit breaker** and structured **metrics** (backend latency, retry count, open-circuit state, rejected requests) — listed among the "and/or" options in the issue — are larger, more architectural changes and are intentionally left out of this focused fix.