### PR TITLE
Fix package metadata generation under hatchling 1.32

### DIFF
--- a/counterparty-core/README.md
+++ b/counterparty-core/README.md
@@ -1,0 +1,38 @@
+# Counterparty Core
+
+**Counterparty Core** is the reference implementation of the
+[Counterparty Protocol](https://counterparty.io), an extension to the Bitcoin
+protocol which implements a number of features that Bitcoin itself does not
+offer. These include token issuance, a fully decentralized and trustless asset
+exchange, contracts for difference, native oracles and trustless gaming.
+Counterparty works by ‘writing in the margins’ of Bitcoin transactions, and all
+Counterparty transactions are Bitcoin transactions with additional data that the
+Counterparty software can read and interpret.
+
+This package is the Python node (`counterparty-server`): it parses the Bitcoin
+blockchain, maintains the Counterparty ledger and serves the Counterparty API.
+It depends on [`counterparty-rs`](https://pypi.org/project/counterparty-rs/),
+the Rust extension used for performance-critical work.
+
+## Documentation
+
+- **[docs.counterparty.io](https://docs.counterparty.io)** — official project
+  documentation, including installation and node operation instructions.
+- **[apidocs.counterparty.io](https://apidocs.counterparty.io/)** — the
+  Counterparty Core API reference.
+- **[github.com/CounterpartyXCP/counterparty-core](https://github.com/CounterpartyXCP/counterparty-core)**
+  — the source repository, its
+  [README](https://github.com/CounterpartyXCP/counterparty-core/blob/master/README.md)
+  and [release notes](https://github.com/CounterpartyXCP/counterparty-core/tree/master/release-notes).
+
+## Contributing
+
+Bug reports and substantial pull requests are welcome — see the
+[contributing guidelines](https://github.com/CounterpartyXCP/counterparty-core/blob/master/.github/CONTRIBUTING.md)
+before opening either. Security vulnerabilities must be disclosed privately per
+the [security policy](https://github.com/CounterpartyXCP/counterparty-core/blob/master/SECURITY.md).
+
+## License
+
+MIT — see
+[LICENSE](https://github.com/CounterpartyXCP/counterparty-core/blob/master/LICENSE).

--- a/counterparty-core/pyproject.toml
+++ b/counterparty-core/pyproject.toml
@@ -7,7 +7,7 @@ name = "counterparty-core"
 requires-python = ">= 3.10"
 dynamic = ["version", "dependencies"]
 description = "Counterparty Protocol Reference Implementation"
-readme = "../README.md"
+readme = "README.md"
 license = "MIT"
 authors = [
   { name = "Counterparty Developers", email = "dev@counterparty.io" },


### PR DESCRIPTION
`hatchling` 1.32.0, released on 2026-08-11, added:

> Reject `project.readme` paths that are absolute or resolve outside of the project directory.

`counterparty-core/pyproject.toml` declared `readme = "../README.md"` and requires `hatchling` without an upper bound, so as of that release every CI job that installs the package dies at metadata generation:

```
ValueError: Readme path must be within the project directory: ../README.md
error: metadata-generation-failed
```

This is why Units, Functionals, Integrations and Client Regtest E2E all went red on `develop` while Ruff, Bandit, Licenses, CodeQL, Pylint, Docker and Rust Test stayed green — the failure is in `pip install -e counterparty-core`, not in any test. `counterparty-rs` (maturin) is unaffected.

## Fix

Add a README inside the package directory and point `readme` at it, rather than pinning `hatchling<1.32`. This also corrects the published metadata: a sdist could never carry `../README.md`, so the PyPI long description was already relying on a path outside the distribution. The new README is short and links to the root docs (docs.counterparty.io, apidocs.counterparty.io, the repository) with absolute URLs, since relative links do not resolve on PyPI.

Verified against `hatchling==1.32.0`: `python -m hatchling metadata` now succeeds and embeds the README.
