### PR TITLE
Make State DB rollbacks incremental (#3485)

### DIFF
--- a/counterparty-client/Cargo.lock
+++ b/counterparty-client/Cargo.lock
@@ -1242,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/counterparty-core/counterpartycore/lib/api/apiserver.py
+++ b/counterparty-core/counterpartycore/lib/api/apiserver.py
@@ -601,14 +601,14 @@ def init_flask_app():
             strict_slashes=False,
             provide_automatic_options=False,
         )
-        for path in ROUTES:
+        for path, route in ROUTES.items():
             # The legacy v1 API is a denial-of-service surface and is disabled by
             # default; skip registering its proxy routes (`/`, `/api/`, `/rpc/`,
             # `/v1/`) unless the operator opted in with `--enable-api-v1`. Not
             # registering them means requests hit the cheap 404 handler instead
             # of the expensive v1 dispatch (which also proxies to a v1 server
             # that is not even running when v1 is disabled).
-            if ROUTES[path]["category"] == "v1" and not config.ENABLE_API_V1:
+            if route["category"] == "v1" and not config.ENABLE_API_V1:
                 continue
             methods = ["OPTIONS", "GET"]
             if path == "/v2/bitcoin/transactions":

--- a/counterparty-core/counterpartycore/lib/api/apiserver.py
+++ b/counterparty-core/counterpartycore/lib/api/apiserver.py
@@ -22,6 +22,7 @@ from counterpartycore.lib import config, exceptions
 from counterpartycore.lib.api import (
     apiwatcher,
     dbbuilder,
+    dbstatus,
     healthz,
     healthz_server,
     queries,
@@ -709,6 +710,27 @@ def run_apiserver(
         pool_monitor = ConnectionPoolMonitor(stop_event, interval_seconds=60)
         pool_monitor.start()
 
+        # Dedicated health-check listener on its own socket + thread pool, isolated from the
+        # public API worker pool so probes cannot be head-of-line blocked by slow requests
+        # (issue #3460). Started *before* the State DB migration/rebuild block below, which
+        # takes tens of minutes on mainnet: until #3485 nothing answered probes during it, so
+        # liveness failed with a connection refusal and Kubernetes killed the pod mid-rebuild,
+        # only for the next start to begin again from zero. It now answers 200 on liveness and
+        # 503 `rebuilding` on readiness throughout. Non-fatal on failure; the task dispatcher
+        # is attached further down, once the WSGI server exists.
+        if not getattr(config, "NO_HEALTHZ_SERVER", False):
+            health_server = healthz_server.HealthCheckServer(
+                host=config.API_HOST,
+                port=config.HEALTHZ_PORT,
+                saturation_grace=getattr(
+                    config,
+                    "HEALTHZ_SATURATION_GRACE",
+                    config.DEFAULT_HEALTHZ_SATURATION_GRACE_SECONDS,
+                ),
+                stop_event=stop_event,
+            )
+            health_server.start()
+
         if args["rebuild_state_db"]:
             dbbuilder.build_state_db()
         elif args["refresh_state_db"]:
@@ -716,9 +738,10 @@ def run_apiserver(
             dbbuilder.refresh_state_db(state_db)
             state_db.close()
         else:
-            database.apply_outstanding_migration(
-                config.STATE_DATABASE, config.STATE_DB_MIGRATIONS_DIR
-            )
+            with dbstatus.rebuilding("migrate", "applying outstanding State DB migrations"):
+                database.apply_outstanding_migration(
+                    config.STATE_DATABASE, config.STATE_DB_MIGRATIONS_DIR
+                )
 
         state_db = database.get_db_connection(
             config.STATE_DATABASE, read_only=False, check_wal=False
@@ -742,23 +765,9 @@ def run_apiserver(
             logger.error("Error starting WSGI Server: %s", e)
             sys.exit(1)
 
-        # Dedicated health-check listener on its own socket + thread pool, isolated from the
-        # public API worker pool so probes cannot be head-of-line blocked by slow requests
-        # (issue #3460). Started here, once the WSGI server (and its task dispatcher) exist,
-        # but before the blocking wsgi_server.run() below. Non-fatal on failure.
-        if not getattr(config, "NO_HEALTHZ_SERVER", False):
-            health_server = healthz_server.HealthCheckServer(
-                host=config.API_HOST,
-                port=config.HEALTHZ_PORT,
-                dispatcher=wsgi_server.get_task_dispatcher(),
-                saturation_grace=getattr(
-                    config,
-                    "HEALTHZ_SATURATION_GRACE",
-                    config.DEFAULT_HEALTHZ_SATURATION_GRACE_SECONDS,
-                ),
-                stop_event=stop_event,
-            )
-            health_server.start()
+        # The worker pool now exists, so the sampler can report its gauges.
+        if health_server is not None:
+            health_server.attach_dispatcher(wsgi_server.get_task_dispatcher())
 
         logger.info("Starting Parent Process Checker thread...")
         parent_checker = ParentProcessChecker(wsgi_server, stop_event, parent_pid)

--- a/counterparty-core/counterpartycore/lib/api/apiserver.py
+++ b/counterparty-core/counterpartycore/lib/api/apiserver.py
@@ -631,7 +631,13 @@ def init_flask_app():
 def execute_upgrade_actions(state_db, upgrade_actions):
     for action in upgrade_actions:
         if action[0] in ["rollback", "reparse"]:
-            dbbuilder.rollback_state_db(state_db, block_index=action[1])
+            # Deliberately the *full* rebuild, not `dbbuilder.rollback_state_db()`
+            # and its incremental fast path: a release that ships a rollback
+            # action may also have changed how the State DB is derived from the
+            # Ledger DB, and only re-applying the migrations picks those changes
+            # up. Reverting row by row would faithfully restore rows built by
+            # the *previous* release's rules.
+            dbbuilder.full_rollback_state_db(state_db, block_index=action[1])
             break  # no need to continue
         if action[0] == "refresh_state_db":
             dbbuilder.refresh_state_db(state_db)

--- a/counterparty-core/counterpartycore/lib/api/apiwatcher.py
+++ b/counterparty-core/counterpartycore/lib/api/apiwatcher.py
@@ -553,8 +553,6 @@ def update_balances(state_db, event):
 
     event_bindings = get_event_bindings(event)
     quantity = event_bindings["quantity"]
-    if quantity == 0:
-        return
 
     if event["event"] == "DEBIT":
         quantity = -quantity
@@ -569,16 +567,40 @@ def update_balances(state_db, event):
     sql = f"SELECT * FROM balances WHERE {field_name} = :address_or_utxo AND asset = :asset"  # noqa: S608 # nosec B608
     existing_balance = fetch_one(state_db, sql, event_bindings)
 
+    # ``block_index`` / ``tx_index`` must be stamped on both paths, exactly as
+    # the ledger stamps its own ``balances`` row for the same credit/debit.
+    # ``block_index`` is what the incremental State DB rollback uses to find
+    # which balances a reorganized block touched (see ``api/staterollback.py``):
+    # left stale, a rolled back node would keep the orphaned quantity forever.
+    # Stamping both also makes a streamed row identical to the one a full
+    # rebuild copies out of the ledger.
     if existing_balance is not None:
+        # A zero-quantity credit/debit still bumps the row: ``ledger.events``
+        # appends a new ``balances`` row for it, so skipping it here would leave
+        # the State DB's block_index/tx_index behind the Ledger DB's.
         sql = f"""
             UPDATE balances
-            SET quantity = quantity + :quantity
+            SET quantity = quantity + :quantity,
+                block_index = :block_index,
+                tx_index = :tx_index
             WHERE {field_name} = :address_or_utxo AND asset = :asset
             """  # noqa: S608 # nosec B608
+    elif event["event"] == "DEBIT" and quantity == 0:
+        # ``remove_from_balance()`` writes no row when there is nothing to debit
+        # ("don't create balance if quantity is 0 and there is no balance").
+        return
     else:
+        # ``asset_longname`` is denormalized onto ``balances`` by migration 0006
+        # (POST_QUERIES); resolve it here too, otherwise every balance row first
+        # created by the event stream carries a NULL longname while the same row
+        # on a freshly built State DB carries the real one.
         sql = f"""
-            INSERT INTO balances ({field_name}, asset, quantity, utxo_address)
-            VALUES (:address_or_utxo, :asset, :quantity, :utxo_address)
+            INSERT INTO balances
+                ({field_name}, asset, quantity, utxo_address, block_index, tx_index,
+                 asset_longname)
+            VALUES
+                (:address_or_utxo, :asset, :quantity, :utxo_address, :block_index, :tx_index,
+                 (SELECT asset_longname FROM assets_info WHERE asset = :asset))
             """  # noqa: S608 # nosec B608
     utxo_address = None
     if "utxo_address" in event_bindings:
@@ -588,6 +610,8 @@ def update_balances(state_db, event):
         "asset": event_bindings["asset"],
         "utxo_address": utxo_address,
         "quantity": quantity,
+        "block_index": event["block_index"],
+        "tx_index": event_bindings.get("tx_index"),
     }
     cursor.execute(sql, insert_bindings)
 

--- a/counterparty-core/counterpartycore/lib/api/dbbuilder.py
+++ b/counterparty-core/counterpartycore/lib/api/dbbuilder.py
@@ -213,17 +213,43 @@ def rollback_state_db(state_db, block_index):
 
     Prefers the incremental path (:mod:`counterpartycore.lib.api.staterollback`),
     whose cost is proportional to the number of rows the rolled back blocks
-    touched. Falls back to the full rebuild below -- which re-derives every
-    table from the entire ledger history -- for a deep rollback, for the
-    ``UPGRADE_ACTIONS`` rollbacks (where the derivation rules themselves may
-    have changed), and for a State DB predating the invariants the incremental
-    path relies on.
+    touched. Falls back to :func:`full_rollback_state_db` -- which re-derives
+    every table from the entire ledger history -- for a deep rollback, for a
+    State DB predating the invariants the incremental path relies on, and if the
+    incremental path raises for any reason at all.
+
+    The ``UPGRADE_ACTIONS`` rollbacks do not come through here: they call
+    :func:`full_rollback_state_db` directly (see
+    ``apiserver.execute_upgrade_actions``), because a release that ships one may
+    also have changed the derivation rules themselves, and only the full rebuild
+    re-applies those.
     """
     reason = staterollback.rollback_reason(state_db, block_index)
     if reason is None:
-        staterollback.rollback_state_db(state_db, block_index)
+        try:
+            staterollback.rollback_state_db(state_db, block_index)
+            return
+        except Exception as e:  # pylint: disable=broad-except
+            # The incremental path is an optimization; the full rebuild is the
+            # ground truth and is always correct. Anything unexpected -- a State
+            # DB whose schema the projection does not fit, a SQL error in a
+            # table this release has never seen -- must degrade to the slow path
+            # rather than propagate: the caller is `apiwatcher.check_reorg()`,
+            # running on the watcher thread, which has no handler for it and
+            # would die, leaving the State DB frozen behind the Ledger DB.
+            logger.warning(
+                "Incremental State DB rollback failed (%s); falling back to the full rebuild.",
+                e,
+                exc_info=True,
+            )
+    elif reason == staterollback.NOTHING_TO_ROLL_BACK:
+        # Re-deriving every table from the entire ledger history to undo nothing
+        # would be the most expensive no-op available. The watcher replays
+        # forward from where the State DB actually is.
+        logger.info("State DB is already below block index %s; nothing to roll back.", block_index)
         return
-    logger.info("Full State DB rebuild required: %s.", reason)
+    else:
+        logger.info("Full State DB rebuild required: %s.", reason)
     full_rollback_state_db(state_db, block_index)
 
 

--- a/counterparty-core/counterpartycore/lib/api/dbbuilder.py
+++ b/counterparty-core/counterpartycore/lib/api/dbbuilder.py
@@ -7,6 +7,7 @@ import time
 from yoyo.migrations import topological_sort
 
 from counterpartycore.lib import config
+from counterpartycore.lib.api import staterollback
 from counterpartycore.lib.cli import log
 from counterpartycore.lib.utils import database
 
@@ -35,6 +36,9 @@ MIGRATIONS_AFTER_ROLLBACK = [
     "0013.add_performance_indexes",
     "0014.add_pool_consolidated_tables",
     "0015.add_dispenser_origin_index",
+    # 0016 indexes tables that 0006 drops and recreates, so it must be
+    # re-applied with them.
+    "0016.add_rollback_block_index_indexes",
 ]
 
 ROLLBACKABLE_TABLES = [
@@ -125,6 +129,9 @@ def build_state_db():
     with log.Spinner("Vacuuming State DB..."):
         state_db = database.get_db_connection(config.STATE_DATABASE, read_only=False)
         database.vacuum(state_db)
+        # Every table was just derived from the Ledger DB, so the invariants
+        # the incremental rollback relies on hold (see ``staterollback``).
+        staterollback.mark_ready(state_db)
         state_db.close()
 
     logger.info("State DB built in %.2f seconds", time.time() - start_time)
@@ -175,6 +182,25 @@ def record_balances_copied_block(state_db):
 
 
 def rollback_state_db(state_db, block_index):
+    """Roll the State DB back to ``block_index - 1``.
+
+    Prefers the incremental path (:mod:`counterpartycore.lib.api.staterollback`),
+    whose cost is proportional to the number of rows the rolled back blocks
+    touched. Falls back to the full rebuild below -- which re-derives every
+    table from the entire ledger history -- for a deep rollback, for the
+    ``UPGRADE_ACTIONS`` rollbacks (where the derivation rules themselves may
+    have changed), and for a State DB predating the invariants the incremental
+    path relies on.
+    """
+    reason = staterollback.rollback_reason(state_db, block_index)
+    if reason is None:
+        staterollback.rollback_state_db(state_db, block_index)
+        return
+    logger.info("Full State DB rebuild required: %s.", reason)
+    full_rollback_state_db(state_db, block_index)
+
+
+def full_rollback_state_db(state_db, block_index):
     logger.info("Rolling back State DB to block index %s...", block_index)
     start_time = time.time()
 
@@ -186,6 +212,7 @@ def rollback_state_db(state_db, block_index):
         # Record the ledger_db block index to prevent double-counting of balances
         # during catch-up (see record_balances_copied_block docstring for details)
         record_balances_copied_block(state_db)
+        staterollback.mark_ready(state_db)
 
     logger.info("State DB rolled back in %.2f seconds", time.time() - start_time)
 
@@ -200,5 +227,6 @@ def refresh_state_db(state_db):
         # Record the ledger_db block index to prevent double-counting of balances
         # during catch-up (see record_balances_copied_block docstring for details)
         record_balances_copied_block(state_db)
+        staterollback.mark_ready(state_db)
 
     logger.info("State DB refreshed in %.2f seconds", time.time() - start_time)

--- a/counterparty-core/counterpartycore/lib/api/dbbuilder.py
+++ b/counterparty-core/counterpartycore/lib/api/dbbuilder.py
@@ -7,7 +7,7 @@ import time
 from yoyo.migrations import topological_sort
 
 from counterpartycore.lib import config
-from counterpartycore.lib.api import staterollback
+from counterpartycore.lib.api import dbstatus, staterollback
 from counterpartycore.lib.cli import log
 from counterpartycore.lib.utils import database
 
@@ -77,21 +77,40 @@ def rollback_migration(state_db, migration_id):
     module.rollback(state_db)
 
 
-def rollback_migrations(state_db, migration_ids):
-    for migration_id in reversed(migration_ids):
-        logger.debug("Rolling back migration `%s`...", migration_id)
-        rollback_migration(state_db, migration_id)
+def rollback_migrations(state_db, migration_ids, progress=None, offset=0):
+    for index, migration_id in enumerate(reversed(migration_ids)):
+        _run_migration_step(
+            state_db, rollback_migration, "Rolling back", migration_id, progress, offset + index
+        )
 
 
-def apply_migrations(state_db, migration_ids):
-    for migration_id in migration_ids:
-        logger.debug("Applying migration `%s`...", migration_id)
-        apply_migration(state_db, migration_id)
+def apply_migrations(state_db, migration_ids, progress=None, offset=0):
+    for index, migration_id in enumerate(migration_ids):
+        _run_migration_step(
+            state_db, apply_migration, "Applying", migration_id, progress, offset + index
+        )
 
 
-def reapply_migrations(state_db, migration_ids):
-    rollback_migrations(state_db, migration_ids)
-    apply_migrations(state_db, migration_ids)
+def _run_migration_step(state_db, run, verb, migration_id, progress, index):
+    """Run one migration, reporting it to the operator and to the health probes.
+
+    Reported at INFO, not DEBUG: these steps are what a State DB rebuild
+    actually spends its tens of minutes on, and their absence from the log is
+    why the 33-minute rebuild in #3485 was indistinguishable from a hang.
+    """
+    if progress is not None:
+        progress.step(f"{verb.lower()} `{migration_id}`", index + 1)
+    logger.info("%s migration `%s`...", verb, migration_id)
+    start_time = time.time()
+    run(state_db, migration_id)
+    logger.info("%s migration `%s` in %.2f seconds", verb, migration_id, time.time() - start_time)
+
+
+def reapply_migrations(state_db, migration_ids, progress=None):
+    # Each migration is dropped and re-applied, hence 2 * len(migration_ids)
+    # reportable steps.
+    rollback_migrations(state_db, migration_ids, progress=progress)
+    apply_migrations(state_db, migration_ids, progress=progress, offset=len(migration_ids))
 
 
 def rollback_tables(state_db, block_index):
@@ -120,19 +139,27 @@ def build_state_db():
     # migration 0010). Make sure the Ledger DB is fully migrated before
     # building the State DB so this command works against bootstrap snapshots
     # that predate the latest Ledger DB migrations.
-    with log.Spinner("Applying Ledger DB migrations"):
-        database.apply_outstanding_migration(config.DATABASE, config.LEDGER_DB_MIGRATIONS_DIR)
+    # Published for the health probes: this runs before the API listener exists,
+    # so ``rebuilding`` is the only thing that distinguishes a pod that is busy
+    # from one that is wedged (see ``api/dbstatus.py``).
+    with dbstatus.rebuilding("build", "applying Ledger DB migrations") as progress:
+        with log.Spinner("Applying Ledger DB migrations"):
+            database.apply_outstanding_migration(config.DATABASE, config.LEDGER_DB_MIGRATIONS_DIR)
 
-    with log.Spinner("Applying migrations"):
-        database.apply_outstanding_migration(config.STATE_DATABASE, config.STATE_DB_MIGRATIONS_DIR)
+        progress.step("applying State DB migrations")
+        with log.Spinner("Applying migrations"):
+            database.apply_outstanding_migration(
+                config.STATE_DATABASE, config.STATE_DB_MIGRATIONS_DIR
+            )
 
-    with log.Spinner("Vacuuming State DB..."):
-        state_db = database.get_db_connection(config.STATE_DATABASE, read_only=False)
-        database.vacuum(state_db)
-        # Every table was just derived from the Ledger DB, so the invariants
-        # the incremental rollback relies on hold (see ``staterollback``).
-        staterollback.mark_ready(state_db)
-        state_db.close()
+        progress.step("vacuuming")
+        with log.Spinner("Vacuuming State DB..."):
+            state_db = database.get_db_connection(config.STATE_DATABASE, read_only=False)
+            database.vacuum(state_db)
+            # Every table was just derived from the Ledger DB, so the invariants
+            # the incremental rollback relies on hold (see ``staterollback``).
+            staterollback.mark_ready(state_db)
+            state_db.close()
 
     logger.info("State DB built in %.2f seconds", time.time() - start_time)
 
@@ -204,15 +231,18 @@ def full_rollback_state_db(state_db, block_index):
     logger.info("Rolling back State DB to block index %s...", block_index)
     start_time = time.time()
 
-    with state_db:
-        with log.Spinner("Rolling back State DB tables..."):
-            rollback_tables(state_db, block_index)
-        with log.Spinner("Re-applying migrations..."):
-            reapply_migrations(state_db, MIGRATIONS_AFTER_ROLLBACK)
-        # Record the ledger_db block index to prevent double-counting of balances
-        # during catch-up (see record_balances_copied_block docstring for details)
-        record_balances_copied_block(state_db)
-        staterollback.mark_ready(state_db)
+    with dbstatus.rebuilding(
+        "rollback", "pruning rolled back rows", total=2 * len(MIGRATIONS_AFTER_ROLLBACK)
+    ) as progress:
+        with state_db:
+            with log.Spinner("Rolling back State DB tables..."):
+                rollback_tables(state_db, block_index)
+            with log.Spinner("Re-applying migrations..."):
+                reapply_migrations(state_db, MIGRATIONS_AFTER_ROLLBACK, progress=progress)
+            # Record the ledger_db block index to prevent double-counting of balances
+            # during catch-up (see record_balances_copied_block docstring for details)
+            record_balances_copied_block(state_db)
+            staterollback.mark_ready(state_db)
 
     logger.info("State DB rolled back in %.2f seconds", time.time() - start_time)
 
@@ -221,12 +251,15 @@ def refresh_state_db(state_db):
     logger.info("Rebuilding non rollbackable tables in State DB...")
     start_time = time.time()
 
-    with state_db:
-        with log.Spinner("Re-applying migrations..."):
-            reapply_migrations(state_db, MIGRATIONS_AFTER_ROLLBACK)
-        # Record the ledger_db block index to prevent double-counting of balances
-        # during catch-up (see record_balances_copied_block docstring for details)
-        record_balances_copied_block(state_db)
-        staterollback.mark_ready(state_db)
+    with dbstatus.rebuilding(
+        "refresh", "re-applying migrations", total=2 * len(MIGRATIONS_AFTER_ROLLBACK)
+    ) as progress:
+        with state_db:
+            with log.Spinner("Re-applying migrations..."):
+                reapply_migrations(state_db, MIGRATIONS_AFTER_ROLLBACK, progress=progress)
+            # Record the ledger_db block index to prevent double-counting of balances
+            # during catch-up (see record_balances_copied_block docstring for details)
+            record_balances_copied_block(state_db)
+            staterollback.mark_ready(state_db)
 
     logger.info("State DB refreshed in %.2f seconds", time.time() - start_time)

--- a/counterparty-core/counterpartycore/lib/api/dbstatus.py
+++ b/counterparty-core/counterpartycore/lib/api/dbstatus.py
@@ -1,0 +1,118 @@
+"""Process-local progress of a long-running State DB maintenance operation.
+
+Building, refreshing or fully rebuilding the State DB takes tens of minutes on
+mainnet, and until now it was completely opaque: it ran before the API and the
+health-check listener existed, so probes got a connection refusal, and it
+logged nothing above DEBUG. An operator watching a pod could not distinguish
+"rebuilding, making progress" from "hung" -- and Kubernetes could not either,
+so a liveness probe would kill the pod mid-rebuild and the next start would
+begin again from zero.
+
+This module is the shared, lock-free-to-read status those two consumers need:
+:mod:`counterpartycore.lib.api.dbbuilder` publishes each phase as it starts it,
+and the health sampler (:mod:`counterpartycore.lib.api.healthz_server`) turns it
+into a distinct ``rebuilding`` readiness state. It is deliberately trivial:
+a single immutable snapshot swapped in under a lock, read without one.
+"""
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from counterpartycore.lib import config
+
+logger = logging.getLogger(config.LOGGER_NAME)
+
+
+@dataclass(frozen=True)
+class RebuildProgress:
+    operation: str  # "build" | "refresh" | "rollback"
+    phase: str  # human-readable name of the step under way
+    step: Optional[int]  # 1-based index of that step, when countable
+    total: Optional[int]  # number of steps, when known upfront
+    started_at: float  # time.monotonic() when the operation began
+
+    @property
+    def seconds(self) -> float:
+        return time.monotonic() - self.started_at
+
+    def as_dict(self):
+        body = {
+            "operation": self.operation,
+            "phase": self.phase,
+            "seconds": round(self.seconds, 1),
+        }
+        if self.step is not None:
+            body["step"] = self.step
+        if self.total is not None:
+            body["total_steps"] = self.total
+        return body
+
+
+_lock = threading.Lock()
+_current: Optional[RebuildProgress] = None
+
+
+def current() -> Optional[RebuildProgress]:
+    """The operation under way, or ``None``. Read without taking the lock:
+    ``_current`` is only ever rebound to a new immutable value."""
+    return _current
+
+
+def start(operation, phase, total=None):
+    global _current  # noqa: PLW0603
+    with _lock:
+        _current = RebuildProgress(
+            operation=operation,
+            phase=phase,
+            step=None,
+            total=total,
+            started_at=time.monotonic(),
+        )
+
+
+def step(phase, index=None):
+    """Advance to the next phase, keeping the operation's start time."""
+    global _current  # noqa: PLW0603
+    with _lock:
+        if _current is None:
+            return
+        _current = RebuildProgress(
+            operation=_current.operation,
+            phase=phase,
+            step=index,
+            total=_current.total,
+            started_at=_current.started_at,
+        )
+
+
+def finish():
+    global _current  # noqa: PLW0603
+    with _lock:
+        _current = None
+
+
+class rebuilding:  # noqa: N801  # used as a context manager, reads as a verb
+    """Publish ``operation`` for the duration of the block, whatever happens.
+
+    ``with dbstatus.rebuilding("refresh", "applying migrations", total=14) as p:``
+    then ``p.step("0006.create_and_populate_consolidated_tables", 6)``.
+    """
+
+    def __init__(self, operation, phase, total=None):
+        self.operation = operation
+        self.phase = phase
+        self.total = total
+
+    def __enter__(self):
+        start(self.operation, self.phase, total=self.total)
+        return self
+
+    def step(self, phase, index=None):
+        step(phase, index=index)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        finish()
+        return False

--- a/counterparty-core/counterpartycore/lib/api/dbstatus.py
+++ b/counterparty-core/counterpartycore/lib/api/dbstatus.py
@@ -15,6 +15,7 @@ into a distinct ``rebuilding`` readiness state. It is deliberately trivial:
 a single immutable snapshot swapped in under a lock, read without one.
 """
 
+import contextlib
 import logging
 import threading
 import time
@@ -51,68 +52,76 @@ class RebuildProgress:
         return body
 
 
-_lock = threading.Lock()
-_current: Optional[RebuildProgress] = None
+class _Tracker:
+    """The single in-flight operation.
+
+    Writers take the lock; readers do not: ``current`` is only ever rebound to
+    a new immutable snapshot, so a reader racing a writer sees either the old
+    one or the new one, never a half-built value.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.current: Optional[RebuildProgress] = None
+
+    def start(self, operation, phase, total=None):
+        with self._lock:
+            self.current = RebuildProgress(
+                operation=operation,
+                phase=phase,
+                step=None,
+                total=total,
+                started_at=time.monotonic(),
+            )
+
+    def step(self, phase, index=None):
+        """Advance to the next phase, keeping the operation's start time."""
+        with self._lock:
+            if self.current is None:
+                return
+            self.current = RebuildProgress(
+                operation=self.current.operation,
+                phase=phase,
+                step=index,
+                total=self.current.total,
+                started_at=self.current.started_at,
+            )
+
+    def finish(self):
+        with self._lock:
+            self.current = None
+
+
+_tracker = _Tracker()
 
 
 def current() -> Optional[RebuildProgress]:
-    """The operation under way, or ``None``. Read without taking the lock:
-    ``_current`` is only ever rebound to a new immutable value."""
-    return _current
+    """The operation under way, or ``None``."""
+    return _tracker.current
 
 
 def start(operation, phase, total=None):
-    global _current  # noqa: PLW0603
-    with _lock:
-        _current = RebuildProgress(
-            operation=operation,
-            phase=phase,
-            step=None,
-            total=total,
-            started_at=time.monotonic(),
-        )
+    _tracker.start(operation, phase, total=total)
 
 
 def step(phase, index=None):
     """Advance to the next phase, keeping the operation's start time."""
-    global _current  # noqa: PLW0603
-    with _lock:
-        if _current is None:
-            return
-        _current = RebuildProgress(
-            operation=_current.operation,
-            phase=phase,
-            step=index,
-            total=_current.total,
-            started_at=_current.started_at,
-        )
+    _tracker.step(phase, index=index)
 
 
 def finish():
-    global _current  # noqa: PLW0603
-    with _lock:
-        _current = None
+    _tracker.finish()
 
 
-class rebuilding:  # noqa: N801  # used as a context manager, reads as a verb
+@contextlib.contextmanager
+def rebuilding(operation, phase, total=None):
     """Publish ``operation`` for the duration of the block, whatever happens.
 
     ``with dbstatus.rebuilding("refresh", "applying migrations", total=14) as p:``
     then ``p.step("0006.create_and_populate_consolidated_tables", 6)``.
     """
-
-    def __init__(self, operation, phase, total=None):
-        self.operation = operation
-        self.phase = phase
-        self.total = total
-
-    def __enter__(self):
-        start(self.operation, self.phase, total=self.total)
-        return self
-
-    def step(self, phase, index=None):
-        step(phase, index=index)
-
-    def __exit__(self, exc_type, exc_value, traceback):
+    start(operation, phase, total=total)
+    try:
+        yield _tracker
+    finally:
         finish()
-        return False

--- a/counterparty-core/counterpartycore/lib/api/healthz_server.py
+++ b/counterparty-core/counterpartycore/lib/api/healthz_server.py
@@ -15,9 +15,9 @@ Endpoints (all GET, JSON):
 * ``/healthz/live``    — liveness: is the process internally alive? 200 unless the sampler
                          heartbeat is stale (a genuine deadlock). Never reflects ledger lag or
                          saturation, so a busy-but-alive pod is never restarted.
-* ``/healthz/ready``   — readiness: should this pod receive traffic? 503 when the ledger is
-                         behind the backend OR the worker pool has been saturated past a grace
-                         period (load shedding).
+* ``/healthz/ready``   — readiness: should this pod receive traffic? 503 when a State DB
+                         rebuild is under way, when the ledger is behind the backend, or when
+                         the worker pool has been saturated past a grace period (load shedding).
 * ``/healthz``         — alias of ``/healthz/ready``.
 * ``/healthz/metrics`` — worker-pool + saturation + handler-latency gauges for alerting.
 """
@@ -33,7 +33,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Optional
 
 from counterpartycore.lib import config
-from counterpartycore.lib.api import apiwatcher
+from counterpartycore.lib.api import apiwatcher, dbstatus
 from counterpartycore.lib.ledger.currentstate import CurrentState
 from counterpartycore.lib.utils import database
 
@@ -63,6 +63,9 @@ class HealthSnapshot:
     saturated: bool
     saturation_seconds: float
     workers: Optional[WorkerMetrics]  # None on gunicorn/werkzeug (no introspectable pool)
+    # Set while a State DB build/refresh/rollback is under way (issue #3485): the
+    # pod is healthy and working, but must not receive traffic yet.
+    rebuild: Optional[dbstatus.RebuildProgress] = None
 
 
 def _instrument_dispatcher(dispatcher):
@@ -181,28 +184,55 @@ class HealthSampler(threading.Thread):
     # -- sampler loop ------------------------------------------------------------------------
     def run(self):
         own_db = None
+        rebuilding = dbstatus.current() is not None
         try:
             self._tick()  # publish a snapshot immediately (worker metrics available at once)
             while not self.stop_event.wait(self.interval):
-                # Open the state DB lazily and tolerate transient unavailability (e.g. during
-                # early startup) by retrying, rather than letting the sampler thread die.
-                if self._owns_db and own_db is None:
-                    try:
-                        own_db = database.get_db_connection(
-                            config.STATE_DATABASE, read_only=True, check_wal=False
-                        )
-                        self._last_parsed_provider = (
-                            lambda db=own_db: apiwatcher.get_last_block_parsed(db)
-                        )
-                    except Exception as e:  # pylint: disable=broad-except
-                        logger.debug("healthz: state DB not ready yet: %s", e)
+                was_rebuilding, rebuilding = rebuilding, dbstatus.current() is not None
+                own_db = self._own_db_for_tick(own_db, was_rebuilding, rebuilding)
                 self._tick()
         finally:
-            if own_db is not None:
-                try:
-                    own_db.close()
-                except Exception as e:  # pylint: disable=broad-except
-                    logger.debug("healthz: error closing state DB connection: %s", e)
+            self._close_own_db(own_db)
+
+    def _own_db_for_tick(self, own_db, was_rebuilding, rebuilding):
+        """Keep the sampler's own state-DB connection valid across a rebuild.
+
+        Returns the connection to use for this tick (possibly None).
+        """
+        if not self._owns_db:
+            return own_db
+        if was_rebuilding and not rebuilding:
+            # build_state_db() unlinks and recreates the file, so a
+            # connection opened before the rebuild now points at a deleted
+            # inode and would report a frozen block height forever. Drop it and
+            # let the branch below reopen against the new file.
+            own_db = self._close_own_db(own_db)
+        if own_db is not None or rebuilding:
+            # Nothing to do, or the file is mid-flight and not worth opening.
+            return own_db
+        # Open lazily and tolerate transient unavailability (e.g. during early
+        # startup) by retrying, rather than letting the sampler thread die.
+        try:
+            own_db = database.get_db_connection(
+                config.STATE_DATABASE, read_only=True, check_wal=False
+            )
+            self._last_parsed_provider = lambda db=own_db: apiwatcher.get_last_block_parsed(db)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug("healthz: state DB not ready yet: %s", e)
+        return own_db
+
+    def _close_own_db(self, own_db):
+        """Close the sampler's own state-DB connection and forget the readings
+        taken through it. Always returns ``None``, for reassignment."""
+        self._last_parsed_provider = None
+        self._last_parsed_value = None
+        self._last_parsed_advanced_at = None
+        if own_db is not None:
+            try:
+                own_db.close()
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug("healthz: error closing state DB connection: %s", e)
+        return None
 
     def stop(self):
         self.stop_event.set()
@@ -223,7 +253,17 @@ class HealthSampler(threading.Thread):
         )
         self._warn_on_saturation(over_saturated, workers, saturation_seconds)
 
-        caught_up, lag, ledger_reason, backend_height, last_parsed = self._compute_caught_up(now)
+        # A State DB rebuild wins over every other readiness signal: the tables
+        # the lag is read from are being dropped and repopulated underneath us,
+        # so "behind_backend" would be both wrong and unactionable.
+        rebuild = dbstatus.current()
+        if rebuild is not None:
+            caught_up, lag, ledger_reason = False, None, "rebuilding"
+            backend_height, last_parsed = self._backend_height_provider(), None
+        else:
+            caught_up, lag, ledger_reason, backend_height, last_parsed = self._compute_caught_up(
+                now
+            )
         ready = caught_up and not over_saturated
         if ready:
             reason = None
@@ -241,6 +281,7 @@ class HealthSampler(threading.Thread):
             saturated=saturated_now,
             saturation_seconds=saturation_seconds,
             workers=workers,
+            rebuild=rebuild,
         )
         self._maybe_log_worker_stats(now, workers, saturation_seconds)
 
@@ -424,6 +465,8 @@ class HealthRequestHandler(BaseHTTPRequestHandler):
         if snap.ready:
             return 200, {"status": "ready"}
         body = {"status": "degraded", "reason": snap.reason}
+        if snap.rebuild is not None:
+            body["rebuild"] = snap.rebuild.as_dict()
         if snap.backend_height is not None:
             body["backend_height"] = snap.backend_height
         if snap.last_parsed is not None:
@@ -459,6 +502,7 @@ class HealthRequestHandler(BaseHTTPRequestHandler):
                 "backend_height": snap.backend_height,
                 "last_parsed_block": snap.last_parsed,
                 "lag": snap.lag,
+                "rebuild": snap.rebuild.as_dict() if snap.rebuild is not None else None,
             },
             "health_handler": {
                 "live": _latency_stats(self.server.live_latencies_ms),
@@ -503,6 +547,21 @@ class HealthCheckServer:
         self.sampler = None
         self._serve_thread = None
         self.started_at_monotonic = time.monotonic()
+
+    def attach_dispatcher(self, dispatcher):
+        """Give the sampler the WSGI task dispatcher once it exists.
+
+        The server is started *before* the WSGI server so that probes are
+        answered during a State DB rebuild (issue #3485), at which point there
+        is no worker pool to introspect yet. Until this is called the pool
+        gauges simply read as unavailable.
+        """
+        if dispatcher is None:
+            return
+        self.dispatcher = dispatcher
+        _instrument_dispatcher(dispatcher)
+        if self.sampler is not None:
+            self.sampler.dispatcher = dispatcher
 
     def start(self):
         try:

--- a/counterparty-core/counterpartycore/lib/api/healthz_server.py
+++ b/counterparty-core/counterpartycore/lib/api/healthz_server.py
@@ -206,7 +206,8 @@ class HealthSampler(threading.Thread):
             # connection opened before the rebuild now points at a deleted
             # inode and would report a frozen block height forever. Drop it and
             # let the branch below reopen against the new file.
-            own_db = self._close_own_db(own_db)
+            self._close_own_db(own_db)
+            own_db = None
         if own_db is not None or rebuilding:
             # Nothing to do, or the file is mid-flight and not worth opening.
             return own_db
@@ -223,7 +224,7 @@ class HealthSampler(threading.Thread):
 
     def _close_own_db(self, own_db):
         """Close the sampler's own state-DB connection and forget the readings
-        taken through it. Always returns ``None``, for reassignment."""
+        taken through it."""
         self._last_parsed_provider = None
         self._last_parsed_value = None
         self._last_parsed_advanced_at = None
@@ -232,7 +233,6 @@ class HealthSampler(threading.Thread):
                 own_db.close()
             except Exception as e:  # pylint: disable=broad-except
                 logger.debug("healthz: error closing state DB connection: %s", e)
-        return None
 
     def stop(self):
         self.stop_event.set()

--- a/counterparty-core/counterpartycore/lib/api/migrations/0004.create_and_populate_assets_info.py
+++ b/counterparty-core/counterpartycore/lib/api/migrations/0004.create_and_populate_assets_info.py
@@ -4,8 +4,8 @@
 import logging
 import time
 
-from counterpartycore.lib import config, ledger
-from counterpartycore.lib.utils import database
+from counterpartycore.lib import config
+from counterpartycore.lib.api.statetables import populate_assets_info
 from yoyo import step
 
 logger = logging.getLogger(config.LOGGER_NAME)
@@ -51,155 +51,11 @@ def apply(db):
             mime_type TEXT DEFAULT 'text/plain'
     )""")
 
-    # Populate `assets_info` with one row per asset, mirroring the latest-wins
-    # semantics of `apiwatcher.update_assets_info` (the streamed handler that
-    # maintains this table at runtime). Each per-asset value is derived
-    # explicitly from the latest valid issuance (`ORDER BY rowid DESC LIMIT 1`)
-    # for fields the streamed handler overwrites on every issuance, and from
-    # `MAX(...)` for the boolean flags `locked` / `description_locked` so that
-    # multiple lock events don't accumulate as integer counts in `BOOL` columns.
-    sql = """
-    INSERT INTO assets_info (
-        asset,
-        asset_id,
-        asset_longname,
-        issuer,
-        owner,
-        divisible,
-        locked,
-        supply,
-        description,
-        description_locked,
-        first_issuance_block_index,
-        last_issuance_block_index,
-        mime_type
-    )
-    SELECT
-        a.asset_name AS asset,
-        a.asset_id,
-        a.asset_longname,
-        (
-            SELECT (SELECT al.address FROM ledger_db.address_list al WHERE al.address_id = i.issuer)
-            FROM ledger_db.issuances i
-            WHERE i.asset = a.asset_index AND i.status = 'valid'
-            ORDER BY i.rowid ASC LIMIT 1
-        ) AS issuer,
-        (
-            SELECT (SELECT al.address FROM ledger_db.address_list al WHERE al.address_id = i.issuer)
-            FROM ledger_db.issuances i
-            WHERE i.asset = a.asset_index AND i.status = 'valid'
-            ORDER BY i.rowid DESC LIMIT 1
-        ) AS owner,
-        (
-            SELECT i.divisible FROM ledger_db.issuances i
-            WHERE i.asset = a.asset_index AND i.status = 'valid'
-            ORDER BY i.rowid DESC LIMIT 1
-        ) AS divisible,
-        COALESCE((
-            SELECT MAX(i.locked) FROM ledger_db.issuances i
-            WHERE i.asset = a.asset_index AND i.status = 'valid'
-        ), 0) AS locked,
-        COALESCE((
-            SELECT SUM(i.quantity) FROM ledger_db.issuances i
-            WHERE i.asset = a.asset_index AND i.status = 'valid'
-        ), 0) AS supply,
-        (
-            SELECT i.description FROM ledger_db.issuances i
-            WHERE i.asset = a.asset_index AND i.status = 'valid'
-            ORDER BY i.rowid DESC LIMIT 1
-        ) AS description,
-        COALESCE((
-            SELECT MAX(i.description_locked) FROM ledger_db.issuances i
-            WHERE i.asset = a.asset_index AND i.status = 'valid'
-        ), 0) AS description_locked,
-        (
-            SELECT MIN(i.block_index) FROM ledger_db.issuances i
-            WHERE i.asset = a.asset_index AND i.status = 'valid'
-        ) AS first_issuance_block_index,
-        (
-            SELECT MAX(i.block_index) FROM ledger_db.issuances i
-            WHERE i.asset = a.asset_index AND i.status = 'valid'
-        ) AS last_issuance_block_index,
-        (
-            SELECT i.mime_type FROM ledger_db.issuances i
-            WHERE i.asset = a.asset_index AND i.status = 'valid'
-            ORDER BY i.rowid DESC LIMIT 1
-        ) AS mime_type
-    FROM ledger_db.assets a
-    WHERE EXISTS (
-        SELECT 1 FROM ledger_db.issuances i
-        WHERE i.asset = a.asset_index AND i.status = 'valid'
-    );
-    """
-    cursor = db.cursor()
-    cursor.execute(sql)
-
-    ledger_db = database.get_db_connection(config.DATABASE)
-    cursor.execute(
-        """
-        INSERT INTO assets_info (
-            asset, divisible, locked, supply, description,
-            first_issuance_block_index, last_issuance_block_index
-        ) VALUES (
-            :asset, :divisible, :locked, :supply, :description,
-            :first_issuance_block_index, :last_issuance_block_index
-        )
-        """,
-        {
-            "asset": "XCP",
-            "divisible": True,
-            "locked": True,
-            "supply": ledger.supplies.xcp_supply(ledger_db),
-            "description": "The Counterparty protocol native currency",
-            "first_issuance_block_index": 278319,
-            "last_issuance_block_index": 283810,
-        },
-    )
-
-    start_time_supply = time.time()
-    logger.debug("Updating the `supply` field...")
-
-    # ``issuances``/``destructions`` resolve to ``ledger_db`` (the State DB has
-    # no such tables) where ``asset`` is the compact ``asset_index``; decode to
-    # the asset name so the supply UPDATE below matches ``assets_info.asset``.
-    db.execute("""
-        CREATE TEMP TABLE issuances_quantity AS
-        SELECT a.asset_name AS asset, SUM(i.quantity) AS quantity
-        FROM ledger_db.issuances i
-        JOIN ledger_db.assets a ON a.asset_index = i.asset
-        WHERE i.status = 'valid' GROUP BY i.asset
-    """)
-    db.execute("""
-        CREATE TEMP TABLE destructions_quantity AS
-        SELECT a.asset_name AS asset, SUM(d.quantity) AS quantity
-        FROM ledger_db.destructions d
-        JOIN ledger_db.assets a ON a.asset_index = d.asset
-        WHERE d.status = 'valid' GROUP BY d.asset
-    """)
-
-    db.execute("""
-        CREATE TEMP TABLE supplies AS
-        SELECT
-            issuances_quantity.asset,
-            issuances_quantity.quantity - COALESCE(destructions_quantity.quantity, 0) AS supply
-        FROM issuances_quantity
-        LEFT JOIN destructions_quantity ON issuances_quantity.asset = destructions_quantity.asset
-    """)
-
-    db.execute("""
-        CREATE INDEX temp.supplies_asset_idx ON supplies(asset)
-    """)
-
-    db.execute("""
-        UPDATE assets_info SET
-        supply = COALESCE((SELECT supplies.supply FROM supplies WHERE assets_info.asset = supplies.asset), supply)
-    """)
-
-    db.execute("DROP TABLE issuances_quantity")
-    db.execute("DROP TABLE destructions_quantity")
-    db.execute("DROP TABLE supplies")
-
-    logger.debug("Updated the `supply` field in %.2f seconds", time.time() - start_time_supply)
+    # ``assets_info`` is a pure projection of the ledger's issuance /
+    # destruction / burn history. The derivation is shared with the
+    # incremental rollback path (which needs the same rules bounded to a block
+    # index) so the two can never drift apart -- see ``api/statetables.py``.
+    populate_assets_info(db)
 
     db.execute("CREATE UNIQUE INDEX assets_info_asset_idx ON assets_info (asset)")
     db.execute("CREATE UNIQUE INDEX assets_info_asset_id_idx ON assets_info (asset_id)")

--- a/counterparty-core/counterpartycore/lib/api/migrations/0006.create_and_populate_consolidated_tables.py
+++ b/counterparty-core/counterpartycore/lib/api/migrations/0006.create_and_populate_consolidated_tables.py
@@ -5,33 +5,18 @@ import logging
 import time
 
 from counterpartycore.lib import config
-from counterpartycore.lib.utils.database import (
-    ADDRESS_INDEX_COLUMN_NAMES,
-    ASSET_INDEX_COLUMN_NAMES,
-    text_affinitize_index_columns,
+from counterpartycore.lib.api.statetables import (
+    LEDGER_CONSOLIDATED_KEYS as CONSOLIDATED_TABLES,
 )
+from counterpartycore.lib.api.statetables import (
+    consolidated_projection,
+)
+from counterpartycore.lib.utils.database import text_affinitize_index_columns
 from yoyo import step
 
 logger = logging.getLogger(config.LOGGER_NAME)
 
 __depends__ = {"0005.create_and_populate_events_count"}
-
-CONSOLIDATED_TABLES = {
-    "fairminters": "tx_hash",
-    # ``utxo`` is the compact ``(utxo_tx_hash, utxo_vout)`` ledger pair; group
-    # by both halves (the State DB stores the reconstructed ``utxo`` string).
-    "balances": "address, utxo_tx_hash, utxo_vout, asset",
-    "addresses": "address",
-    "dispensers": "source, asset, tx_hash",
-    # match tables: the composite TEXT ``id`` was dropped; the match is keyed
-    # by the ``(tx0_index, tx1_index)`` pair (compact-hash storage migration).
-    "bet_matches": "tx0_index, tx1_index",
-    "bets": "tx_hash",
-    "order_matches": "tx0_index, tx1_index",
-    "orders": "tx_hash",
-    "rps": "tx_hash",
-    "rps_matches": "tx0_index, tx1_index",
-}
 
 ADDITONAL_COLUMNS = {
     "fairminters": [
@@ -134,36 +119,15 @@ def build_consolidated_table(state_db, table_name):
         CREATE INDEX temp.latest_ids_idx ON latest_ids(max_id)
     """)
 
-    # The State DB stores asset *names* (it must read its own rows without the
-    # Ledger DB attached). Asset columns are stored as the compact
-    # ``asset_index`` in ``ledger_db``, so decode them back to names here while
-    # ``ledger_db`` is attached (the INSERT ... SELECT bypasses the rowtracer).
-    columns = []
-    for column in state_db.execute(f"PRAGMA table_info({table_name})"):
-        col = column["name"]
-        if col in ASSET_INDEX_COLUMN_NAMES:
-            columns.append(
-                f"(SELECT asset_name FROM ledger_db.assets WHERE asset_index = b.{col}) AS {col}"  # noqa: S608  # nosec B608
-            )
-        elif col in ADDRESS_INDEX_COLUMN_NAMES:
-            # decode the compact ``address_id`` back to the address string
-            columns.append(
-                f"(SELECT address FROM ledger_db.address_list WHERE address_id = b.{col}) AS {col}"  # noqa: S608  # nosec B608
-            )
-        elif col == "utxo" and table_name == "balances":
-            # reconstruct the ``tx_hash:vout`` string from the compact ledger
-            # ``(utxo_tx_hash, utxo_vout)`` pair (``lower(hex(...))`` yields the
-            # lowercase hex the utxo string used; a NULL tx_hash -> NULL utxo).
-            columns.append(
-                "lower(hex(b.utxo_tx_hash)) || ':' || b.utxo_vout AS utxo"  # noqa: S608  # nosec B608
-            )
-        else:
-            columns.append(f"b.{col}")
-    select_fields = ", ".join(columns)
+    # The State DB stores decoded asset names / addresses / utxo strings where
+    # the Ledger DB stores compact indexes. The projection is shared with the
+    # incremental rollback path so the two can never drift apart -- see
+    # ``api/statetables.py``.
+    names, expressions = consolidated_projection(state_db, table_name)
 
     state_db.execute(f"""
-        INSERT INTO {table_name}
-        SELECT {select_fields}
+        INSERT INTO {table_name} ({", ".join(names)})
+        SELECT {", ".join(expressions)}
         FROM ledger_db.{table_name} b
         JOIN latest_ids l ON b.rowid = l.max_id
     """)  # noqa S608 # nosec B608

--- a/counterparty-core/counterpartycore/lib/api/migrations/0014.add_pool_consolidated_tables.py
+++ b/counterparty-core/counterpartycore/lib/api/migrations/0014.add_pool_consolidated_tables.py
@@ -5,25 +5,18 @@ import logging
 import time
 
 from counterpartycore.lib import config
-from counterpartycore.lib.utils.database import (
-    ADDRESS_INDEX_COLUMN_NAMES,
-    ASSET_INDEX_COLUMN_NAMES,
-    text_affinitize_index_columns,
+from counterpartycore.lib.api.statetables import (
+    LEDGER_POOL_KEYS as POOL_TABLES,
 )
+from counterpartycore.lib.api.statetables import (
+    consolidated_projection,
+)
+from counterpartycore.lib.utils.database import text_affinitize_index_columns
 from yoyo import step
 
 logger = logging.getLogger(config.LOGGER_NAME)
 
 __depends__ = {"0013.add_performance_indexes"}
-
-# group_by fields determine which columns identify a unique record
-# (used to get the latest version via MAX(rowid)).
-POOL_TABLES = {
-    "pools": "asset_a, asset_b",
-    "pool_deposits": "tx_hash",
-    "pool_withdrawals": "tx_hash",
-    "pool_matches": "rowid",
-}
 
 
 def dict_factory(cursor, row):
@@ -68,29 +61,17 @@ def build_table(state_db, table_name, group_by):
     """)  # noqa: S608  # nosec B608
     state_db.execute("CREATE INDEX temp.latest_ids_idx ON latest_ids(max_id)")
 
-    # The State DB stores asset *names*; decode the compact ``asset_index`` back
-    # to names while ``ledger_db`` is attached (the INSERT ... SELECT bypasses
-    # the rowtracer). ``lp_asset`` is not normalized, so it is copied verbatim.
-    columns = []
-    for col in state_db.execute(f"PRAGMA table_info({table_name})"):
-        name = col["name"]
-        if name in ASSET_INDEX_COLUMN_NAMES:
-            columns.append(
-                f"(SELECT asset_name FROM ledger_db.assets WHERE asset_index = b.{name}) AS {name}"  # noqa: S608  # nosec B608
-            )
-        elif name in ADDRESS_INDEX_COLUMN_NAMES:
-            # decode the compact ``address_id`` back to the address string
-            columns.append(
-                f"(SELECT address FROM ledger_db.address_list WHERE address_id = b.{name}) AS {name}"  # noqa: S608  # nosec B608
-            )
-        else:
-            columns.append(f"b.{name}")
-    select_fields = ", ".join(columns)
+    # The State DB stores decoded asset names / addresses where the Ledger DB
+    # stores compact indexes. The projection is shared with the incremental
+    # rollback path so the two can never drift apart -- see
+    # ``api/statetables.py``.
+    names, expressions = consolidated_projection(state_db, table_name)
 
-    # table_name comes from POOL_TABLES dict; select_fields is built from PRAGMA table_info results
+    # table_name comes from POOL_TABLES; the projection is built from PRAGMA
+    # table_info results
     state_db.execute(f"""
-        INSERT INTO {table_name}
-        SELECT {select_fields}
+        INSERT INTO {table_name} ({", ".join(names)})
+        SELECT {", ".join(expressions)}
         FROM ledger_db.{table_name} b
         JOIN latest_ids l ON b.rowid = l.max_id
     """)  # noqa: S608  # nosec B608

--- a/counterparty-core/counterpartycore/lib/api/migrations/0016.add_rollback_block_index_indexes.py
+++ b/counterparty-core/counterpartycore/lib/api/migrations/0016.add_rollback_block_index_indexes.py
@@ -1,0 +1,34 @@
+#
+# file: counterpartycore/lib/api/migrations/0016.add_rollback_block_index_indexes.py
+#
+# The incremental rollback (issue #3485) finds the objects a reorganization
+# invalidated with ``SELECT ... FROM <table> WHERE block_index >= ?``. Most
+# consolidated tables inherit a ``block_index`` index from the Ledger DB schema
+# (migration 0006 copies the ledger's indexes verbatim), but ``addresses``,
+# ``rps`` and ``rps_matches`` never had one. They are small, so the missing
+# index is not a correctness problem -- it just turns three seeks into three
+# full scans on every reorg. Add them explicitly.
+#
+from yoyo import step
+
+__depends__ = {"0015.add_dispenser_origin_index"}
+
+INDEXES = {
+    "addresses_block_index_idx": "addresses (block_index)",
+    "rps_block_index_idx": "rps (block_index)",
+    "rps_matches_block_index_idx": "rps_matches (block_index)",
+}
+
+
+def apply(db):
+    for name, target in INDEXES.items():
+        db.execute(f"CREATE INDEX IF NOT EXISTS {name} ON {target}")  # noqa: S608  # nosec B608
+
+
+def rollback(db):
+    for name in INDEXES:
+        db.execute(f"DROP INDEX IF EXISTS {name}")  # noqa: S608  # nosec B608
+
+
+if not __name__.startswith("apsw_"):
+    steps = [step(apply, rollback)]

--- a/counterparty-core/counterpartycore/lib/api/staterollback.py
+++ b/counterparty-core/counterpartycore/lib/api/staterollback.py
@@ -1,0 +1,410 @@
+"""Incremental State DB rollback (issue #3485).
+
+Historically ``dbbuilder.rollback_state_db()`` did not roll anything back: it
+deleted the rows of three append-only tables and then *re-applied* thirteen
+migrations, each of which drops its table and repopulates it from the entire
+ledger history. The cost was therefore O(history) and independent of how deep
+the reorganization was -- a one-block mainnet reorg rebuilt the whole State DB
+(~33 minutes, and the API degraded badly for the last minutes of it because
+the single giant write transaction grew the WAL to several GB).
+
+This module reverts only what the orphaned blocks changed:
+
+  * **append-only tables** (``parsed_events``, ``address_events``,
+    ``all_expirations``, ``pool_matches``) are pruned by ``block_index``;
+  * **consolidated tables** (``balances``, ``orders``, ... -- one row per
+    object, holding its latest version) have their rows touched at or after the
+    rollback point deleted and re-inserted from the object's latest Ledger DB
+    version *strictly below* the rollback point;
+  * **counters** (``events_count``, ``transaction_types_count``) are
+    decremented / re-derived, and ``assets_info`` -- a pure projection of the
+    ledger's issuance history -- is re-derived with the same block bound.
+
+The cost is proportional to the number of rows the orphaned blocks touched.
+
+Why "strictly below the rollback point" matters
+-----------------------------------------------
+When the API watcher detects a reorganization the Ledger DB has *already*
+rolled back and may have re-parsed part of the new chain. Restoring a row to
+the ledger's current tip would leave the State DB ahead of ``parsed_events``,
+and the watcher's forward replay would then apply those blocks a second time.
+Every ledger read here is therefore bounded by ``block_index < rollback point``.
+That bound is safe because the watcher derives the rollback point from the last
+*matching* event hash, which is necessarily at or below the ledger's own
+rollback point.
+"""
+
+import logging
+import time
+
+import apsw
+
+from counterpartycore.lib import config
+from counterpartycore.lib.api import statetables
+from counterpartycore.lib.utils import database
+from counterpartycore.lib.utils.database import (
+    ADDRESS_INDEX_COLUMN_NAMES,
+    ASSET_INDEX_COLUMN_NAMES,
+)
+
+logger = logging.getLogger(config.LOGGER_NAME)
+
+
+# Deeper than this and a full rebuild is both simpler and (past a point)
+# cheaper than reverting row by row. Real reorganizations are one or two
+# blocks; the deep rollbacks in ``config.UPGRADE_ACTIONS`` intentionally want
+# the full rebuild anyway, since the derivation rules themselves may have
+# changed between releases.
+MAX_INCREMENTAL_DEPTH = 1000
+
+# Set on every State DB whose ``balances.block_index`` is known to be
+# maintained (see ``apiwatcher.update_balances``). Without that column being
+# up to date, the consolidated-table restore cannot find which balances an
+# orphaned block touched, so a State DB missing the marker falls back to the
+# full rebuild -- which sets the marker, making the fallback self-healing.
+READY_FLAG = "INCREMENTAL_ROLLBACK_READY"
+
+# Append-only State DB tables: every row carries the ``block_index`` of the
+# event that produced it, so reverting is a DELETE.
+PRUNABLE_TABLES = [
+    "parsed_events",
+    "address_events",
+    "all_expirations",
+    # keyed on ``rowid`` by migration 0014, i.e. copied verbatim from the
+    # ledger and never updated in place.
+    "pool_matches",
+]
+
+
+def _fetch_one(db, query, bindings=None):
+    cursor = db.cursor()
+    cursor.execute(query, bindings)
+    return cursor.fetchone()
+
+
+def _table_exists(db, table_name):
+    row = _fetch_one(
+        db,
+        "SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table_name,),
+    )
+    return row is not None and row["count"] > 0
+
+
+def attach_ledger_db(db):
+    """Attach ``ledger_db`` if the caller has not already done so."""
+    row = _fetch_one(
+        db,
+        "SELECT COUNT(*) AS count FROM pragma_database_list WHERE name = ?",
+        ("ledger_db",),
+    )
+    if row is not None and row["count"] > 0:
+        return False
+    db.cursor().execute("ATTACH DATABASE ? AS ledger_db", (config.DATABASE,))
+    return True
+
+
+def mark_ready(state_db):
+    """Record that this State DB was fully derived from the Ledger DB and is
+    therefore eligible for incremental rollback."""
+    database.set_config_value(state_db, READY_FLAG, "1")
+
+
+def is_ready(state_db):
+    return database.get_config_value(state_db, READY_FLAG) == "1"
+
+
+def rollback_reason(state_db, block_index):
+    """Return ``None`` when the incremental path applies, else a short reason
+    explaining why the caller must fall back to the full rebuild.
+
+    Any unexpected failure here (a State DB old enough to be missing the
+    ``config`` or ``parsed_events`` table, say) also selects the full rebuild:
+    this function only picks a path, and the full rebuild is always correct.
+    """
+    # A local import: apiwatcher imports dbbuilder, which imports this module.
+    from counterpartycore.lib.api import apiwatcher  # noqa: PLC0415
+
+    if block_index <= config.BLOCK_FIRST:
+        return "full rollback requested"
+    try:
+        if not is_ready(state_db):
+            return "State DB predates incremental rollback support"
+        last_block_parsed = apiwatcher.get_last_block_parsed(state_db, no_cache=True)
+    except apsw.Error as e:
+        return f"State DB cannot be inspected ({e})"
+    if last_block_parsed <= 0:
+        return "State DB is empty"
+    if block_index > last_block_parsed:
+        return "nothing to roll back"
+    depth = last_block_parsed - block_index + 1
+    if depth > MAX_INCREMENTAL_DEPTH:
+        return f"rollback depth ({depth} blocks) exceeds {MAX_INCREMENTAL_DEPTH}"
+    return None
+
+
+# -----------------------------------------------------------------------------
+# Consolidated tables
+# -----------------------------------------------------------------------------
+
+
+def _ledger_match_clause(column):
+    """SQL matching one State DB key column (``s``) against its Ledger DB
+    counterpart (``b``).
+
+    ``IS`` rather than ``=`` throughout: the key columns are nullable
+    (``balances`` rows are keyed on *either* ``address`` or ``utxo``) and
+    SQLite treats ``IS`` as a null-safe ``=``, index lookups included.
+    """
+    if column == "utxo":
+        # ``utxo`` is the ``<64 hex chars>:<vout>`` string; the Ledger DB keeps
+        # the compact ``(utxo_tx_hash BLOB, utxo_vout)`` pair. A NULL utxo
+        # (an address balance) yields NULL on both halves.
+        return (
+            "b.utxo_tx_hash IS unhex(substr(s.utxo, 1, 64)) "
+            "AND b.utxo_vout IS CAST(substr(s.utxo, 66) AS INTEGER)"
+        )
+    if column in ASSET_INDEX_COLUMN_NAMES:
+        return (
+            f"b.{column} IS (SELECT asset_index FROM ledger_db.assets "  # noqa: S608  # nosec B608
+            f"WHERE asset_name = s.{column})"
+        )
+    if column in ADDRESS_INDEX_COLUMN_NAMES:
+        return (
+            f"b.{column} IS (SELECT address_id FROM ledger_db.address_list "  # noqa: S608  # nosec B608
+            f"WHERE address = s.{column})"
+        )
+    # ``tx_hash`` / ``tx0_index`` / ``tx1_index``: same representation on both
+    # sides (BLOB(32) and INTEGER respectively).
+    return f"b.{column} IS s.{column}"
+
+
+def _restore_consolidated_table(state_db, table, key_columns, block_index):
+    """Revert one consolidated table to its state at ``block_index - 1``.
+
+    Returns the number of objects reverted.
+    """
+    block_index = int(block_index)
+    match = " AND ".join(_ledger_match_clause(column) for column in key_columns)
+    cursor = state_db.cursor()
+
+    # For every object whose latest version was written at or after the
+    # rollback point, find the rowid of its latest Ledger DB version strictly
+    # below it (NULL when the object did not exist before the reorg).
+    cursor.execute("DROP TABLE IF EXISTS temp.rollback_restore")
+    cursor.execute(f"""
+        CREATE TEMP TABLE rollback_restore AS
+        SELECT
+            s.rowid AS state_rowid,
+            (
+                SELECT MAX(b.rowid) FROM ledger_db.{table} b
+                WHERE {match} AND b.block_index < {block_index}
+            ) AS ledger_rowid
+        FROM {table} s
+        WHERE s.block_index >= {block_index}
+    """)  # noqa: S608  # nosec B608
+
+    reverted = _fetch_one(state_db, "SELECT COUNT(*) AS count FROM rollback_restore")["count"]
+    if reverted == 0:
+        cursor.execute("DROP TABLE temp.rollback_restore")
+        return 0
+
+    cursor.execute(f"""
+        DELETE FROM {table} WHERE rowid IN (SELECT state_rowid FROM rollback_restore)
+    """)  # noqa: S608  # nosec B608
+
+    names, expressions = statetables.consolidated_projection(state_db, table)
+    cursor.execute(f"""
+        INSERT INTO {table} ({", ".join(names)})
+        SELECT {", ".join(expressions)}
+        FROM ledger_db.{table} b
+        WHERE b.rowid IN (
+            SELECT ledger_rowid FROM rollback_restore WHERE ledger_rowid IS NOT NULL
+        )
+    """)  # noqa: S608  # nosec B608
+
+    cursor.execute("DROP TABLE temp.rollback_restore")
+    logger.debug("Reverted %s object(s) in `%s`", reverted, table)
+    return reverted
+
+
+def _refresh_fairminter_totals(state_db, block_index):
+    """Recompute ``fairminters``' ``earned_quantity`` / ``paid_quantity`` /
+    ``commission``, which are aggregated from ``fairmints`` rather than copied
+    from the ledger row (migration 0006's POST_QUERIES, and
+    ``apiwatcher.update_fairminters`` at runtime).
+    """
+    block_index = int(block_index)
+    cursor = state_db.cursor()
+    cursor.execute("DROP TABLE IF EXISTS temp.rollback_fairmints")
+    cursor.execute(f"""
+        CREATE TEMP TABLE rollback_fairmints AS
+        SELECT
+            fairminter_tx_index,
+            SUM(earn_quantity) AS earned_quantity,
+            SUM(paid_quantity) AS paid_quantity,
+            SUM(commission) AS commission
+        FROM ledger_db.fairmints
+        WHERE status = 'valid' AND block_index < {block_index}
+        GROUP BY fairminter_tx_index
+    """)  # noqa: S608  # nosec B608
+    cursor.execute(
+        "CREATE INDEX temp.rollback_fairmints_idx ON rollback_fairmints(fairminter_tx_index)"
+    )
+    # A fairminter with no valid fairmint left gets NULL back, which is what a
+    # fresh build produces (SUM over an empty set).
+    cursor.execute("""
+        UPDATE fairminters SET
+            earned_quantity = (
+                SELECT earned_quantity FROM rollback_fairmints t
+                WHERE t.fairminter_tx_index = fairminters.tx_index
+            ),
+            paid_quantity = (
+                SELECT paid_quantity FROM rollback_fairmints t
+                WHERE t.fairminter_tx_index = fairminters.tx_index
+            ),
+            commission = (
+                SELECT commission FROM rollback_fairmints t
+                WHERE t.fairminter_tx_index = fairminters.tx_index
+            )
+    """)
+    cursor.execute("DROP TABLE temp.rollback_fairmints")
+
+
+# -----------------------------------------------------------------------------
+# Counters and projections
+# -----------------------------------------------------------------------------
+
+
+def _collect_orphan_events(state_db, block_index):
+    """Tally the events the orphaned blocks produced, *before* pruning
+    ``parsed_events``. Returns ``{event name: count}``; the same counts stay in
+    the ``rollback_events`` temp table for ``_rollback_events_count``.
+    """
+    block_index = int(block_index)
+    cursor = state_db.cursor()
+    cursor.execute("DROP TABLE IF EXISTS temp.rollback_events")
+    cursor.execute(f"""
+        CREATE TEMP TABLE rollback_events AS
+        SELECT event, COUNT(*) AS orphan_count
+        FROM parsed_events
+        WHERE block_index >= {block_index}
+        GROUP BY event
+    """)  # noqa: S608  # nosec B608
+    rows = state_db.cursor().execute("SELECT event, orphan_count FROM rollback_events").fetchall()
+    return {row["event"]: row["orphan_count"] for row in rows}
+
+
+def _rollback_events_count(state_db):
+    """Subtract the orphaned events from ``events_count``. Exact: the streamed
+    handler increments it once per row inserted into ``parsed_events``."""
+    cursor = state_db.cursor()
+    cursor.execute("""
+        UPDATE events_count SET count = count - COALESCE(
+            (SELECT orphan_count FROM rollback_events o WHERE o.event = events_count.event), 0
+        )
+    """)
+    # An event type that no longer occurs at all is absent from a fresh build,
+    # not present with a zero count.
+    cursor.execute("DELETE FROM events_count WHERE count <= 0")
+    cursor.execute("DROP TABLE temp.rollback_events")
+
+
+def _rebuild_transaction_types_count(state_db, block_index):
+    """``transaction_types_count`` cannot be decremented from ``parsed_events``
+    (which does not record the transaction type) and the orphaned
+    ``transactions`` rows are already gone from the ledger, so re-derive it --
+    a single grouped scan, no table drop and no index rebuild."""
+    block_index = int(block_index)
+    cursor = state_db.cursor()
+    cursor.execute("DELETE FROM transaction_types_count")
+    cursor.execute(f"""
+        INSERT INTO transaction_types_count (transaction_type, count)
+        SELECT transaction_type, COUNT(*) AS counter
+        FROM ledger_db.transactions
+        WHERE block_index < {block_index}
+        GROUP BY transaction_type
+    """)  # noqa: S608  # nosec B608
+
+
+def _rebuild_assets_info(state_db, block_index):
+    cursor = state_db.cursor()
+    cursor.execute("DELETE FROM assets_info")
+    statetables.populate_assets_info(state_db, max_block_index=block_index)
+
+
+# -----------------------------------------------------------------------------
+# Entry point
+# -----------------------------------------------------------------------------
+
+
+def rollback(state_db, block_index):
+    """Revert the State DB to its state at ``block_index - 1``.
+
+    The caller is responsible for the enclosing transaction and for having
+    checked :func:`rollback_reason`.
+    """
+    # Local import: apiwatcher imports dbbuilder, which imports this module.
+    from counterpartycore.lib.api import apiwatcher  # noqa: PLC0415
+
+    # Left attached on exit, like the migration path: this is the long-lived
+    # State DB write connection, and DETACH is not valid inside a transaction.
+    attach_ledger_db(state_db)
+    cursor = state_db.cursor()
+    cursor.execute("PRAGMA foreign_keys=OFF")
+    try:
+        orphan_counts = _collect_orphan_events(state_db, block_index)
+        orphan_events = set(orphan_counts)
+
+        for table in PRUNABLE_TABLES:
+            if not _table_exists(state_db, table):
+                continue
+            cursor.execute(
+                f"DELETE FROM {table} WHERE block_index >= ?",  # noqa: S608  # nosec B608
+                (block_index,),
+            )
+
+        reverted = {}
+        for table, key_columns in statetables.STATE_CONSOLIDATED_KEYS.items():
+            if not _table_exists(state_db, table):
+                # AMM pool tables do not exist before activation.
+                continue
+            reverted[table] = _restore_consolidated_table(state_db, table, key_columns, block_index)
+
+        _rollback_events_count(state_db)
+        if "NEW_TRANSACTION" in orphan_events:
+            _rebuild_transaction_types_count(state_db, block_index)
+        if reverted.get("fairminters") or "NEW_FAIRMINT" in orphan_events:
+            _refresh_fairminter_totals(state_db, block_index)
+
+        asset_events = set(apiwatcher.ASSET_EVENTS) | set(apiwatcher.XCP_DESTROY_EVENTS)
+        if orphan_events & asset_events:
+            _rebuild_assets_info(state_db, block_index)
+
+        # ``parsed_events`` shrank, so the cached tip must be recomputed.
+        apiwatcher.update_last_parsed_events_cache(state_db, event=None)
+        # The State DB now sits exactly at ``block_index - 1``, so the
+        # double-counting guard a full rebuild needs (which copies balances
+        # from the ledger's *current* tip) does not apply here.
+        database.set_config_value(state_db, "BALANCES_COPIED_AT_BLOCK", None)
+        mark_ready(state_db)
+
+        # Logged at INFO: this line is the only visibility an operator has into
+        # what a reorganization actually cost them.
+        logger.info(
+            "Reverted %s event(s) and %s object(s) %s",
+            sum(orphan_counts.values()),
+            sum(reverted.values()),
+            {table: count for table, count in reverted.items() if count},
+        )
+    finally:
+        cursor.execute("PRAGMA foreign_keys=ON")
+
+
+def rollback_state_db(state_db, block_index):
+    """Incrementally roll the State DB back to ``block_index - 1``."""
+    logger.info("Rolling back State DB to block index %s (incremental)...", block_index)
+    start_time = time.time()
+    with state_db:
+        rollback(state_db, block_index)
+    logger.info("State DB rolled back in %.2f seconds", time.time() - start_time)

--- a/counterparty-core/counterpartycore/lib/api/staterollback.py
+++ b/counterparty-core/counterpartycore/lib/api/staterollback.py
@@ -123,6 +123,7 @@ def rollback_reason(state_db, block_index):
     this function only picks a path, and the full rebuild is always correct.
     """
     # A local import: apiwatcher imports dbbuilder, which imports this module.
+    # pylint: disable=import-outside-toplevel
     from counterpartycore.lib.api import apiwatcher  # noqa: PLC0415
 
     if block_index <= config.BLOCK_FIRST:
@@ -345,6 +346,7 @@ def rollback(state_db, block_index):
     checked :func:`rollback_reason`.
     """
     # Local import: apiwatcher imports dbbuilder, which imports this module.
+    # pylint: disable=import-outside-toplevel
     from counterpartycore.lib.api import apiwatcher  # noqa: PLC0415
 
     # Left attached on exit, like the migration path: this is the long-lived

--- a/counterparty-core/counterpartycore/lib/api/staterollback.py
+++ b/counterparty-core/counterpartycore/lib/api/staterollback.py
@@ -37,8 +37,6 @@ rollback point.
 import logging
 import time
 
-import apsw
-
 from counterpartycore.lib import config
 from counterpartycore.lib.api import statetables
 from counterpartycore.lib.utils import database
@@ -63,6 +61,15 @@ MAX_INCREMENTAL_DEPTH = 1000
 # orphaned block touched, so a State DB missing the marker falls back to the
 # full rebuild -- which sets the marker, making the fallback self-healing.
 READY_FLAG = "INCREMENTAL_ROLLBACK_READY"
+
+# Returned by ``rollback_reason`` when the State DB is already at or below the
+# requested block. Unlike the other reasons this one does *not* select the full
+# rebuild: there is nothing to undo, and re-deriving every table from the whole
+# ledger history to achieve nothing would be the most expensive no-op available.
+# Reachable from the CLI (``counterparty-server rollback/reparse`` to a block the
+# State DB has not caught up to yet), never from ``apiwatcher.check_reorg``,
+# whose target is always strictly below the last parsed block.
+NOTHING_TO_ROLL_BACK = "nothing to roll back"
 
 # Append-only State DB tables: every row carries the ``block_index`` of the
 # event that produced it, so reverting is a DELETE.
@@ -116,7 +123,10 @@ def is_ready(state_db):
 
 def rollback_reason(state_db, block_index):
     """Return ``None`` when the incremental path applies, else a short reason
-    explaining why the caller must fall back to the full rebuild.
+    explaining why the caller must take another path.
+
+    :data:`NOTHING_TO_ROLL_BACK` is the one reason that does not mean "fall
+    back to the full rebuild" -- see the caller in ``dbbuilder``.
 
     Any unexpected failure here (a State DB old enough to be missing the
     ``config`` or ``parsed_events`` table, say) also selects the full rebuild:
@@ -132,12 +142,16 @@ def rollback_reason(state_db, block_index):
         if not is_ready(state_db):
             return "State DB predates incremental rollback support"
         last_block_parsed = apiwatcher.get_last_block_parsed(state_db, no_cache=True)
-    except apsw.Error as e:
+    except Exception as e:  # pylint: disable=broad-except
+        # Deliberately broad: this function only picks a path. Anything that
+        # stops us inspecting the State DB -- an apsw error on a schema too old
+        # to have ``config`` / ``parsed_events``, a cached tip that will not
+        # parse as an int -- must select the full rebuild rather than propagate.
         return f"State DB cannot be inspected ({e})"
     if last_block_parsed <= 0:
         return "State DB is empty"
     if block_index > last_block_parsed:
-        return "nothing to roll back"
+        return NOTHING_TO_ROLL_BACK
     depth = last_block_parsed - block_index + 1
     if depth > MAX_INCREMENTAL_DEPTH:
         return f"rollback depth ({depth} blocks) exceeds {MAX_INCREMENTAL_DEPTH}"
@@ -305,6 +319,17 @@ def _rollback_events_count(state_db):
             (SELECT orphan_count FROM rollback_events o WHERE o.event = events_count.event), 0
         )
     """)
+    # A negative count cannot happen if the invariant above holds, so it is
+    # worth a warning rather than a silent DELETE: it would mean the streamed
+    # handler and ``parsed_events`` have drifted apart, and every later rollback
+    # would be wrong in the same way.
+    negative = cursor.execute("SELECT event, count FROM events_count WHERE count < 0").fetchall()
+    if negative:
+        logger.warning(
+            "`events_count` went negative while rolling back, which should be impossible: %s. "
+            "Rebuild the State DB with `--rebuild-state-db` to resynchronize it.",
+            {row["event"]: row["count"] for row in negative},
+        )
     # An event type that no longer occurs at all is absent from a fresh build,
     # not present with a zero count.
     cursor.execute("DELETE FROM events_count WHERE count <= 0")
@@ -342,8 +367,10 @@ def _rebuild_assets_info(state_db, block_index):
 def rollback(state_db, block_index):
     """Revert the State DB to its state at ``block_index - 1``.
 
-    The caller is responsible for the enclosing transaction and for having
-    checked :func:`rollback_reason`.
+    The caller is responsible for the enclosing transaction, for having checked
+    :func:`rollback_reason`, and for having disabled foreign-key enforcement --
+    ``PRAGMA foreign_keys`` is a no-op inside a transaction, so it cannot be set
+    here (see :func:`rollback_state_db`).
     """
     # Local import: apiwatcher imports dbbuilder, which imports this module.
     # pylint: disable=import-outside-toplevel
@@ -353,60 +380,68 @@ def rollback(state_db, block_index):
     # State DB write connection, and DETACH is not valid inside a transaction.
     attach_ledger_db(state_db)
     cursor = state_db.cursor()
-    cursor.execute("PRAGMA foreign_keys=OFF")
-    try:
-        orphan_counts = _collect_orphan_events(state_db, block_index)
-        orphan_events = set(orphan_counts)
 
-        for table in PRUNABLE_TABLES:
-            if not _table_exists(state_db, table):
-                continue
-            cursor.execute(
-                f"DELETE FROM {table} WHERE block_index >= ?",  # noqa: S608  # nosec B608
-                (block_index,),
-            )
+    orphan_counts = _collect_orphan_events(state_db, block_index)
+    orphan_events = set(orphan_counts)
 
-        reverted = {}
-        for table, key_columns in statetables.STATE_CONSOLIDATED_KEYS.items():
-            if not _table_exists(state_db, table):
-                # AMM pool tables do not exist before activation.
-                continue
-            reverted[table] = _restore_consolidated_table(state_db, table, key_columns, block_index)
-
-        _rollback_events_count(state_db)
-        if "NEW_TRANSACTION" in orphan_events:
-            _rebuild_transaction_types_count(state_db, block_index)
-        if reverted.get("fairminters") or "NEW_FAIRMINT" in orphan_events:
-            _refresh_fairminter_totals(state_db, block_index)
-
-        asset_events = set(apiwatcher.ASSET_EVENTS) | set(apiwatcher.XCP_DESTROY_EVENTS)
-        if orphan_events & asset_events:
-            _rebuild_assets_info(state_db, block_index)
-
-        # ``parsed_events`` shrank, so the cached tip must be recomputed.
-        apiwatcher.update_last_parsed_events_cache(state_db, event=None)
-        # The State DB now sits exactly at ``block_index - 1``, so the
-        # double-counting guard a full rebuild needs (which copies balances
-        # from the ledger's *current* tip) does not apply here.
-        database.set_config_value(state_db, "BALANCES_COPIED_AT_BLOCK", None)
-        mark_ready(state_db)
-
-        # Logged at INFO: this line is the only visibility an operator has into
-        # what a reorganization actually cost them.
-        logger.info(
-            "Reverted %s event(s) and %s object(s) %s",
-            sum(orphan_counts.values()),
-            sum(reverted.values()),
-            {table: count for table, count in reverted.items() if count},
+    for table in PRUNABLE_TABLES:
+        if not _table_exists(state_db, table):
+            continue
+        cursor.execute(
+            f"DELETE FROM {table} WHERE block_index >= ?",  # noqa: S608  # nosec B608
+            (block_index,),
         )
-    finally:
-        cursor.execute("PRAGMA foreign_keys=ON")
+
+    reverted = {}
+    for table, key_columns in statetables.STATE_CONSOLIDATED_KEYS.items():
+        if not _table_exists(state_db, table):
+            # AMM pool tables do not exist before activation.
+            continue
+        reverted[table] = _restore_consolidated_table(state_db, table, key_columns, block_index)
+
+    _rollback_events_count(state_db)
+    if "NEW_TRANSACTION" in orphan_events:
+        _rebuild_transaction_types_count(state_db, block_index)
+    if reverted.get("fairminters") or "NEW_FAIRMINT" in orphan_events:
+        _refresh_fairminter_totals(state_db, block_index)
+
+    asset_events = set(apiwatcher.ASSET_EVENTS) | set(apiwatcher.XCP_DESTROY_EVENTS)
+    if orphan_events & asset_events:
+        _rebuild_assets_info(state_db, block_index)
+
+    # ``parsed_events`` shrank, so the cached tip must be recomputed.
+    apiwatcher.update_last_parsed_events_cache(state_db, event=None)
+    # The State DB now sits exactly at ``block_index - 1``, so the
+    # double-counting guard a full rebuild needs (which copies balances
+    # from the ledger's *current* tip) does not apply here.
+    database.set_config_value(state_db, "BALANCES_COPIED_AT_BLOCK", None)
+    mark_ready(state_db)
+
+    # Logged at INFO: this line is the only visibility an operator has into
+    # what a reorganization actually cost them.
+    logger.info(
+        "Reverted %s event(s) and %s object(s) %s",
+        sum(orphan_counts.values()),
+        sum(reverted.values()),
+        {table: count for table, count in reverted.items() if count},
+    )
 
 
 def rollback_state_db(state_db, block_index):
     """Incrementally roll the State DB back to ``block_index - 1``."""
     logger.info("Rolling back State DB to block index %s (incremental)...", block_index)
     start_time = time.time()
-    with state_db:
-        rollback(state_db, block_index)
+    cursor = state_db.cursor()
+    # Migration 0006 copies the Ledger DB's CREATE TABLE statements verbatim, so
+    # several consolidated tables carry FOREIGN KEY clauses pointing at parent
+    # tables (``blocks``, ``transactions``) that the State DB does not have.
+    # Enforcement has to be off while their rows are deleted and re-inserted --
+    # and ``PRAGMA foreign_keys`` is a documented no-op inside a transaction, so
+    # it must be set here, *before* ``with state_db:`` opens one.
+    cursor.execute("PRAGMA foreign_keys=OFF")
+    try:
+        with state_db:
+            rollback(state_db, block_index)
+    finally:
+        cursor.execute("PRAGMA foreign_keys=ON")
     logger.info("State DB rolled back in %.2f seconds", time.time() - start_time)

--- a/counterparty-core/counterpartycore/lib/api/statetables.py
+++ b/counterparty-core/counterpartycore/lib/api/statetables.py
@@ -95,8 +95,15 @@ DERIVED_COLUMNS = {
         # ``(utxo_tx_hash, utxo_vout)`` pair (``lower(hex(...))`` yields the
         # lowercase hex the utxo string used; a NULL tx_hash -> NULL utxo).
         "utxo": "lower(hex(b.utxo_tx_hash)) || ':' || b.utxo_vout",
-        # migration 0006 fills this with a post-INSERT UPDATE from ``assets``;
-        # the same value, resolved inline, so a restored row is complete.
+        # ``asset_longname`` is not a ledger column: migration 0006 adds it with
+        # ALTER TABLE *after* the bulk INSERT and fills it from ``assets`` in its
+        # POST_QUERIES, so on the build path this rule is never reached (the
+        # column does not exist yet when the projection is computed). It exists
+        # for the rollback path, where the column is already there and a restored
+        # row would otherwise come back with a NULL longname. Same value, same
+        # source -- ``ledger_db.assets`` -- as both the migration's POST_QUERY
+        # and ``apiwatcher.update_balances`` (which reads it back out of
+        # ``assets_info``, itself a projection of ``ledger_db.assets``).
         "asset_longname": (
             "(SELECT asset_longname FROM ledger_db.assets WHERE asset_index = b.asset)"
         ),

--- a/counterparty-core/counterpartycore/lib/api/statetables.py
+++ b/counterparty-core/counterpartycore/lib/api/statetables.py
@@ -1,0 +1,351 @@
+"""Shared derivation rules for the State DB tables that mirror the Ledger DB.
+
+Two independent code paths populate those tables from ``ledger_db``:
+
+  * the **build** path -- API migrations ``0004`` (``assets_info``), ``0006``
+    (consolidated tables) and ``0014`` (AMM pool tables) -- which recreates
+    every table from the full ledger history, and
+  * the **incremental rollback** path (:mod:`counterpartycore.lib.api.staterollback`),
+    which reverts only the rows a reorganization invalidated.
+
+Both must derive each row *identically*: the State DB stores decoded asset
+names, address strings and ``tx_hash:vout`` utxo strings where the Ledger DB
+stores the compact ``asset_index`` / ``address_id`` / ``(utxo_tx_hash,
+utxo_vout)`` pair. Any drift between the two projections would silently
+diverge a rolled-back node from a freshly built one -- the exact class of bug
+that is impossible to detect from the API. The rules therefore live here,
+once, and both paths import them.
+
+This module deliberately depends only on ``config`` and ``utils.database``:
+it is imported by yoyo-driven migrations, which run on a stdlib ``sqlite3``
+connection outside the usual apsw plumbing.
+"""
+
+import logging
+
+from counterpartycore.lib import config
+from counterpartycore.lib.utils.database import (
+    ADDRESS_INDEX_COLUMN_NAMES,
+    ASSET_INDEX_COLUMN_NAMES,
+)
+
+logger = logging.getLogger(config.LOGGER_NAME)
+
+
+# Consolidated tables copied from ``ledger_db`` by migration 0006, mapped to
+# the column list that identifies a unique object. The Ledger DB keeps every
+# version of an object as an appended row; the State DB keeps only the latest
+# one (``MAX(rowid)`` per key).
+LEDGER_CONSOLIDATED_KEYS = {
+    "fairminters": "tx_hash",
+    # ``utxo`` is the compact ``(utxo_tx_hash, utxo_vout)`` ledger pair; group
+    # by both halves (the State DB stores the reconstructed ``utxo`` string).
+    "balances": "address, utxo_tx_hash, utxo_vout, asset",
+    "addresses": "address",
+    "dispensers": "source, asset, tx_hash",
+    # match tables: the composite TEXT ``id`` was dropped; the match is keyed
+    # by the ``(tx0_index, tx1_index)`` pair (compact-hash storage migration).
+    "bet_matches": "tx0_index, tx1_index",
+    "bets": "tx_hash",
+    "order_matches": "tx0_index, tx1_index",
+    "orders": "tx_hash",
+    "rps": "tx_hash",
+    "rps_matches": "tx0_index, tx1_index",
+}
+
+# Same, for the AMM pool tables added by migration 0014. ``pool_matches`` is
+# keyed on ``rowid``, i.e. it is append-only and copied verbatim.
+LEDGER_POOL_KEYS = {
+    "pools": "asset_a, asset_b",
+    "pool_deposits": "tx_hash",
+    "pool_withdrawals": "tx_hash",
+    "pool_matches": "rowid",
+}
+
+# The same keys expressed in **State DB** column names, for the rollback path
+# (which starts from a State DB row and looks up its Ledger DB ancestor).
+# Identical to the two dicts above except for ``balances``, where the State DB
+# keeps the reconstructed ``utxo`` string instead of the compact pair, and for
+# ``pool_matches``, which is append-only (see ``PRUNABLE_TABLES``).
+STATE_CONSOLIDATED_KEYS = {
+    "fairminters": ["tx_hash"],
+    "balances": ["address", "utxo", "asset"],
+    "addresses": ["address"],
+    "dispensers": ["source", "asset", "tx_hash"],
+    "bet_matches": ["tx0_index", "tx1_index"],
+    "bets": ["tx_hash"],
+    "order_matches": ["tx0_index", "tx1_index"],
+    "orders": ["tx_hash"],
+    "rps": ["tx_hash"],
+    "rps_matches": ["tx0_index", "tx1_index"],
+    "pools": ["asset_a", "asset_b"],
+    "pool_deposits": ["tx_hash"],
+    "pool_withdrawals": ["tx_hash"],
+}
+
+# State DB columns that have no Ledger DB counterpart and must be derived by
+# an explicit expression when copying a ledger row (``b`` is the ledger row).
+# Columns absent from both the ledger table and this map are left out of the
+# copy entirely (they are maintained separately -- see ``fairminters``'
+# ``earned_quantity`` / ``paid_quantity`` / ``commission``, aggregated from
+# ``fairmints``).
+DERIVED_COLUMNS = {
+    "balances": {
+        # reconstruct the ``tx_hash:vout`` string from the compact ledger
+        # ``(utxo_tx_hash, utxo_vout)`` pair (``lower(hex(...))`` yields the
+        # lowercase hex the utxo string used; a NULL tx_hash -> NULL utxo).
+        "utxo": "lower(hex(b.utxo_tx_hash)) || ':' || b.utxo_vout",
+        # migration 0006 fills this with a post-INSERT UPDATE from ``assets``;
+        # the same value, resolved inline, so a restored row is complete.
+        "asset_longname": (
+            "(SELECT asset_longname FROM ledger_db.assets WHERE asset_index = b.asset)"
+        ),
+    },
+}
+
+
+def _rows(db, sql, bindings=None):
+    """Fetch rows as dicts on both apsw and stdlib sqlite3 connections."""
+    cursor = db.execute(sql, bindings) if bindings else db.execute(sql)
+    return cursor.fetchall()
+
+
+def _column_names(db, table_name, schema="main"):
+    rows = _rows(db, f"PRAGMA {schema}.table_info({table_name})")  # noqa: S608  # nosec B608
+    names = []
+    for row in rows:
+        names.append(row["name"] if isinstance(row, dict) else row[1])
+    return names
+
+
+def consolidated_projection(db, table_name):
+    """Return ``(column_names, select_expressions)`` for copying one
+    ``ledger_db.<table_name>`` row (aliased ``b``) into the State DB table of
+    the same name.
+
+    ``ledger_db`` must be attached to ``db``. Asset / address columns are
+    decoded to their TEXT name, ``*_hash`` columns are copied verbatim (both
+    schemas store BLOB(32)), and per-table derived columns come from
+    ``DERIVED_COLUMNS``.
+    """
+    ledger_columns = set(_column_names(db, table_name, schema="ledger_db"))
+    derived = DERIVED_COLUMNS.get(table_name, {})
+
+    names = []
+    expressions = []
+    for column in _column_names(db, table_name):
+        if column in derived:
+            names.append(column)
+            expressions.append(f"{derived[column]} AS {column}")
+        elif column in ASSET_INDEX_COLUMN_NAMES and column in ledger_columns:
+            # The State DB stores asset *names* (it must read its own rows
+            # without the Ledger DB attached); decode the compact index.
+            names.append(column)
+            expressions.append(
+                f"(SELECT asset_name FROM ledger_db.assets WHERE asset_index = b.{column}) AS {column}"  # noqa: S608  # nosec B608
+            )
+        elif column in ADDRESS_INDEX_COLUMN_NAMES and column in ledger_columns:
+            names.append(column)
+            expressions.append(
+                f"(SELECT address FROM ledger_db.address_list WHERE address_id = b.{column}) AS {column}"  # noqa: S608  # nosec B608
+            )
+        elif column in ledger_columns:
+            names.append(column)
+            expressions.append(f"b.{column}")
+        # else: a State DB-only column with no derivation rule; skipped.
+
+    return names, expressions
+
+
+# -----------------------------------------------------------------------------
+# assets_info
+# -----------------------------------------------------------------------------
+
+ASSETS_INFO_COLUMNS = """
+    asset,
+    asset_id,
+    asset_longname,
+    issuer,
+    owner,
+    divisible,
+    locked,
+    supply,
+    description,
+    description_locked,
+    first_issuance_block_index,
+    last_issuance_block_index,
+    mime_type
+"""
+
+
+def _block_bound(max_block_index, alias):
+    """SQL fragment restricting a ledger table to blocks strictly below
+    ``max_block_index`` (``""`` when unbounded)."""
+    if max_block_index is None:
+        return ""
+    return f" AND {alias}.block_index < {int(max_block_index)}"
+
+
+def populate_assets_info(db, max_block_index=None):
+    """(Re)populate an existing, empty ``assets_info`` table from ``ledger_db``.
+
+    ``assets_info`` is a pure projection of the ledger's ``issuances`` /
+    ``destructions`` / ``burns`` history, so it is re-derived rather than
+    incrementally undone. ``max_block_index`` bounds the derivation to blocks
+    strictly below it, which is what the rollback path needs: the Ledger DB may
+    already have re-parsed the *new* chain past the reorganization point, and
+    those blocks must not leak into a State DB that is being rewound to just
+    before it.
+
+    ``ledger_db`` must be attached to ``db``, and the table must exist and be
+    empty (migration 0004 creates it; the rollback path DELETEs it first).
+    """
+    bound_i = _block_bound(max_block_index, "i")
+    bound_d = _block_bound(max_block_index, "d")
+
+    # One row per asset, mirroring the latest-wins semantics of
+    # ``apiwatcher.update_assets_info`` (the streamed handler that maintains
+    # this table at runtime). Each per-asset value is derived explicitly from
+    # the latest valid issuance (``ORDER BY rowid DESC LIMIT 1``) for fields the
+    # streamed handler overwrites on every issuance, and from ``MAX(...)`` for
+    # the boolean flags ``locked`` / ``description_locked`` so that multiple
+    # lock events don't accumulate as integer counts in ``BOOL`` columns.
+    db.execute(f"""
+    INSERT INTO assets_info ({ASSETS_INFO_COLUMNS})
+    SELECT
+        a.asset_name AS asset,
+        a.asset_id,
+        a.asset_longname,
+        (
+            SELECT (SELECT al.address FROM ledger_db.address_list al WHERE al.address_id = i.issuer)
+            FROM ledger_db.issuances i
+            WHERE i.asset = a.asset_index AND i.status = 'valid'{bound_i}
+            ORDER BY i.rowid ASC LIMIT 1
+        ) AS issuer,
+        (
+            SELECT (SELECT al.address FROM ledger_db.address_list al WHERE al.address_id = i.issuer)
+            FROM ledger_db.issuances i
+            WHERE i.asset = a.asset_index AND i.status = 'valid'{bound_i}
+            ORDER BY i.rowid DESC LIMIT 1
+        ) AS owner,
+        (
+            SELECT i.divisible FROM ledger_db.issuances i
+            WHERE i.asset = a.asset_index AND i.status = 'valid'{bound_i}
+            ORDER BY i.rowid DESC LIMIT 1
+        ) AS divisible,
+        COALESCE((
+            SELECT MAX(i.locked) FROM ledger_db.issuances i
+            WHERE i.asset = a.asset_index AND i.status = 'valid'{bound_i}
+        ), 0) AS locked,
+        COALESCE((
+            SELECT SUM(i.quantity) FROM ledger_db.issuances i
+            WHERE i.asset = a.asset_index AND i.status = 'valid'{bound_i}
+        ), 0) AS supply,
+        (
+            SELECT i.description FROM ledger_db.issuances i
+            WHERE i.asset = a.asset_index AND i.status = 'valid'{bound_i}
+            ORDER BY i.rowid DESC LIMIT 1
+        ) AS description,
+        COALESCE((
+            SELECT MAX(i.description_locked) FROM ledger_db.issuances i
+            WHERE i.asset = a.asset_index AND i.status = 'valid'{bound_i}
+        ), 0) AS description_locked,
+        (
+            SELECT MIN(i.block_index) FROM ledger_db.issuances i
+            WHERE i.asset = a.asset_index AND i.status = 'valid'{bound_i}
+        ) AS first_issuance_block_index,
+        (
+            SELECT MAX(i.block_index) FROM ledger_db.issuances i
+            WHERE i.asset = a.asset_index AND i.status = 'valid'{bound_i}
+        ) AS last_issuance_block_index,
+        (
+            SELECT i.mime_type FROM ledger_db.issuances i
+            WHERE i.asset = a.asset_index AND i.status = 'valid'{bound_i}
+            ORDER BY i.rowid DESC LIMIT 1
+        ) AS mime_type
+    FROM ledger_db.assets a
+    WHERE EXISTS (
+        SELECT 1 FROM ledger_db.issuances i
+        WHERE i.asset = a.asset_index AND i.status = 'valid'{bound_i}
+    );
+    """)  # noqa: S608  # nosec B608
+
+    # XCP has no ``issuances`` rows: its supply is burns minus every fee/
+    # destruction that removes XCP from circulation. This mirrors
+    # ``ledger.supplies.xcp_supply()`` in SQL so it can take the same block
+    # bound (the Python helper always reads the ledger at its current tip).
+    db.execute(f"""
+        INSERT INTO assets_info (
+            asset, divisible, locked, supply, description,
+            first_issuance_block_index, last_issuance_block_index
+        )
+        SELECT
+            '{config.XCP}',
+            1,
+            1,
+            COALESCE((
+                SELECT SUM(i.earned) FROM ledger_db.burns i
+                WHERE i.status = 'valid'{bound_i}
+            ), 0) - (
+                COALESCE((
+                    SELECT SUM(i.quantity) FROM ledger_db.destructions i
+                    WHERE i.status = 'valid'{bound_i}
+                    AND i.asset = (SELECT asset_index FROM ledger_db.assets WHERE asset_name = '{config.XCP}')
+                ), 0)
+                + COALESCE((
+                    SELECT SUM(i.fee_paid) FROM ledger_db.issuances i
+                    WHERE i.status = 'valid'{bound_i}
+                ), 0)
+                + COALESCE((
+                    SELECT SUM(i.fee_paid) FROM ledger_db.dividends i
+                    WHERE i.status = 'valid'{bound_i}
+                ), 0)
+                + COALESCE((
+                    SELECT SUM(i.fee_paid) FROM ledger_db.sweeps i
+                    WHERE i.status = 'valid'{bound_i}
+                ), 0)
+            ),
+            'The Counterparty protocol native currency',
+            278319,
+            283810
+    """)  # noqa: S608  # nosec B608
+
+    # ``supply`` above counts issuances only; subtract destructions. Done as a
+    # separate set-based pass (rather than one more correlated subquery) so a
+    # full rebuild stays a couple of sequential scans.
+    # ``DROP ... IF EXISTS`` first: unlike the migration, the rollback path can
+    # call this repeatedly on one long-lived connection, and a run that failed
+    # partway could otherwise leave these behind.
+    for temp_table in ("issuances_quantity", "destructions_quantity", "supplies"):
+        db.execute(f"DROP TABLE IF EXISTS temp.{temp_table}")  # noqa: S608  # nosec B608
+
+    db.execute(f"""
+        CREATE TEMP TABLE issuances_quantity AS
+        SELECT a.asset_name AS asset, SUM(i.quantity) AS quantity
+        FROM ledger_db.issuances i
+        JOIN ledger_db.assets a ON a.asset_index = i.asset
+        WHERE i.status = 'valid'{bound_i} GROUP BY i.asset
+    """)  # noqa: S608  # nosec B608
+    db.execute(f"""
+        CREATE TEMP TABLE destructions_quantity AS
+        SELECT a.asset_name AS asset, SUM(d.quantity) AS quantity
+        FROM ledger_db.destructions d
+        JOIN ledger_db.assets a ON a.asset_index = d.asset
+        WHERE d.status = 'valid'{bound_d} GROUP BY d.asset
+    """)  # noqa: S608  # nosec B608
+    db.execute("""
+        CREATE TEMP TABLE supplies AS
+        SELECT
+            issuances_quantity.asset,
+            issuances_quantity.quantity - COALESCE(destructions_quantity.quantity, 0) AS supply
+        FROM issuances_quantity
+        LEFT JOIN destructions_quantity ON issuances_quantity.asset = destructions_quantity.asset
+    """)
+    db.execute("""CREATE INDEX temp.supplies_asset_idx ON supplies(asset)""")
+    db.execute("""
+        UPDATE assets_info SET
+        supply = COALESCE((SELECT supplies.supply FROM supplies WHERE assets_info.asset = supplies.asset), supply)
+    """)
+    db.execute("DROP TABLE issuances_quantity")
+    db.execute("DROP TABLE destructions_quantity")
+    db.execute("DROP TABLE supplies")

--- a/counterparty-core/counterpartycore/lib/config.py
+++ b/counterparty-core/counterpartycore/lib/config.py
@@ -40,6 +40,11 @@ UPGRADE_ACTIONS = {
         "11.0.4": [("rollback", 926807)],
         "11.1.0": [("rollback", 941000)],
         "11.2.0": [("refresh_state_db", 0)],
+        # The incremental State DB rollback (#3485) needs
+        # ``balances.block_index`` to be up to date on every row; a
+        # refresh re-derives the State DB from the Ledger DB so the
+        # first reorg after the upgrade is already on the fast path.
+        "11.4.0": [("refresh_state_db", 0)],
     },
     "testnet3": {
         "10.3.0": [("reparse", 0)],
@@ -58,6 +63,11 @@ UPGRADE_ACTIONS = {
         "11.0.4": [("reparse", 4017708)],
         "11.1.0": [("refresh_state_db", 0)],
         "11.2.0": [("refresh_state_db", 0)],
+        # The incremental State DB rollback (#3485) needs
+        # ``balances.block_index`` to be up to date on every row; a
+        # refresh re-derives the State DB from the Ledger DB so the
+        # first reorg after the upgrade is already on the fast path.
+        "11.4.0": [("refresh_state_db", 0)],
     },
     "testnet4": {
         "10.10.0": [("rollback", 64492)],
@@ -67,12 +77,22 @@ UPGRADE_ACTIONS = {
         "11.0.3": [("reparse", 99290)],
         "11.1.0": [("refresh_state_db", 0)],
         "11.2.0": [("refresh_state_db", 0)],
+        # The incremental State DB rollback (#3485) needs
+        # ``balances.block_index`` to be up to date on every row; a
+        # refresh re-derives the State DB from the Ledger DB so the
+        # first reorg after the upgrade is already on the fast path.
+        "11.4.0": [("refresh_state_db", 0)],
     },
     "signet": {
         "11.0.2": [("refresh_state_db", 0)],
         "11.0.3": [("reparse", 266993)],
         "11.1.0": [("refresh_state_db", 0)],
         "11.2.0": [("refresh_state_db", 0)],
+        # The incremental State DB rollback (#3485) needs
+        # ``balances.block_index`` to be up to date on every row; a
+        # refresh re-derives the State DB from the Ledger DB so the
+        # first reorg after the upgrade is already on the fast path.
+        "11.4.0": [("refresh_state_db", 0)],
     },
 }
 

--- a/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
@@ -502,8 +502,20 @@ def test_check_database_version(state_db, ledger_db, test_helpers, caplog, monke
     def refresh_mock(db):
         apiserver.logger.info("Refreshing state database")
 
-    monkeypatch.setattr("counterpartycore.lib.api.dbbuilder.rollback_state_db", rollback_mock)
+    # `full_rollback_state_db`, not `rollback_state_db`: an upgrade action must
+    # never take the incremental fast path (the derivation rules themselves may
+    # have changed in the release that ships the action).
+    monkeypatch.setattr("counterpartycore.lib.api.dbbuilder.full_rollback_state_db", rollback_mock)
     monkeypatch.setattr("counterpartycore.lib.api.dbbuilder.refresh_state_db", refresh_mock)
+    # Guard the intent: if `execute_upgrade_actions` ever goes back through the
+    # dispatcher, this mock fires and the test fails loudly instead of silently
+    # running an incremental rollback.
+    monkeypatch.setattr(
+        "counterpartycore.lib.api.dbbuilder.rollback_state_db",
+        lambda db, block_index: pytest.fail(
+            "upgrade actions must call full_rollback_state_db, not the dispatcher"
+        ),
+    )
 
     with test_helpers.capture_log(
         caplog,

--- a/counterparty-core/counterpartycore/test/units/api/dbstatus_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/dbstatus_test.py
@@ -1,0 +1,349 @@
+"""Tests for the rebuild-progress status and the ``rebuilding`` health state (#3485).
+
+A State DB rebuild runs before the API listener exists and takes tens of
+minutes. These tests pin the two properties that make it survivable: the health
+server answers throughout, and it says *why* it is not ready.
+"""
+
+import http.client
+import json
+import threading
+import time
+from collections import deque
+
+import pytest
+from counterpartycore.lib.api import dbstatus, healthz_server
+from counterpartycore.lib.api.healthz_server import (
+    HealthRequestHandler,
+    HealthSampler,
+    HealthSnapshot,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_status():
+    """``dbstatus`` is process-global; never leak a rebuild into another test."""
+    dbstatus.finish()
+    yield
+    dbstatus.finish()
+
+
+# --------------------------------------------------------------------------------------------
+# dbstatus
+# --------------------------------------------------------------------------------------------
+
+
+def test_no_operation_by_default():
+    assert dbstatus.current() is None
+
+
+def test_start_step_finish():
+    dbstatus.start("refresh", "re-applying migrations", total=28)
+    progress = dbstatus.current()
+    assert progress.operation == "refresh"
+    assert progress.phase == "re-applying migrations"
+    assert progress.step is None
+    assert progress.total == 28
+
+    dbstatus.step("applying `0006.create_and_populate_consolidated_tables`", 20)
+    progress = dbstatus.current()
+    assert progress.step == 20
+    assert progress.total == 28, "total must survive a step"
+    assert progress.operation == "refresh", "operation must survive a step"
+
+    dbstatus.finish()
+    assert dbstatus.current() is None
+
+
+def test_step_outside_an_operation_is_a_noop():
+    dbstatus.step("orphan", 1)
+    assert dbstatus.current() is None
+
+
+def test_elapsed_time_is_measured_from_the_start_not_the_step():
+    dbstatus.start("rollback", "pruning")
+    started_at = dbstatus.current().started_at
+    dbstatus.step("re-applying", 1)
+    assert dbstatus.current().started_at == started_at
+    assert dbstatus.current().seconds >= 0
+
+
+def test_context_manager_clears_on_exception():
+    with pytest.raises(ValueError, match="boom"), dbstatus.rebuilding("build", "migrating"):
+        assert dbstatus.current() is not None
+        raise ValueError("boom")
+    assert dbstatus.current() is None, "a failed rebuild must not leave the pod unready forever"
+
+
+def test_as_dict_omits_unknown_counters():
+    dbstatus.start("build", "applying migrations")
+    body = dbstatus.current().as_dict()
+    assert body["operation"] == "build"
+    assert body["phase"] == "applying migrations"
+    assert "seconds" in body
+    assert "step" not in body
+    assert "total_steps" not in body
+
+
+# --------------------------------------------------------------------------------------------
+# Sampler: the rebuilding readiness axis
+# --------------------------------------------------------------------------------------------
+
+
+def _sampler(**kwargs):
+    defaults = {
+        "last_parsed_provider": lambda: 100,
+        "backend_height_provider": lambda: 100,
+        "block_time_provider": lambda: None,
+        "api_only_provider": lambda: False,
+        "saturation_grace": 5,
+    }
+    defaults.update(kwargs)
+    return HealthSampler(**defaults)
+
+
+def test_rebuild_makes_the_pod_unready():
+    sampler = _sampler()
+    sampler._tick()
+    assert sampler.current_snapshot().ready is True
+
+    dbstatus.start("refresh", "re-applying migrations", total=28)
+    sampler._tick()
+    snap = sampler.current_snapshot()
+    assert snap.ready is False
+    assert snap.reason == "rebuilding"
+    assert snap.rebuild.operation == "refresh"
+
+
+def test_rebuild_wins_over_the_lag_signal():
+    """While the State DB is being dropped and repopulated, the block height read
+    from it is meaningless -- reporting ``behind_backend`` would send the
+    operator chasing the wrong problem."""
+    sampler = _sampler(backend_height_provider=lambda: 200, last_parsed_provider=lambda: 100)
+    sampler._tick()
+    assert sampler.current_snapshot().reason == "behind_backend"
+
+    dbstatus.start("rollback", "pruning")
+    sampler._tick()
+    snap = sampler.current_snapshot()
+    assert snap.reason == "rebuilding"
+    assert snap.last_parsed is None, "a mid-rebuild block height must not be published"
+
+
+def test_readiness_recovers_when_the_rebuild_ends():
+    sampler = _sampler()
+    dbstatus.start("build", "applying migrations")
+    sampler._tick()
+    assert sampler.current_snapshot().ready is False
+
+    dbstatus.finish()
+    sampler._tick()
+    snap = sampler.current_snapshot()
+    assert snap.ready is True
+    assert snap.rebuild is None
+
+
+def test_heartbeat_stays_fresh_during_a_rebuild():
+    """Liveness must not fail while rebuilding: that is exactly what killed the
+    pod mid-rebuild and restarted the work from zero."""
+    sampler = _sampler()
+    dbstatus.start("refresh", "re-applying migrations")
+    sampler._tick()
+    assert sampler.heartbeat_age() < sampler.liveness_heartbeat_timeout
+
+
+# --------------------------------------------------------------------------------------------
+# HTTP surface
+# --------------------------------------------------------------------------------------------
+
+
+class _FakeSampler:
+    liveness_heartbeat_timeout = 30
+
+    def __init__(self, snapshot):
+        self._snapshot = snapshot
+
+    def current_snapshot(self):
+        return self._snapshot
+
+    def heartbeat_age(self):
+        return 0.0
+
+
+def _rebuilding_snapshot():
+    dbstatus.start("refresh", "applying `0006.create_and_populate_consolidated_tables`", total=28)
+    dbstatus.step("applying `0006.create_and_populate_consolidated_tables`", 20)
+    return HealthSnapshot(
+        ready=False,
+        reason="rebuilding",
+        backend_height=900000,
+        last_parsed=None,
+        lag=None,
+        saturated=False,
+        saturation_seconds=0.0,
+        workers=None,
+        rebuild=dbstatus.current(),
+    )
+
+
+@pytest.fixture
+def rebuilding_server():
+    httpd = healthz_server.ThreadingHTTPServer(("127.0.0.1", 0), HealthRequestHandler)
+    httpd.daemon_threads = True
+    httpd.sampler = _FakeSampler(_rebuilding_snapshot())
+    httpd.started_at_monotonic = time.monotonic()
+    httpd.live_latencies_ms = deque(maxlen=256)
+    httpd.ready_latencies_ms = deque(maxlen=256)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+
+    def get(path):
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", path)
+        resp = conn.getresponse()
+        body = json.loads(resp.read().decode())
+        code = resp.status
+        conn.close()
+        return code, body
+
+    yield get
+    httpd.shutdown()
+    httpd.server_close()
+    thread.join(timeout=5)
+
+
+def test_http_liveness_ok_while_rebuilding(rebuilding_server):
+    assert rebuilding_server("/healthz/live") == (200, {"status": "alive"})
+
+
+def test_http_readiness_reports_the_rebuild(rebuilding_server):
+    code, body = rebuilding_server("/healthz/ready")
+    assert code == 503
+    assert body["reason"] == "rebuilding"
+    assert body["rebuild"]["operation"] == "refresh"
+    assert body["rebuild"]["step"] == 20
+    assert body["rebuild"]["total_steps"] == 28
+    assert "0006" in body["rebuild"]["phase"]
+
+
+def test_http_metrics_reports_the_rebuild(rebuilding_server):
+    _code, body = rebuilding_server("/healthz/metrics")
+    assert body["readiness"]["reason"] == "rebuilding"
+    assert body["readiness"]["rebuild"]["step"] == 20
+
+
+# --------------------------------------------------------------------------------------------
+# Late dispatcher attachment
+# --------------------------------------------------------------------------------------------
+
+
+def test_server_starts_without_a_dispatcher_and_accepts_one_later():
+    """The health server now starts before the WSGI server, so there is no
+    worker pool to introspect at first; the gauges must simply read as
+    unavailable until one is attached."""
+    server = healthz_server.HealthCheckServer(host="127.0.0.1", port=0)
+    server.start()
+    try:
+        assert server.sampler is not None
+        assert server.sampler.dispatcher is None
+        assert server.sampler.current_snapshot().workers is None
+
+        dispatcher = type(
+            "Dispatcher", (), {"threads": {1, 2}, "active_count": 0, "stop_count": 0}
+        )()
+        dispatcher.queue = deque()
+        dispatcher.add_task = lambda task: None
+        server.attach_dispatcher(dispatcher)
+
+        assert server.sampler.dispatcher is dispatcher
+        server.sampler._tick()
+        assert server.sampler.current_snapshot().workers.total == 2
+    finally:
+        server.stop()
+
+
+def test_attach_dispatcher_ignores_none():
+    server = healthz_server.HealthCheckServer(host="127.0.0.1", port=0)
+    server.start()
+    try:
+        server.attach_dispatcher(None)
+        assert server.sampler.dispatcher is None
+    finally:
+        server.stop()
+
+
+# --------------------------------------------------------------------------------------------
+# The sampler's own DB connection across a rebuild
+# --------------------------------------------------------------------------------------------
+
+
+class _FakeConn:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def _owning_sampler(monkeypatch):
+    """A sampler that owns its state-DB connection, with the connection factory
+    replaced by a counter."""
+    opened = []
+
+    def fake_connection(*_args, **_kwargs):
+        conn = _FakeConn()
+        opened.append(conn)
+        return conn
+
+    monkeypatch.setattr(healthz_server.database, "get_db_connection", fake_connection)
+    sampler = HealthSampler(
+        backend_height_provider=lambda: 100,
+        block_time_provider=lambda: None,
+        api_only_provider=lambda: False,
+    )
+    assert sampler._owns_db is True
+    return sampler, opened
+
+
+def test_sampler_opens_its_connection_once_when_idle(monkeypatch):
+    sampler, opened = _owning_sampler(monkeypatch)
+    conn = sampler._own_db_for_tick(None, False, False)
+    assert len(opened) == 1
+    assert sampler._own_db_for_tick(conn, False, False) is conn
+    assert len(opened) == 1
+
+
+def test_sampler_does_not_open_during_a_rebuild(monkeypatch):
+    """The file may be unlinked or mid-migration; opening it buys nothing and
+    can pin a doomed inode."""
+    sampler, opened = _owning_sampler(monkeypatch)
+    assert sampler._own_db_for_tick(None, False, True) is None
+    assert opened == []
+
+
+def test_sampler_reopens_after_a_rebuild(monkeypatch):
+    """``build_state_db()`` unlinks and recreates the file: a connection held
+    across it reads a deleted inode and would report a frozen block height for
+    the rest of the process's life."""
+    sampler, opened = _owning_sampler(monkeypatch)
+    stale = sampler._own_db_for_tick(None, False, False)
+    assert len(opened) == 1
+
+    # ... a rebuild runs ...
+    assert sampler._own_db_for_tick(stale, False, True) is stale
+    # ... and finishes: falling edge.
+    fresh = sampler._own_db_for_tick(stale, True, False)
+
+    assert stale.closed is True
+    assert fresh is not stale
+    assert len(opened) == 2
+
+
+def test_sampler_with_injected_provider_is_left_alone(monkeypatch):
+    """Tests (and any future caller) that inject a provider own no connection;
+    the rebuild lifecycle must not touch them."""
+    sampler, opened = _owning_sampler(monkeypatch)
+    sampler._owns_db = False
+    assert sampler._own_db_for_tick(None, True, False) is None
+    assert opened == []

--- a/counterparty-core/counterpartycore/test/units/api/staterollback_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/staterollback_test.py
@@ -1,0 +1,326 @@
+"""Tests for the incremental State DB rollback (issue #3485).
+
+The two tests that matter here are differential: the incremental rollback
+replaces "re-derive everything from the ledger" with "undo what changed", and
+the only way that is trustworthy is to check, table by table, that it lands on
+exactly the same State DB the full rebuild would have produced -- and that a
+rollback followed by the watcher's forward replay is a no-op.
+"""
+
+import pytest
+from counterpartycore.lib import config
+from counterpartycore.lib.api import apiwatcher, dbbuilder, staterollback, statetables
+from counterpartycore.lib.parser import blocks
+from counterpartycore.lib.utils import database
+
+# Tables whose contents are not derived from the ledger (yoyo bookkeeping) or
+# whose contents legitimately differ between a rebuild and a rollback (the
+# ``config`` table holds the version string, the rollback marker and the
+# rebuild-only ``BALANCES_COPIED_AT_BLOCK`` guard).
+NON_DERIVED_TABLES = {"config"}
+
+
+def _derived_tables(db):
+    rows = db.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
+    ).fetchall()
+    return [
+        row["name"]
+        for row in rows
+        if not row["name"].startswith("_yoyo")
+        and not row["name"].startswith("sqlite_")
+        and row["name"] not in NON_DERIVED_TABLES
+    ]
+
+
+def _dump_table(db, table):
+    """Order-independent, type-stable snapshot of a table's contents."""
+    rows = db.execute(f"SELECT * FROM {table}").fetchall()  # noqa: S608  # nosec B608
+    return sorted(repr(sorted(row.items())) for row in rows)
+
+
+def _dump_state_db(db):
+    return {table: _dump_table(db, table) for table in _derived_tables(db)}
+
+
+def _assert_same_state(expected, actual, context):
+    assert set(expected) == set(actual), f"{context}: table sets differ"
+    for table in sorted(expected):
+        assert expected[table] == actual[table], (
+            f"{context}: `{table}` differs "
+            f"({len(expected[table])} expected rows vs {len(actual[table])})"
+        )
+
+
+def _last_block(db):
+    return db.execute("SELECT MAX(block_index) AS block_index FROM blocks").fetchone()[
+        "block_index"
+    ]
+
+
+def _nth_last_active_block(db, count):
+    """Block index of the ``count``-th most recent block that actually contains
+    transactions. The fixture ends on a long run of empty blocks, so rolling
+    back "N blocks from the tip" would revert nothing at all and make these
+    tests vacuous."""
+    rows = db.execute(
+        "SELECT DISTINCT block_index FROM transactions ORDER BY block_index DESC LIMIT ?",
+        (count,),
+    ).fetchall()
+    return rows[-1]["block_index"]
+
+
+def _block_of_last_split_fairmint(db):
+    """Block of the most recent fairmint on a fairminter that has fairmints in
+    more than one block. Rolling back to it leaves the fairminter itself alive
+    (restored to an earlier version) while dropping some of its fairmints --
+    the only way to exercise the recomputation of earned_quantity /
+    paid_quantity / commission, which are aggregated from fairmints
+    rather than copied from the ledger row."""
+    row = db.execute(
+        """
+        SELECT MAX(block_index) AS block_index FROM fairmints
+        WHERE status = 'valid'
+        GROUP BY fairminter_tx_index
+        HAVING COUNT(DISTINCT block_index) > 1
+        ORDER BY block_index DESC LIMIT 1
+        """
+    ).fetchone()
+    assert row is not None, "the fixture no longer has a multi-block fairminter"
+    return row["block_index"]
+
+
+def _touched_objects(db, target):
+    """How many consolidated objects the rollback will have to revert."""
+    return {
+        table: db.execute(
+            f"SELECT COUNT(*) AS count FROM {table} WHERE block_index >= ?",  # noqa: S608  # nosec B608
+            (target,),
+        ).fetchone()["count"]
+        for table in statetables.STATE_CONSOLIDATED_KEYS
+    }
+
+
+# =============================================================================
+# Differential tests
+# =============================================================================
+
+# (case id, target selector, deep-rollback cap override). Targets are chosen
+# from the fixture's *active* blocks: its tip sits ~700 empty blocks past the
+# last transaction, so "N blocks from the tip" would revert nothing at all.
+# The last case reverts essentially the whole fixture -- every consolidated
+# table, utxo balances and match tables included -- which needs the depth cap
+# lifted for that reason.
+ROLLBACK_CASES = [
+    ("1-active-block", lambda db: _nth_last_active_block(db, 1), None),
+    ("3-active-blocks", lambda db: _nth_last_active_block(db, 3), None),
+    ("10-active-blocks", lambda db: _nth_last_active_block(db, 10), None),
+    ("30-active-blocks", lambda db: _nth_last_active_block(db, 30), None),
+    ("mid-fairminter", _block_of_last_split_fairmint, None),
+    ("whole-fixture", lambda db: _nth_last_active_block(db, 60), 5000),
+]
+
+
+@pytest.mark.parametrize(("case", "select_target", "depth_cap"), ROLLBACK_CASES)
+def test_incremental_rollback_matches_full_rebuild(
+    state_db, ledger_db, monkeypatch, case, select_target, depth_cap
+):
+    """A reorganization must leave the State DB exactly where a from-scratch
+    rebuild against the same rolled-back ledger would. This is the test that
+    makes the incremental path trustworthy: the failure mode it guards against
+    is a silent divergence no API response would reveal."""
+    if depth_cap is not None:
+        monkeypatch.setattr(staterollback, "MAX_INCREMENTAL_DEPTH", depth_cap)
+    target = select_target(ledger_db)
+    touched = _touched_objects(state_db, target)
+    assert sum(touched.values()) > 0, "nothing would be reverted; the test is vacuous"
+
+    # The Ledger DB always rolls back first; the API watcher reacts afterwards.
+    blocks.rollback(ledger_db, block_index=target, force=True)
+
+    assert staterollback.rollback_reason(state_db, target) is None
+    dbbuilder.rollback_state_db(state_db, target)
+    incremental = _dump_state_db(state_db)
+
+    # Rebuild from scratch against the same ledger and compare.
+    state_db.close()
+    database.StateDBConnectionPool().close()
+    dbbuilder.build_state_db()
+    rebuilt_db = database.get_db_connection(config.STATE_DATABASE, read_only=True)
+    try:
+        rebuilt = _dump_state_db(rebuilt_db)
+    finally:
+        rebuilt_db.close()
+
+    _assert_same_state(rebuilt, incremental, f"{case}: rollback to block {target} ({touched})")
+
+
+@pytest.mark.parametrize(("case", "select_target", "depth_cap"), ROLLBACK_CASES)
+def test_rollback_then_replay_is_a_noop(
+    state_db, ledger_db, monkeypatch, case, select_target, depth_cap
+):
+    """Rolling the State DB back and letting the watcher replay the same blocks
+    must reproduce it exactly. This covers the other half of the contract: the
+    streamed handlers have to be able to run on top of reverted rows."""
+    if depth_cap is not None:
+        monkeypatch.setattr(staterollback, "MAX_INCREMENTAL_DEPTH", depth_cap)
+    before = _dump_state_db(state_db)
+    target = select_target(ledger_db)
+    assert sum(_touched_objects(state_db, target).values()) > 0
+
+    dbbuilder.rollback_state_db(state_db, target)
+    assert _dump_state_db(state_db) != before, "rollback did not change anything"
+
+    apiwatcher.catch_up(ledger_db, state_db)
+    _assert_same_state(before, _dump_state_db(state_db), f"{case}: replay from block {target}")
+
+
+def test_rollback_reverts_balances(state_db, ledger_db):
+    """Spot check on the table the whole design hinges on."""
+    target = _nth_last_active_block(ledger_db, 10)
+    expected = ledger_db.execute(
+        """
+        SELECT COUNT(*) AS count FROM (
+            SELECT MAX(rowid) FROM balances WHERE block_index < ?
+            GROUP BY address, utxo_tx_hash, utxo_vout, asset
+        )
+        """,
+        (target,),
+    ).fetchone()["count"]
+
+    blocks.rollback(ledger_db, block_index=target, force=True)
+    dbbuilder.rollback_state_db(state_db, target)
+
+    assert (
+        state_db.execute("SELECT COUNT(*) AS count FROM balances").fetchone()["count"] == expected
+    )
+    assert (
+        state_db.execute(
+            "SELECT COUNT(*) AS count FROM balances WHERE block_index >= ?", (target,)
+        ).fetchone()["count"]
+        == 0
+    )
+
+
+# =============================================================================
+# Fallback conditions
+# =============================================================================
+
+
+def test_full_rebuild_for_block_zero(state_db, ledger_db):
+    assert staterollback.rollback_reason(state_db, 0) == "full rollback requested"
+
+
+def test_full_rebuild_for_deep_rollback(state_db, ledger_db):
+    last_block = apiwatcher.get_last_block_parsed(state_db, no_cache=True)
+    target = max(1, last_block - staterollback.MAX_INCREMENTAL_DEPTH)
+    reason = staterollback.rollback_reason(state_db, target)
+    assert reason is not None and "exceeds" in reason
+
+
+def test_full_rebuild_when_marker_missing(state_db, ledger_db):
+    """A State DB built by an older release has stale ``balances.block_index``
+    values, so it must not take the incremental path."""
+    database.set_config_value(state_db, staterollback.READY_FLAG, None)
+    assert (
+        staterollback.rollback_reason(state_db, _last_block(ledger_db))
+        == "State DB predates incremental rollback support"
+    )
+
+
+def test_full_rebuild_marks_state_db_ready(state_db, ledger_db):
+    database.set_config_value(state_db, staterollback.READY_FLAG, None)
+    dbbuilder.rollback_state_db(state_db, _last_block(ledger_db))
+    assert staterollback.is_ready(state_db)
+
+
+def test_build_state_db_marks_ready(state_db, ledger_db):
+    assert staterollback.is_ready(state_db)
+
+
+# =============================================================================
+# Invariants the incremental path relies on
+# =============================================================================
+
+
+def test_state_keys_agree_with_ledger_keys():
+    """The State DB key columns must be the Ledger DB grouping columns, with
+    the single documented exception of ``balances``' utxo pair."""
+    ledger_keys = dict(statetables.LEDGER_CONSOLIDATED_KEYS)
+    ledger_keys.update(statetables.LEDGER_POOL_KEYS)
+    # ``pool_matches`` is append-only (keyed on rowid); it is pruned, not restored.
+    del ledger_keys["pool_matches"]
+
+    assert set(ledger_keys) == set(statetables.STATE_CONSOLIDATED_KEYS)
+    for table, columns in statetables.STATE_CONSOLIDATED_KEYS.items():
+        expected = [column.strip() for column in ledger_keys[table].split(",")]
+        if table == "balances":
+            expected = ["address", "utxo", "asset"]
+        assert columns == expected, f"{table} key columns drifted"
+
+
+def test_every_consolidated_table_has_a_block_index_index(state_db):
+    """``WHERE block_index >= ?`` is how the rollback finds what to revert; on a
+    mainnet-sized table a missing index turns that seek into a full scan."""
+    for table in statetables.STATE_CONSOLIDATED_KEYS:
+        indexed = state_db.execute(
+            "SELECT COUNT(*) AS count FROM sqlite_master "
+            "WHERE type = 'index' AND tbl_name = ? AND sql LIKE '%block_index%'",
+            (table,),
+        ).fetchone()["count"]
+        assert indexed > 0, f"`{table}` has no index on block_index"
+
+
+def test_ledger_lookup_uses_an_index(state_db, ledger_db):
+    """The per-object ledger lookup must be an index SEARCH. A SCAN here would
+    be a full table scan *per reverted object* -- catastrophically worse than
+    the full rebuild it replaces."""
+    staterollback.attach_ledger_db(state_db)
+    for table, key_columns in statetables.STATE_CONSOLIDATED_KEYS.items():
+        match = " AND ".join(
+            staterollback._ledger_match_clause(column)  # noqa: SLF001
+            for column in key_columns
+        )
+        plan = state_db.execute(
+            f"""
+            EXPLAIN QUERY PLAN
+            SELECT s.rowid, (
+                SELECT MAX(b.rowid) FROM ledger_db.{table} b
+                WHERE {match} AND b.block_index < 1
+            ) FROM {table} s WHERE s.block_index >= 1
+            """  # noqa: S608  # nosec B608
+        ).fetchall()
+        details = [row["detail"] for row in plan]
+        scans = [
+            detail for detail in details if detail.startswith("SCAN") and f"{table} AS b" in detail
+        ]
+        assert not scans, f"ledger lookup on `{table}` full-scans: {details}"
+
+
+def test_projection_covers_every_state_column(state_db, ledger_db):
+    """Every consolidated-table column must either be copied from the ledger or
+    be maintained by an explicit pass; a column silently dropped from the
+    projection would come back NULL after a rollback."""
+    # ``fairminters``' aggregates are recomputed from ``fairmints`` by
+    # ``_refresh_fairminter_totals``, not copied from the ledger row.
+    maintained_separately = {"fairminters": {"earned_quantity", "paid_quantity", "commission"}}
+    staterollback.attach_ledger_db(state_db)
+    for table in statetables.STATE_CONSOLIDATED_KEYS:
+        names, expressions = statetables.consolidated_projection(state_db, table)
+        assert len(names) == len(expressions)
+        columns = {
+            column["name"] for column in state_db.execute(f"PRAGMA table_info({table})").fetchall()
+        }
+        missing = columns - set(names) - maintained_separately.get(table, set())
+        assert not missing, f"`{table}` columns absent from the projection: {missing}"
+
+
+def test_orphan_events_drive_the_optional_passes(state_db, ledger_db):
+    """``assets_info`` / ``transaction_types_count`` are only re-derived when
+    the orphaned blocks actually contained the relevant events."""
+    staterollback.attach_ledger_db(state_db)
+    target = _last_block(ledger_db)
+    counts = staterollback._collect_orphan_events(state_db, target)  # noqa: SLF001
+    state_db.execute("DROP TABLE temp.rollback_events")
+    assert counts, "the fixture's last block should produce events"
+    assert counts["BLOCK_PARSED"] == 1

--- a/counterparty-core/counterpartycore/test/units/api/staterollback_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/staterollback_test.py
@@ -52,6 +52,10 @@ def _assert_same_state(expected, actual, context):
         )
 
 
+def _foreign_keys(db):
+    return db.execute("PRAGMA foreign_keys").fetchone()["foreign_keys"]
+
+
 def _last_block(db):
     return db.execute("SELECT MAX(block_index) AS block_index FROM blocks").fetchone()[
         "block_index"
@@ -226,6 +230,80 @@ def test_full_rebuild_when_marker_missing(state_db, ledger_db):
         staterollback.rollback_reason(state_db, _last_block(ledger_db))
         == "State DB predates incremental rollback support"
     )
+
+
+def test_nothing_to_roll_back_is_a_noop(state_db, ledger_db, monkeypatch):
+    """A target above the State DB's own tip has nothing to undo. Re-deriving
+    every table from the whole ledger history to achieve that would be the most
+    expensive no-op available -- the watcher just replays forward instead."""
+    target = apiwatcher.get_last_block_parsed(state_db, no_cache=True) + 1
+    assert staterollback.rollback_reason(state_db, target) == staterollback.NOTHING_TO_ROLL_BACK
+
+    before = _dump_state_db(state_db)
+    rebuilt = []
+    monkeypatch.setattr(
+        dbbuilder, "full_rollback_state_db", lambda db, block_index: rebuilt.append(block_index)
+    )
+    dbbuilder.rollback_state_db(state_db, target)
+
+    assert rebuilt == [], "a no-op rollback triggered a full rebuild"
+    _assert_same_state(before, _dump_state_db(state_db), "no-op rollback")
+
+
+def test_incremental_failure_falls_back_to_the_full_rebuild(state_db, ledger_db, monkeypatch):
+    """The incremental path is an optimization; the full rebuild is the ground
+    truth. A failure must degrade to it, not propagate: the caller is
+    ``apiwatcher.check_reorg()`` on the watcher thread, which has no handler for
+    it and would die, freezing the State DB behind the Ledger DB."""
+    target = _nth_last_active_block(ledger_db, 3)
+    before = _dump_state_db(state_db)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated incremental failure")
+
+    # Fail *after* the prune and the consolidated restore have written rows, so
+    # the test also proves the enclosing transaction undoes them.
+    monkeypatch.setattr(staterollback, "_rollback_events_count", boom)
+    rebuilt = []
+    monkeypatch.setattr(
+        dbbuilder, "full_rollback_state_db", lambda db, block_index: rebuilt.append(block_index)
+    )
+
+    dbbuilder.rollback_state_db(state_db, target)
+
+    assert rebuilt == [target], "a failed incremental rollback did not fall back"
+    _assert_same_state(
+        before, _dump_state_db(state_db), "a failed incremental rollback left rows behind"
+    )
+
+
+def test_unreadable_state_db_selects_the_full_rebuild(state_db, ledger_db, monkeypatch):
+    """`rollback_reason` only picks a path, so *any* failure to inspect the
+    State DB has to select the full rebuild rather than propagate."""
+
+    def boom(*args, **kwargs):
+        raise ValueError("invalid literal for int()")
+
+    monkeypatch.setattr(apiwatcher, "get_last_block_parsed", boom)
+    reason = staterollback.rollback_reason(state_db, _last_block(ledger_db))
+    assert reason is not None and "cannot be inspected" in reason
+
+
+def test_foreign_keys_are_disabled_outside_the_transaction(state_db, ledger_db, monkeypatch):
+    """``PRAGMA foreign_keys`` is a documented no-op inside a transaction, so the
+    guard has to be set before the rollback opens one -- and restored after."""
+    seen = []
+    real_rollback = staterollback.rollback
+
+    def record(db, block_index):
+        seen.append(_foreign_keys(db))
+        return real_rollback(db, block_index)
+
+    monkeypatch.setattr(staterollback, "rollback", record)
+    dbbuilder.rollback_state_db(state_db, _nth_last_active_block(ledger_db, 1))
+
+    assert seen == [0], "foreign key enforcement was still on during the rollback"
+    assert _foreign_keys(state_db) == 1, "foreign key enforcement was not restored"
 
 
 def test_full_rebuild_marks_state_db_ready(state_db, ledger_db):

--- a/counterparty-rs/Cargo.lock
+++ b/counterparty-rs/Cargo.lock
@@ -750,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/pylintrc
+++ b/pylintrc
@@ -99,10 +99,6 @@ recursive=yes
 # source root.
 source-roots=
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no

--- a/release-notes/release-notes-v11.4.0.md
+++ b/release-notes/release-notes-v11.4.0.md
@@ -6,9 +6,13 @@ Until now a Bitcoin reorganization — however shallow — rebuilt the entire St
 
 Rollbacks are now proportional to what the orphaned blocks actually changed. A one-block reorg reverts a handful of rows instead of tens of millions.
 
+The rebuild that remains — at upgrade, and for the deep rollbacks a new release occasionally requires — is no longer silent. It now reports itself: the dedicated health listener starts **before** it, answers `200` on liveness and `503 rebuilding` on readiness throughout, and names the step under way.
+
 # Upgrading
 
 This release **requires a one-time State DB refresh**, applied automatically on first start (`refresh_state_db`). It takes roughly as long as one of the old reorg rebuilds and happens once, at a moment you control, rather than unpredictably at the next reorg. There is no ledger reparse and no protocol change.
+
+**Point your Kubernetes probes at the dedicated health listener before upgrading** (port `4002` on mainnet — `/healthz/live` for liveness, `/healthz/ready` for readiness), if you have not already since v11.3.0. During the refresh the pod reports `200` on liveness and `503 rebuilding` on readiness, so it stays out of rotation and is not restarted. A liveness probe still pointed at the API port would get a connection refusal for the whole refresh and kill the pod, and the next start would begin the work again from zero.
 
 To upgrade, download the latest version of `counterparty-core` and restart `counterparty-server`.
 
@@ -28,6 +32,18 @@ A single `logger.info` line now reports what a reorganization cost — how many 
 **Fallbacks.** The full rebuild is still used, and is still correct, for a rollback deeper than 1,000 blocks, for the `UPGRADE_ACTIONS` rollbacks (where the derivation rules themselves may have changed between releases), and for a State DB that predates this release. That last check is self-healing: such a State DB takes the full path once, which marks it eligible for the incremental path afterwards.
 
 **Verification.** The incremental path is covered by differential tests that roll a fixture back to six different points — from a single active block up to essentially its whole history — and assert, table by table, that the result is identical to a from-scratch rebuild against the same rolled-back ledger, and that a rollback followed by the watcher's forward replay reproduces the State DB exactly. Every optional pass in the rollback (the counters, the `assets_info` re-derivation, the `fairminters` aggregates, the block bound on the ledger lookups) was checked by mutation: removing it makes those tests fail.
+
+## A rebuild that reports itself (#3485)
+
+Every remaining State DB build, refresh or full rollback now publishes its progress (`counterpartycore/lib/api/dbstatus.py`), and two consumers read it:
+
+- **The health listener starts first.** It used to be created after the migration/rebuild block, so for the tens of minutes that block runs there was no socket to probe at all — liveness got a connection refusal, Kubernetes killed the pod mid-rebuild, and the restart began again from zero. It is now started before that block (the WSGI task dispatcher is attached later, once the worker pool exists; until then the pool gauges simply read as unavailable).
+- **`rebuilding` is a distinct readiness state.** `/healthz/ready` returns `503` with `reason: "rebuilding"` and a `rebuild` object naming the operation, the current step and the elapsed time; `/healthz/metrics` carries the same. It takes precedence over the lag signal, which reads from tables that are being dropped and repopulated and would otherwise report a misleading `behind_backend`. Liveness stays `200` throughout — the process is healthy and working.
+- **Each migration is logged at INFO, with its duration.** Previously the whole rebuild logged nothing above DEBUG, which is why the 33 minutes in the incident report were indistinguishable from a hang.
+
+The health sampler also reopens its own State DB connection after a rebuild: `build_state_db()` unlinks and recreates the file, so a connection held across it would have reported a frozen block height for the rest of the process's life.
+
+**On serving from a second State DB while one is rebuilt** (suggestion 2 in the issue): not implemented, and we think it should not be. Once rollbacks are incremental, a full rebuild only happens at startup, before any listener exists — there are no readers to keep serving. The atomic-swap machinery (a second file, connection-pool epoch invalidation, a swap under live readers) would carry real risk for a case that no longer arises, whereas a correct `rebuilding` readiness state removes the pod from rotation and explains why, which is what suggestion 3 was really after.
 
 ## State DB / Ledger DB consistency fixes
 

--- a/release-notes/release-notes-v11.4.0.md
+++ b/release-notes/release-notes-v11.4.0.md
@@ -4,13 +4,17 @@ Counterparty Core v11.4.0 makes State DB rollbacks incremental (#3485).
 
 Until now a Bitcoin reorganization — however shallow — rebuilt the entire State DB. On mainnet a **one-block reorg took ~33 minutes**, during the last ~6 of which the public API returned 5xx, despite the process having ample CPU and memory headroom. The cost had nothing to do with how deep the reorganization was: `rollback_state_db()` deleted the rows of three tables and then re-applied thirteen migrations, each of which dropped its table and repopulated it from the entire ledger history (`parsed_events` alone is a full copy of `messages`).
 
-Rollbacks are now proportional to what the orphaned blocks actually changed. A one-block reorg reverts a handful of rows instead of tens of millions.
+Rollbacks now revert what the orphaned blocks actually changed instead of re-deriving everything. A one-block reorg touches a handful of rows instead of tens of millions.
+
+Two passes are still re-derived rather than undone, because the data needed to decrement them disappears from the Ledger DB along with the orphaned blocks: `transaction_types_count` (one grouped scan of `transactions`, whenever a rolled back block held a transaction) and `assets_info` (whenever it held an issuance, a burn, a destruction, a sweep or a dividend — which includes every fairmint). They dominate what a reorg now costs, and they are a fraction of the thirteen migrations they replace, but the result is not zero: expect minutes rather than the previous half hour.
 
 The rebuild that remains — at upgrade, and for the deep rollbacks a new release occasionally requires — is no longer silent. It now reports itself: the dedicated health listener starts **before** it, answers `200` on liveness and `503 rebuilding` on readiness throughout, and names the step under way.
 
 # Upgrading
 
-This release **requires a one-time State DB refresh**, applied automatically on first start (`refresh_state_db`). It takes roughly as long as one of the old reorg rebuilds and happens once, at a moment you control, rather than unpredictably at the next reorg. There is no ledger reparse and no protocol change.
+This release performs a **one-time State DB refresh** on first start (`refresh_state_db`), automatically. It takes roughly as long as one of the old reorg rebuilds. There is no ledger reparse and no protocol change.
+
+The refresh is an optimization, not a correctness requirement: it pays the cost of the last full rebuild at a moment you control rather than unpredictably at your next reorg. A State DB that has not been through it is flagged as ineligible for the incremental path and simply takes the old full-rebuild route once, which then flags it as eligible. Nodes therefore converge on the fast path either way — a node upgraded with `--force` (which skips the version check, and so the refresh) is correct, just slower on its first reorg.
 
 **Point your Kubernetes probes at the dedicated health listener before upgrading** (port `4002` on mainnet — `/healthz/live` for liveness, `/healthz/ready` for readiness), if you have not already since v11.3.0. During the refresh the pod reports `200` on liveness and `503 rebuilding` on readiness, so it stays out of rotation and is not restarted. A liveness probe still pointed at the API port would get a connection refusal for the whole refresh and kill the pod, and the next start would begin the work again from zero.
 
@@ -29,7 +33,9 @@ To upgrade, download the latest version of `counterparty-core` and restart `coun
 
 A single `logger.info` line now reports what a reorganization cost — how many events and objects were reverted, per table. Previously the 33 minutes were entirely silent at INFO level.
 
-**Fallbacks.** The full rebuild is still used, and is still correct, for a rollback deeper than 1,000 blocks, for the `UPGRADE_ACTIONS` rollbacks (where the derivation rules themselves may have changed between releases), and for a State DB that predates this release. That last check is self-healing: such a State DB takes the full path once, which marks it eligible for the incremental path afterwards.
+**Fallbacks.** The full rebuild is still used, and is still correct, for a rollback deeper than 1,000 blocks, for the `UPGRADE_ACTIONS` rollbacks (where the derivation rules themselves may have changed between releases, so they call it directly and never consult the fast path), for a State DB that predates this release, and if the incremental path raises for any reason at all — it is an optimization layered over a path that already worked, and a failure degrades to that path instead of stopping the watcher. A rollback target the State DB has not caught up to yet is now a logged no-op rather than a full rebuild that undoes nothing.
+
+**One visible consequence.** State DB listings (`/v2/orders`, `/v2/dispensers`, `/v2/balances`, …) are ordered and paginated by `rowid` by default. The full rebuild rewrote every table, so it re-canonicalized that order on each reorg; the incremental path re-inserts only the reverted objects, which therefore move to the front of the default `DESC` listing. The rows and their contents are identical — only their relative order differs, and only for objects a reorg touched. An in-flight cursor should be restarted after a reorg, as before.
 
 **Verification.** The incremental path is covered by differential tests that roll a fixture back to six different points — from a single active block up to essentially its whole history — and assert, table by table, that the result is identical to a from-scratch rebuild against the same rolled-back ledger, and that a rollback followed by the watcher's forward replay reproduces the State DB exactly. Every optional pass in the rollback (the counters, the `assets_info` re-derivation, the `fairminters` aggregates, the block bound on the ledger lookups) was checked by mutation: removing it makes those tests fail.
 

--- a/release-notes/release-notes-v11.4.0.md
+++ b/release-notes/release-notes-v11.4.0.md
@@ -57,3 +57,7 @@ The differential tests above surfaced three ways in which a State DB maintained 
 
 - The rules for projecting a Ledger DB row into its State DB counterpart — decoding the compact `asset_index` / `address_id` / `(utxo_tx_hash, utxo_vout)` representations — now live in one place, `counterpartycore/lib/api/statetables.py`, shared by the build path (migrations `0004`, `0006`, `0014`) and the rollback path. Two independent copies of these rules would drift, and drift here is a silent divergence no API response would reveal.
 - New State DB migration `0016` adds the missing `block_index` indexes on `addresses`, `rps` and `rps_matches`.
+
+## Security
+
+- Bumped `h2` to 0.4.19 in both Rust lockfiles for **RUSTSEC-2026-0258** ("h2 unbounded empty DATA frames"). `counterparty-rs` carried 0.4.8 and `counterparty-client` 0.4.15; the advisory requires >= 0.4.16.

--- a/release-notes/release-notes-v11.4.0.md
+++ b/release-notes/release-notes-v11.4.0.md
@@ -1,0 +1,43 @@
+# Release Notes - Counterparty Core v11.4.0 (TBD)
+
+Counterparty Core v11.4.0 makes State DB rollbacks incremental (#3485).
+
+Until now a Bitcoin reorganization — however shallow — rebuilt the entire State DB. On mainnet a **one-block reorg took ~33 minutes**, during the last ~6 of which the public API returned 5xx, despite the process having ample CPU and memory headroom. The cost had nothing to do with how deep the reorganization was: `rollback_state_db()` deleted the rows of three tables and then re-applied thirteen migrations, each of which dropped its table and repopulated it from the entire ledger history (`parsed_events` alone is a full copy of `messages`).
+
+Rollbacks are now proportional to what the orphaned blocks actually changed. A one-block reorg reverts a handful of rows instead of tens of millions.
+
+# Upgrading
+
+This release **requires a one-time State DB refresh**, applied automatically on first start (`refresh_state_db`). It takes roughly as long as one of the old reorg rebuilds and happens once, at a moment you control, rather than unpredictably at the next reorg. There is no ledger reparse and no protocol change.
+
+To upgrade, download the latest version of `counterparty-core` and restart `counterparty-server`.
+
+# Changelog
+
+## Incremental State DB rollback (#3485)
+
+`dbbuilder.rollback_state_db()` now reverts the State DB instead of re-deriving it (`counterpartycore/lib/api/staterollback.py`):
+
+- **Append-only tables** (`parsed_events`, `address_events`, `all_expirations`, `pool_matches`) are pruned by `block_index`.
+- **Consolidated tables** (`balances`, `orders`, `dispensers`, `fairminters`, the match tables, the AMM pool tables — one row per object holding its latest version) have the rows touched at or after the rollback point deleted and re-inserted from that object's latest Ledger DB version *strictly below* the rollback point. The block bound matters: when the API watcher reacts to a reorganization the Ledger DB has already rolled back and may have re-parsed part of the new chain, and restoring to the ledger's current tip would leave the State DB ahead of `parsed_events` and cause the forward replay to apply those blocks twice.
+- **Counters** are adjusted rather than recomputed from scratch: `events_count` is decremented by the orphaned events, and `transaction_types_count` / `assets_info` / the `fairminters` aggregates are re-derived only when the orphaned blocks actually contained the relevant events.
+- Views and indexes are no longer dropped and rebuilt, because the tables they cover are no longer dropped and rebuilt.
+
+A single `logger.info` line now reports what a reorganization cost — how many events and objects were reverted, per table. Previously the 33 minutes were entirely silent at INFO level.
+
+**Fallbacks.** The full rebuild is still used, and is still correct, for a rollback deeper than 1,000 blocks, for the `UPGRADE_ACTIONS` rollbacks (where the derivation rules themselves may have changed between releases), and for a State DB that predates this release. That last check is self-healing: such a State DB takes the full path once, which marks it eligible for the incremental path afterwards.
+
+**Verification.** The incremental path is covered by differential tests that roll a fixture back to six different points — from a single active block up to essentially its whole history — and assert, table by table, that the result is identical to a from-scratch rebuild against the same rolled-back ledger, and that a rollback followed by the watcher's forward replay reproduces the State DB exactly. Every optional pass in the rollback (the counters, the `assets_info` re-derivation, the `fairminters` aggregates, the block bound on the ledger lookups) was checked by mutation: removing it makes those tests fail.
+
+## State DB / Ledger DB consistency fixes
+
+The differential tests above surfaced three ways in which a State DB maintained by the event stream drifted from one built from scratch. All three are fixed in `apiwatcher.update_balances()`, and the one-time refresh normalizes existing rows:
+
+- `balances.block_index` and `balances.tx_index` were never written by the event stream, so every balance changed since the last full build carried a stale (or `NULL`) value. This is also what the incremental rollback uses to find which balances an orphaned block touched.
+- `balances.asset_longname` was `NULL` for every balance row first created by the event stream, while the same row on a freshly built node carried the real longname.
+- A zero-quantity `CREDIT`/`DEBIT` was skipped entirely, where the parser still appends a `balances` row for it (bumping that row's block and transaction index). An existing balance row is now always updated, whatever the quantity, and a zero-quantity debit against a non-existent balance still writes nothing — matching `ledger.events.remove_from_balance()`.
+
+## Refactoring
+
+- The rules for projecting a Ledger DB row into its State DB counterpart — decoding the compact `asset_index` / `address_id` / `(utxo_tx_hash, utxo_vout)` representations — now live in one place, `counterpartycore/lib/api/statetables.py`, shared by the build path (migrations `0004`, `0006`, `0014`) and the rollback path. Two independent copies of these rules would drift, and drift here is a silent divergence no API response would reveal.
+- New State DB migration `0016` adds the missing `block_index` indexes on `addresses`, `rps` and `rps_matches`.


### PR DESCRIPTION
Fixes #3485.

A one-block mainnet reorganization took **~33 minutes** and made the public API return 5xx for the last ~6 of them, with the process sitting at 2.2 of 8 cores and an idle worker pool.

The cost had nothing to do with how deep the reorganization was. `rollback_state_db()` deleted the rows of three tables and then re-applied thirteen migrations, each of which drops its table and repopulates it from the entire ledger history — `parsed_events` alone is a full copy of `messages`. And all of it ran in a single write transaction, so the WAL grew to several GB with no checkpoint possible, which is what degraded the readers: not the duration itself, but the transaction.

## What changed

### Rollbacks are incremental (`lib/api/staterollback.py`)

The State DB is now reverted rather than re-derived:

- **Append-only tables** (`parsed_events`, `address_events`, `all_expirations`, `pool_matches`) are pruned by `block_index`.
- **Consolidated tables** — `balances`, `orders`, `dispensers`, `fairminters`, the match tables, the AMM pool tables: one row per object, holding its latest version — have the rows touched at or after the rollback point deleted, and re-inserted from that object's latest Ledger DB version **strictly below** the rollback point.
- **Counters** are adjusted, not recomputed: `events_count` is decremented by the orphaned events (exact — the streamed handler increments it once per `parsed_events` row), and `transaction_types_count` / `assets_info` / the `fairminters` aggregates are re-derived only when the orphaned blocks actually contained the relevant events.
- Views and indexes are no longer dropped and rebuilt, because the tables they cover no longer are.

Cost is now proportional to what the orphaned blocks touched, with two exceptions: `transaction_types_count` (a grouped scan of `transactions`, whenever a rolled back block held one) and `assets_info` (whenever it held an issuance, burn, destruction, sweep or dividend — which includes every fairmint) are re-derived, because the rows needed to decrement them leave the Ledger DB with the orphaned blocks. They dominate what a reorg now costs: minutes rather than the previous half hour, not zero.

**Why the block bound matters.** When the API watcher reacts to a reorganization the Ledger DB has *already* rolled back and may have re-parsed part of the new chain. Restoring a row to the ledger's current tip would leave the State DB ahead of `parsed_events`, and the watcher's forward replay would then apply those blocks a second time. The bound is safe because the watcher derives the rollback point from the last *matching* event hash, which is necessarily at or below the ledger's own rollback point.

**Fallbacks.** The full rebuild is still used, and still correct, for a rollback deeper than 1000 blocks, for a State DB predating this change, and if the incremental path raises for any reason at all — it is an optimization layered over a path that already worked, and the caller is `check_reorg()` on the watcher thread, which has no handler and would die. The State DB check is self-healing: such a State DB takes the full path once, which marks it eligible for the incremental one.

The `UPGRADE_ACTIONS` rollbacks never reach the dispatcher: `execute_upgrade_actions` calls `full_rollback_state_db()` directly, because a release that ships one may also have changed the derivation rules and only re-applying the migrations picks that up.

A rollback target the State DB has not caught up to yet — reachable from the CLI, never from `check_reorg()`, whose target is strictly below the last parsed block — is a logged no-op rather than a full rebuild that undoes nothing.

### The remaining rebuild reports itself (`lib/api/dbstatus.py`)

A full rebuild still happens at upgrade. It was invisible in two compounding ways:

- **The health listener was created after the migration/rebuild block**, so for the tens of minutes it runs there was no socket to probe. Liveness got a connection refusal, Kubernetes killed the pod mid-rebuild, and the next start began again from zero. It now starts *before* that block; the WSGI task dispatcher is attached later, once the worker pool exists.
- **The rebuild logged nothing above DEBUG**, which is why those 33 minutes were indistinguishable from a hang. Each migration is now logged at INFO with its duration.

`/healthz/ready` gains a distinct `rebuilding` state — `503` with the operation, the current step and the elapsed time — which takes precedence over the lag signal (that one reads from tables being dropped and repopulated, and would report a misleading `behind_backend`). Liveness stays `200`: the process is healthy and working.

The sampler also reopens its own State DB connection once a rebuild ends: `build_state_db()` unlinks and recreates the file, so a connection held across it read a deleted inode and would have reported a frozen block height for the rest of the process's life.

### Consistency fixes surfaced by the tests

The differential tests below found three ways a State DB maintained by the event stream had drifted from one built from scratch — invisible until now because every reorg rebuilt everything. All three are in `apiwatcher.update_balances()`:

- `balances.block_index` and `balances.tx_index` were never written by the event stream, so every balance changed since the last full build carried a stale or `NULL` value. `block_index` is also what the incremental rollback uses to find which balances an orphaned block touched.
- `balances.asset_longname` was `NULL` for every balance row first created by the event stream.
- A zero-quantity `CREDIT`/`DEBIT` was skipped entirely, where the parser still appends a `balances` row for it (bumping that row's block and transaction index).

### Refactoring

The rules for projecting a Ledger DB row into its State DB counterpart — decoding the compact `asset_index` / `address_id` / `(utxo_tx_hash, utxo_vout)` representations — now live once in `lib/api/statetables.py`, shared by the build path (migrations `0004`, `0006`, `0014`) and the rollback path. Two independent copies of those rules would drift, and drift here is a silent divergence no API response would reveal.

New State DB migration `0016` adds the missing `block_index` indexes on `addresses`, `rps` and `rps_matches`.

## On suggestion 2 (build a repaired State DB separately, swap readers atomically)

Deliberately not implemented. Once rollbacks are incremental, a full rebuild only happens at startup, *before* any listener exists — there are no readers to keep serving. The atomic-swap machinery (a second file, connection-pool epoch invalidation, a swap under live readers, WAL and `ATTACH ledger_db` coordination) would carry real risk for a case that no longer arises. A correct `rebuilding` readiness state removes the pod from rotation and explains why, which is what suggestion 3 was really after.

The one residual case is a node started with `--force` (which skips `check_database_version`, and therefore the upgrade refresh) taking the full path on its next reorg while serving traffic. There, readiness now sheds the pod instead of returning a storm of 5xx. Happy to revisit if that is not considered enough.

## Verification

- **Differential tests** compare contents, not row order. `rowid` is the default ordering and pagination cursor for State DB listings, and restored rows are re-inserted at the end of their table, so they move to the front of a `DESC` listing where the full rebuild used to re-canonicalize that order. Contents are identical; only the relative order of reorg-touched objects differs. Noted in the release notes.
- **Differential tests** roll a fixture back to six points — from a single active block up to essentially its whole history — and assert, table by table, that the result is identical to a from-scratch rebuild against the same rolled-back ledger, *and* that a rollback followed by the watcher's forward replay reproduces the State DB exactly.
- Every optional pass in the rollback (the counters, the `assets_info` re-derivation, the `fairminters` aggregates, the block bound on the ledger lookups) was checked by mutation: removing it makes those tests fail. One gap was found that way — the `fairminters` aggregates were not covered — and a case was added for it.
- A test asserts the per-object ledger lookup resolves to an index `SEARCH`, never a `SCAN`: a full scan *per reverted object* would be far worse than the rebuild it replaces.
- 1642 unit tests and 19 functional tests pass; `ruff check` and `ruff format` clean. Four of those cover the fallbacks directly: the no-op target, a mid-rollback failure degrading to the full rebuild (and leaving no rows behind), an uninspectable State DB, and the `PRAGMA foreign_keys` guard sitting outside the transaction — it is a documented no-op inside one, which is where it used to be.

The regtest integration suite has not been run against a real bitcoind on this branch yet, and the incremental path has not been exercised against a mainnet-sized State DB.

## Upgrading

This needs a **one-time State DB refresh**, applied automatically on first start via `UPGRADE_ACTIONS`. It takes roughly as long as one of the old reorg rebuilds and happens once, at a moment operators control, rather than unpredictably at the next reorg.

Two things worth a second opinion:

- The `UPGRADE_ACTIONS` entry is keyed on **`11.4.0`** and `check_database_version` matches `VERSION_STRING` exactly, so it must track the final release number. The consequence of getting it wrong is mild rather than silent breakage: a State DB without the marker takes the old full-rebuild route on its first reorg, which sets the marker. The refresh buys the timing, not the correctness.
- Operators must point Kubernetes probes at the dedicated health listener (port `4002`, `/healthz/live` and `/healthz/ready`) **before** upgrading — the follow-up from v11.3.0 / Infrastructure#252. A liveness probe still on the API port would get a connection refusal for the whole refresh and kill the pod.

