### PR TITLE
Fix signet gate; Add checkpoints; publish v11.3.0 bootstrap

### DIFF
--- a/.github/workflows/pytest_action.yml
+++ b/.github/workflows/pytest_action.yml
@@ -43,6 +43,11 @@ jobs:
         with:
           path: ~/.cache/counterparty-integration-cache/${{ inputs.integration_cache_network }}
           # Cache key version: increment to invalidate incompatible caches
+          # v6: bootstrap snapshots bumped to v11.3.0. A restored cache short-circuits
+          # the bootstrap download, so without a new key the integration tests would
+          # keep running against the v11.2.0-derived DBs and never exercise the new
+          # snapshots. It also drops any signet cache poisoned by the ungated
+          # `correct_transaction_fee` (activation moved from block 0 to 321300).
           # v5: addresses normalized to a compact `address_id` FK (`address_list`)
           # and `utxo` TEXT split into `(utxo_tx_hash BLOB, utxo_vout)`, folded
           # into migration 0010. yoyo never re-applies an already-applied 0010,
@@ -54,9 +59,9 @@ jobs:
           # migration 0004 then fails with `no such column: a.asset_index`.
           # v3: compact-hash match tables re-keyed on (tx0_index, tx1_index);
           # the v2 cached DBs carry the old TEXT `id` schema and are incompatible.
-          key: integration-v5-${{ inputs.integration_cache_network }}-${{ github.run_id }}
+          key: integration-v6-${{ inputs.integration_cache_network }}-${{ github.run_id }}
           restore-keys: |
-            integration-v5-${{ inputs.integration_cache_network }}-
+            integration-v6-${{ inputs.integration_cache_network }}-
 
       - name: Set up Python
         uses: actions/setup-python@v3
@@ -124,7 +129,7 @@ jobs:
           path: ~/.cache/counterparty-integration-cache/${{ inputs.integration_cache_network }}
           # Cache key version: increment to invalidate incompatible caches
           # (must match the restore key above).
-          key: integration-v5-${{ inputs.integration_cache_network }}-${{ github.run_id }}
+          key: integration-v6-${{ inputs.integration_cache_network }}-${{ github.run_id }}
 
       - name: Upload coverage
         uses: codecov/codecov-action@v5

--- a/counterparty-core/counterpartycore/lib/config.py
+++ b/counterparty-core/counterpartycore/lib/config.py
@@ -278,12 +278,12 @@ PROTOCOL_CHANGES_URL = "https://counterparty.io/protocol_changes.json"
 
 
 BOOTSTRAP_URL_BASE = "https://storage.googleapis.com/counterparty-bootstrap"
-# Version tag embedded in the bootstrap snapshot file names (e.g. "v11.2.0").
+# Version tag embedded in the bootstrap snapshot file names (e.g. "v11.3.0").
 # Versioned names let several releases coexist in the bucket. This tag tracks the
 # latest *published* snapshot set, which may lag behind VERSION_STRING when a
 # release needs no new snapshots (no database migration) or when they have not
 # been uploaded yet — bump it when new snapshots are published to the bucket.
-BOOTSTRAP_VERSION = "v11.2.0"
+BOOTSTRAP_VERSION = "v11.3.0"
 
 # Ledger / state database base file names per network (as stored in the bucket).
 # testnet3 is intentionally absent: it is deprecated and no snapshots are produced

--- a/counterparty-core/counterpartycore/lib/messages/data/checkpoints.py
+++ b/counterparty-core/counterpartycore/lib/messages/data/checkpoints.py
@@ -726,6 +726,10 @@ CHECKPOINTS_MAINNET = {
         "ledger_hash": "50f6d80cf7bfb48cb660570acee0eacdef5ae411d03320e6068e69033dd0e648",
         "txlist_hash": "27094cc108c55f8000aba276a7ffaf77565b49d86523ca5b4dc94605f2a2c254",
     },
+    961411: {
+        "ledger_hash": "d82a114071f5207f10bd3eb8eb792533900e14c493af7ab85adadb64d2bb656e",
+        "txlist_hash": "f8a9bb0a2c516ee319299fcedbe750546f54ad86eecef0e6b2e21a3a67877520",
+    }
 }
 
 CONSENSUS_HASH_VERSION_TESTNET3 = 7
@@ -942,6 +946,10 @@ CHECKPOINTS_TESTNET4 = {
         "ledger_hash": "bbe5848cf8d8fccf655d9e3e74873b3f0b1d85a7047f4d18441394770741e469",
         "txlist_hash": "d61c88dd8147f567f15a3bd2dc8c652e7d48428ad50ed1714f7f700a123845fb",
     },
+    147329: {
+        "ledger_hash": "04f5fe95ec91d58b4104c27855e17ea706e0a30f91245fe5cc212669e03d5bd9",
+        "txlist_hash": "357da5ece31d55e84c3f871d737591ca4d8df45fab21456d53fc88a92649108e",
+    }
 }
 
 CONSENSUS_HASH_VERSION_SIGNET = 1
@@ -978,4 +986,8 @@ CHECKPOINTS_SIGNET = {
         "ledger_hash": "e16c1efb0c0ebacce211751308d97bdd526f15f53d04cc2b2beea0281e90aea7",
         "txlist_hash": "e49498ddd90ab80c5e59eb2ecb9540552bc8828e5ec5cdd453907e8df3f92d53",
     },
+    316609: {
+        "ledger_hash": "23a3dc96462c89684cc353d0f92d8734a097eb417fa18c44af1e8a0a8b4cb836",
+        "txlist_hash": "16c5846178df8f6cc6b2086f90fdf9f717636df9bdf25093561817e4df070cc4",
+    }
 }

--- a/counterparty-core/counterpartycore/lib/messages/data/checkpoints.py
+++ b/counterparty-core/counterpartycore/lib/messages/data/checkpoints.py
@@ -729,7 +729,7 @@ CHECKPOINTS_MAINNET = {
     961411: {
         "ledger_hash": "d82a114071f5207f10bd3eb8eb792533900e14c493af7ab85adadb64d2bb656e",
         "txlist_hash": "f8a9bb0a2c516ee319299fcedbe750546f54ad86eecef0e6b2e21a3a67877520",
-    }
+    },
 }
 
 CONSENSUS_HASH_VERSION_TESTNET3 = 7
@@ -949,7 +949,7 @@ CHECKPOINTS_TESTNET4 = {
     147329: {
         "ledger_hash": "04f5fe95ec91d58b4104c27855e17ea706e0a30f91245fe5cc212669e03d5bd9",
         "txlist_hash": "357da5ece31d55e84c3f871d737591ca4d8df45fab21456d53fc88a92649108e",
-    }
+    },
 }
 
 CONSENSUS_HASH_VERSION_SIGNET = 1
@@ -989,5 +989,5 @@ CHECKPOINTS_SIGNET = {
     316609: {
         "ledger_hash": "23a3dc96462c89684cc353d0f92d8734a097eb417fa18c44af1e8a0a8b4cb836",
         "txlist_hash": "16c5846178df8f6cc6b2086f90fdf9f717636df9bdf25093561817e4df070cc4",
-    }
+    },
 }

--- a/counterparty-core/counterpartycore/protocol_changes.json
+++ b/counterparty-core/counterpartycore/protocol_changes.json
@@ -1490,6 +1490,6 @@
         "block_index": 966200,
         "testnet3_block_index": 5166000,
         "testnet4_block_index": 153700,
-        "signet_block_index": 0
+        "signet_block_index": 321300
     }
 }

--- a/counterparty-core/counterpartycore/test/units/cli/bootstrap_test.py
+++ b/counterparty-core/counterpartycore/test/units/cli/bootstrap_test.py
@@ -22,16 +22,17 @@ def test_verify_signature():
 
 
 def test_generate_urls():
-    counterparty_url = "https://example.com/counterparty.db.v11.2.0.zst"
+    version = config.BOOTSTRAP_VERSION
+    counterparty_url = f"https://example.com/counterparty.db.{version}.zst"
     urls = bootstrap.generate_urls(counterparty_url)
     assert urls == [
         (
-            "https://example.com/counterparty.db.v11.2.0.zst",
-            "https://example.com/counterparty.db.v11.2.0.sig",
+            f"https://example.com/counterparty.db.{version}.zst",
+            f"https://example.com/counterparty.db.{version}.sig",
         ),
         (
-            "https://example.com/state.db.v11.2.0.zst",
-            "https://example.com/state.db.v11.2.0.sig",
+            f"https://example.com/state.db.{version}.zst",
+            f"https://example.com/state.db.{version}.sig",
         ),
     ]
 
@@ -89,9 +90,9 @@ def test_compress_db_roundtrip(tmp_path):
     with open(db_path, "wb") as f:
         f.write(payload)
 
-    zst_path = bootstrap.compress_db(db_path, "v11.2.0", compression_level=1)
+    zst_path = bootstrap.compress_db(db_path, config.BOOTSTRAP_VERSION, compression_level=1)
 
-    assert zst_path == db_path + ".v11.2.0.zst"
+    assert zst_path == db_path + f".{config.BOOTSTRAP_VERSION}.zst"
     assert os.path.exists(zst_path)
     with open(zst_path, "rb") as f:
         assert pyzstd.decompress(f.read()) == payload
@@ -101,8 +102,8 @@ def test_compress_db_roundtrip(tmp_path):
 
 
 def test_verify_prepared_signature_ok(tmp_path, monkeypatch, capsys):
-    zst_path = str(tmp_path / "counterparty.db.v11.2.0.zst")
-    sig_path = str(tmp_path / "counterparty.db.v11.2.0.sig")
+    zst_path = str(tmp_path / f"counterparty.db.{config.BOOTSTRAP_VERSION}.zst")
+    sig_path = str(tmp_path / f"counterparty.db.{config.BOOTSTRAP_VERSION}.sig")
     open(zst_path, "wb").close()
     open(sig_path, "wb").close()
 
@@ -114,8 +115,8 @@ def test_verify_prepared_signature_ok(tmp_path, monkeypatch, capsys):
 
 
 def test_verify_prepared_signature_raises(tmp_path, monkeypatch):
-    zst_path = str(tmp_path / "counterparty.db.v11.2.0.zst")
-    sig_path = str(tmp_path / "counterparty.db.v11.2.0.sig")
+    zst_path = str(tmp_path / f"counterparty.db.{config.BOOTSTRAP_VERSION}.zst")
+    sig_path = str(tmp_path / f"counterparty.db.{config.BOOTSTRAP_VERSION}.sig")
     open(zst_path, "wb").close()
     open(sig_path, "wb").close()
 
@@ -149,7 +150,9 @@ def test_prepare_bootstrap_happy_path(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(bootstrap, "sign_file", lambda zst, key: zst.replace(".zst", ".sig"))
     monkeypatch.setattr(bootstrap, "verify_prepared_signature", lambda zst, sig: None)
 
-    bootstrap.prepare_bootstrap(signing_key="dev@counterparty.io", version="v11.2.0")
+    bootstrap.prepare_bootstrap(
+        signing_key="dev@counterparty.io", version=f"v{config.VERSION_STRING}"
+    )
 
     assert len(calls) == 2
     assert "Prepared 2 snapshot(s)" in capsys.readouterr().out

--- a/counterparty-core/tools/compareledger.py
+++ b/counterparty-core/tools/compareledger.py
@@ -242,8 +242,8 @@ def get_last_block(database_file_1, database_file_2):
 database_file_1 = sys.argv[1]
 database_file_2 = sys.argv[2]
 
-LAST_BLOCK = 277880
+LAST_BLOCK = 266992
 # compare_ledger(database_file_1, database_file_2)
-check_hashes(database_file_1, database_file_2, "ledger_hash")
+check_hashes(database_file_1, database_file_2, "txlist_hash")
 # get_checkpoints(database_file_1)
 # get_last_block(database_file_1, database_file_2)

--- a/counterparty-rs/src/indexer/config.rs
+++ b/counterparty-rs/src/indexer/config.rs
@@ -162,7 +162,12 @@ impl Heights {
                 taproot_support: 0,
                 fix_is_segwit: 0,
                 ordinals_metadata_support: 0,
-                correct_transaction_fee: 0,
+                // Signet history is published in the bootstrap snapshots, so this fee
+                // correction MUST activate at a future height: enabling it from block 0
+                // recomputes the fee of already-parsed transactions and forks `txlist_hash`
+                // against the v11.2.0 snapshot (observed at block 265704). Keep in sync
+                // with `signet_block_index` in protocol_changes.json.
+                correct_transaction_fee: 321300,
             },
         }
     }


### PR DESCRIPTION
Fix ungated correct_transaction_fee on signet and publish v11.3.0 bootstrap

`correct_transaction_fee` was activated at block 0 on signet (copied from the regtest config) instead of a future height. Since signet history is shipped in the bootstrap snapshots, this recomputed the fee of already-parsed transactions and forked `txlist_hash` against the v11.2.0 snapshot, observed at block 265704. Move the activation to block 321300 in both `protocol_changes.json` and the Rust `Heights`, with a comment explaining why height 0 is not an option there.

Add the checkpoints locking the state of the newly published snapshots: mainnet 961411, testnet4 147329 and signet 316609. The signet one sits below 321300, so it pins the pre-correction history — the one the snapshot actually contains — and any node replaying it now converges again.

Bump `BOOTSTRAP_VERSION` to v11.3.0 now that the snapshots are published, and derive the version from `config` in the bootstrap unit tests so they stop hard-coding it.

Bump the integration cache key to v6: a restored cache short-circuits the bootstrap download, so without a new key the tests would keep running against the v11.2.0-derived DBs, and it also drops any signet cache poisoned by the ungated fee correction.
