### PR TITLE
ci: pin electrs commit + cap lints to stop nightly Rust drift breaking integration tests

### DIFF
--- a/.github/workflows/pytest_action.yml
+++ b/.github/workflows/pytest_action.yml
@@ -83,9 +83,16 @@ jobs:
           sudo cp bitcoin-28.0/bin/bitcoind /usr/local/bin/bitcoind
           sudo cp bitcoin-28.0/bin/bitcoin-wallet /usr/local/bin/bitcoin-wallet
           git clone https://github.com/mempool/electrs && cd electrs
+          # Pin electrs to a known commit: mempool/electrs publishes no releases, so
+          # cloning the default branch tracked a moving target that could change under us.
+          git checkout bf622e58bf0b1c01cb2f8ebb23cf35a98b41e67b
           rustup toolchain install nightly
           cargo +nightly update
-          cargo +nightly install --path=.
+          # Cap future-incompatibility lints to warnings. A recent nightly promoted
+          # `semicolon_in_expressions_from_macros` to a hard error, which breaks the old
+          # error-chain `bail!()` calls in electrs and fails the build. electrs is a
+          # third-party binary we only run in tests, so downgrading the lint is safe.
+          RUSTFLAGS='--cap-lints=warn' cargo +nightly install --path=.
 
       - name: Run tests
         # `BACKEND_API_KEY` (when defined as a repo/org secret) lifts the


### PR DESCRIPTION
## Problem

The Integrations / Regtest CI jobs are red on **every branch** (including `master` and `develop`), not because of any code change. The `Install Bitcoin & Electrs` step in `.github/workflows/pytest_action.yml` builds `mempool/electrs` with two **unpinned moving targets**:

```yaml
git clone https://github.com/mempool/electrs && cd electrs   # tip of the default branch
rustup toolchain install nightly                             # latest nightly
cargo +nightly install --path=.
```

A recent **nightly Rust** promoted `semicolon_in_expressions_from_macros` (part of `deny(future_incompatible)`) from a warning to a hard error. electrs' old error-chain `bail!()` calls then fail to compile:

```
error: trailing semicolon in macro used in expression position
  --> src/daemon.rs:73:32
   |
73 |     -28 => bail!(ErrorKind::Connection(err.to_string())),
error: could not compile `mempool-electrs` (lib) due to 22 previous errors
```

Evidence this is environmental, not a regression:
- The identical failure hit `master` (run `29475137542`, 2026-07-16), which carries none of the in-flight PR changes.
- Last green Integrations run on `develop` was 2026-07-08 — before the nightly bump.

## Changes

- **Pin electrs** to a specific commit (`bf622e5`). `mempool/electrs` publishes no releases, so cloning the default branch tracked whatever was on tip.
- **Build with `RUSTFLAGS='--cap-lints=warn'`** so future-incompatibility lints in this third-party test-only binary are downgraded to warnings instead of failing the build. This is date-independent and resilient to the same class of nightly drift recurring.

## Notes

This unblocks all currently-red integration jobs (e.g. #3463). No production/consensus code is touched — CI workflow only.