### PR TITLE
Keep API available during State DB reorg rebuilds

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/apiserver.py
+++ b/counterparty-core/counterpartycore/lib/api/apiserver.py
@@ -57,6 +57,18 @@ def verify_password(username, password):
 
 
 def is_server_ready():
+    # A staged State DB rebuild deliberately serves the last internally
+    # consistent snapshot until the replacement is complete. Keep the
+    # singleton routable during that degraded-but-readable period.
+    if CurrentState().state_db_rebuilding():
+        return (
+            not CurrentState().state_db_rebuild_cache_cold()
+            and not config.DISABLE_API_CACHE
+            and config.API_PASSWORD is None
+            and CurrentState().state_db_rebuild_age()
+            <= config.DEFAULT_STATE_DB_REBUILD_MAX_READY_SECONDS
+        )
+
     backend_height = CurrentState().current_backend_height()
     block_index = CurrentState().current_block_index()
 
@@ -109,6 +121,24 @@ def is_cachable(rule, route=None, result=None):
     if request.path == "/v2/addresses/mempool":
         return False
     if "show_unconfirmed=true" in request.url:
+        return False
+    return True
+
+
+def can_serve_stale_during_state_db_rebuild(rule, route):
+    """Whether a request may use a response cached before rebuilding."""
+    if rule in {"/v2/healthz", "/healthz"}:
+        return True
+    if request.method != "GET" or config.API_PASSWORD is not None:
+        return False
+    path = request.path.lower()
+    if any(fragment in path for fragment in ("/compose/", "/mempool")):
+        return False
+    if request.args.get("show_unconfirmed", "false").lower() in {"true", "1"}:
+        return False
+    if route is not None and route["category"] in {"bitcoin", "compose", "mempool", "v1"}:
+        return False
+    if route is not None and route["function"].__module__.endswith(".compose"):
         return False
     return True
 
@@ -198,7 +228,13 @@ def return_result(
     response.headers["X-COUNTERPARTY-READY"] = is_server_ready()
     response.headers["X-COUNTERPARTY-VERSION"] = config.VERSION_STRING
     response.headers["X-BITCOIN-HEIGHT"] = CurrentState().current_backend_height()
-    response.headers["X-LEDGER-STATE"] = CurrentState().ledger_state()
+    rebuilding = CurrentState().state_db_rebuilding()
+    response.headers["X-LEDGER-STATE"] = (
+        "State DB Rebuilding" if rebuilding else CurrentState().ledger_state()
+    )
+    if rebuilding:
+        response.headers["X-COUNTERPARTY-STALE"] = "true"
+        response.headers["X-STATE-DB-REBUILD-AGE"] = str(int(CurrentState().state_db_rebuild_age()))
     response.headers["Content-Type"] = "application/json"
     set_cache_control_headers(response, http_code, result)
     set_cors_headers(response)
@@ -354,8 +390,12 @@ def cache_response(uncached, response):
 
 def execute_api_function(rule, route, function_args):
     # cache everything for one block
-    with StateDBConnectionPool().connection() as state_db:
-        current_block_index = apiwatcher.get_last_block_parsed(state_db)
+    rebuilding = CurrentState().state_db_rebuilding()
+    if rebuilding:
+        current_block_index = CurrentState().current_block_index()
+    else:
+        with StateDBConnectionPool().connection() as state_db:
+            current_block_index = apiwatcher.get_last_block_parsed(state_db)
     cache_key = f"{current_block_index}:{request.url}"
     # except for blocks
     if request.path.startswith("/v2/blocks/") and not request.path.startswith("/v2/blocks/last"):
@@ -367,6 +407,11 @@ def execute_api_function(rule, route, function_args):
             sentry_get_span.set_data("cache.hit", True)
             return BLOCK_CACHE[cache_key]  # already-enriched CachedResponse
         sentry_get_span.set_data("cache.hit", False)
+
+    if rebuilding and rule not in {"/v2/healthz", "/healthz"}:
+        raise exceptions.StateDBRebuildUnavailable(
+            "State DB is rebuilding and no safe pre-reorg cached response exists"
+        )
 
     needed_db = function_needs_db(route["function"])
     if needed_db == "ledger_db":
@@ -447,11 +492,28 @@ def handle_route(**kwargs):
             )
 
         if rule == "/v2/":
+            if CurrentState().state_db_rebuilding():
+                return return_result(
+                    503,
+                    error="State DB is rebuilding; API metadata requires fresh state",
+                    start_time=start_time,
+                    query_args=query_args,
+                )
             return return_result(
                 200, result=api_root(), start_time=start_time, query_args=query_args
             )
 
         route = ROUTES.get(rule)
+
+        if CurrentState().state_db_rebuilding() and not can_serve_stale_during_state_db_rebuild(
+            rule, route
+        ):
+            return return_result(
+                503,
+                error="State DB is rebuilding; this request requires fresh state",
+                start_time=start_time,
+                query_args=query_args,
+            )
 
         # parse args
         try:
@@ -464,6 +526,8 @@ def handle_route(**kwargs):
         # call the function
         try:
             result = execute_api_function(rule, route, function_args)
+        except exceptions.StateDBRebuildUnavailable as e:
+            return return_result(503, error=str(e), start_time=start_time, query_args=query_args)
         except exceptions.BitcoindRPCError as e:
             # The Bitcoin backend is unavailable or degraded. This is transient
             # and not the client's fault, so return a retryable 503 rather than a
@@ -674,7 +738,17 @@ class ConnectionPoolMonitor(threading.Thread):
 
 
 def run_apiserver(
-    args, server_ready_value, stop_event, shared_backend_height, parent_pid, log_stream
+    args,
+    server_ready_value,
+    stop_event,
+    shared_backend_height,
+    parent_pid,
+    log_stream,
+    state_db_rebuild_ready_event=None,
+    state_db_rebuilding_value=None,
+    state_db_rebuild_started_at_value=None,
+    state_db_rebuild_cache_cold_value=None,
+    api_child_fatal_event=None,
 ):
     logger.info("Starting API Server process...")
 
@@ -696,6 +770,11 @@ def run_apiserver(
         # Initialize Sentry, logging, config, etc.
         sentry.init()
         initialise_log_and_config(argparse.Namespace(**args), api=True, log_stream=log_stream)
+        CurrentState().set_state_db_rebuild_shared_values(
+            state_db_rebuilding_value,
+            state_db_rebuild_started_at_value,
+            state_db_rebuild_cache_cold_value,
+        )
 
         # Start memory profiler if enabled via --memory-profile flag
         if getattr(config, "MEMORY_PROFILE", False):
@@ -708,6 +787,9 @@ def run_apiserver(
         logger.info("Starting Connection Pool Monitor thread...")
         pool_monitor = ConnectionPoolMonitor(stop_event, interval_seconds=60)
         pool_monitor.start()
+
+        if not args["rebuild_state_db"] and not args["refresh_state_db"]:
+            dbbuilder.activate_staged_state_db()
 
         if args["rebuild_state_db"]:
             dbbuilder.build_state_db()
@@ -726,7 +808,11 @@ def run_apiserver(
         check_database_version(state_db)
 
         watcher_started_at = time.monotonic()
-        watcher = apiwatcher.APIWatcher(state_db)
+        watcher = apiwatcher.APIWatcher(
+            state_db,
+            state_db_rebuild_ready_event,
+            fatal_event=api_child_fatal_event,
+        )
         logger.info("API Watcher initialized in %.2fs.", time.monotonic() - watcher_started_at)
         watcher.start()
 
@@ -826,25 +912,50 @@ class ParentProcessChecker(threading.Thread):
 
 
 class APIServer:
-    def __init__(self, stop_event, shared_backend_height):
+    def __init__(self, stop_event, shared_backend_height, state_db_rebuild_ready_event=None):
         self.process = None
         self.server_ready_value = Value("I", 0)
+        # ``stop_event`` is the lifetime of the whole Counterparty server.
+        # Each API child gets a separate event so a coordinated child restart
+        # can drain the old process without permanently stopping its successor.
         self.stop_event = stop_event
+        self.child_stop_event = None
         self.shared_backend_height = shared_backend_height
+        self.state_db_rebuild_ready_event = state_db_rebuild_ready_event or multiprocessing.Event()
+        # The parent owns rebuild state so it survives both an unexpected API
+        # child crash and the deliberate child restart used for activation.
+        # Gunicorn workers inherit these same synchronized values.
+        self.state_db_rebuilding_value = Value("b", 0)
+        self.state_db_rebuild_started_at_value = Value("d", 0.0)
+        self.state_db_rebuild_cache_cold_value = Value("b", 0)
+        self.api_child_fatal_event = multiprocessing.Event()
+        self.process_lock = threading.RLock()
+        self.rebuild_monitor = None
+        self.restart_args = None
+        self.restart_log_stream = None
 
-    def start(self, args, log_stream):
+    def _start_process(self, args, log_stream):
         if self.process is not None:
             raise exceptions.APIError("API Server is already running")
+        if self.state_db_rebuilding_value.value:
+            self.state_db_rebuild_cache_cold_value.value = True
+        self.api_child_fatal_event.clear()
+        self.child_stop_event = multiprocessing.Event()
         self.process = Process(
             name="API",
             target=run_apiserver,
             args=(
                 vars(args),
                 self.server_ready_value,
-                self.stop_event,
+                self.child_stop_event,
                 self.shared_backend_height,
                 os.getpid(),
                 log_stream,
+                self.state_db_rebuild_ready_event,
+                self.state_db_rebuilding_value,
+                self.state_db_rebuild_started_at_value,
+                self.state_db_rebuild_cache_cold_value,
+                self.api_child_fatal_event,
             ),
         )
         try:
@@ -855,13 +966,85 @@ class APIServer:
             raise e
         return self.process
 
+    def start(self, args, log_stream):
+        with self.process_lock:
+            return self._start_process(args, log_stream)
+
+    def start_rebuild_monitor(self, args, log_stream):
+        if self.rebuild_monitor is not None:
+            return
+        self.restart_args = args
+        self.restart_log_stream = log_stream
+        self.rebuild_monitor = threading.Thread(
+            target=self._monitor_rebuilt_state_db,
+            name="StateDBRebuildMonitor",
+            daemon=True,
+        )
+        self.rebuild_monitor.start()
+
+    def _monitor_rebuilt_state_db(self):
+        while not self.stop_event.is_set():
+            if not self.state_db_rebuild_ready_event.wait(timeout=1):
+                with self.process_lock:
+                    child_died = self.process is not None and not self.process.is_alive()
+                child_fatal = self.api_child_fatal_event.is_set()
+                if (child_died or child_fatal) and not self.stop_event.is_set():
+                    reason = "critical watcher failure" if child_fatal else "unexpected exit"
+                    logger.error("API child reported %s; restarting it.", reason)
+                    try:
+                        self.restart(activating_rebuild=False)
+                    except Exception:  # pylint: disable=broad-except
+                        logger.exception("Could not restart unexpected API child failure.")
+                        os.kill(os.getpid(), signal.SIGTERM)
+                        return
+                continue
+            self.state_db_rebuild_ready_event.clear()
+            if self.stop_event.is_set():
+                return
+            try:
+                self.restart(activating_rebuild=True)
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    "Could not restart API child to activate rebuilt State DB; "
+                    "requesting full process restart."
+                )
+                os.kill(os.getpid(), signal.SIGTERM)
+                return
+
+    def restart(self, activating_rebuild=False):
+        if activating_rebuild:
+            logger.warning("Restarting API child to activate rebuilt State DB...")
+        else:
+            logger.warning("Restarting API child after unexpected exit...")
+        with self.process_lock:
+            self._stop_process()
+            if self.stop_event.is_set():
+                return
+            self.process = None
+            self.server_ready_value.value = 0
+            self._start_process(self.restart_args, self.restart_log_stream)
+
+        deadline = time.monotonic() + 300
+        while not self.is_ready():
+            if self.stop_event.is_set():
+                return
+            if self.process is None or not self.process.is_alive() or time.monotonic() >= deadline:
+                raise exceptions.APIError("Restarted API child did not become ready")
+            time.sleep(0.1)
+        if activating_rebuild:
+            logger.warning("API child restarted successfully with rebuilt State DB.")
+        else:
+            logger.warning("API child restarted successfully after unexpected exit.")
+
     def is_ready(self):
         return self.server_ready_value.value == 1
 
-    def stop(self):
+    def _stop_process(self):
         logger.info("Stopping API Server process...")
-        if self.process.is_alive():
+        if self.process is not None and self.process.is_alive():
             started_at = time.monotonic()
+            if self.child_stop_event is not None:
+                self.child_stop_event.set()
             try:
                 os.kill(self.process.pid, signal.SIGTERM)
             except ProcessLookupError:
@@ -880,6 +1063,15 @@ class APIServer:
                 logger.info("API Server process stopped in %.2fs.", elapsed)
         else:
             logger.info("API Server process was already stopped.")
+
+    def stop(self):
+        with self.process_lock:
+            self._stop_process()
+        if (
+            self.rebuild_monitor is not None
+            and self.rebuild_monitor is not threading.current_thread()
+        ):
+            self.rebuild_monitor.join(timeout=2)
 
     def has_stopped(self):
         return self.server_ready_value.value == 2

--- a/counterparty-core/counterpartycore/lib/api/apiwatcher.py
+++ b/counterparty-core/counterpartycore/lib/api/apiwatcher.py
@@ -7,11 +7,21 @@ import apsw
 
 from counterpartycore.lib import config, exceptions
 from counterpartycore.lib.api import dbbuilder
+from counterpartycore.lib.ledger.currentstate import CurrentState
 from counterpartycore.lib.parser import utxosinfo
 from counterpartycore.lib.utils import database, hashcodec
 from counterpartycore.lib.utils.helpers import format_duration
 
 logger = logging.getLogger(config.LOGGER_NAME)
+
+
+class AnyStopEvent:
+    def __init__(self, *events):
+        self.events = events
+
+    def is_set(self):
+        return any(event.is_set() for event in self.events)
+
 
 UPDATE_EVENTS_ID_FIELDS = {
     "BLOCK_PARSED": ["block_index"],
@@ -720,15 +730,37 @@ def parse_event(state_db, event, ledger_db=None):
         logger.event(f"Event parsed: {event['message_index']} {event['event']}")
 
 
+def get_ledger_data_version(ledger_db):
+    return ledger_db.execute("PRAGMA data_version").fetchone()["data_version"]
+
+
 def catch_up(ledger_db, state_db, watcher=None):
-    check_reorg(ledger_db, state_db)
+    rebuild_staged = check_reorg(
+        ledger_db,
+        state_db,
+        watcher.stage_state_db_rebuild if watcher is not None else None,
+    )
+    if rebuild_staged:
+        return
     event_to_parse_count = get_event_to_parse_count(ledger_db, state_db)
     if event_to_parse_count > 0:
         logger.debug("%s events to catch up...", event_to_parse_count)
         start_time = time.time()
         event_parsed = 0
+        lineage_checked_at = None
         next_event = get_next_event_to_parse(ledger_db, state_db)
         while next_event and (watcher is None or not watcher.stop_event.is_set()):
+            ledger_data_version = get_ledger_data_version(ledger_db)
+            lineage_at = (next_event["block_index"], ledger_data_version)
+            if watcher is not None and lineage_at != lineage_checked_at:
+                rebuild_staged = check_reorg(
+                    ledger_db,
+                    state_db,
+                    watcher.stage_state_db_rebuild,
+                )
+                if rebuild_staged:
+                    return
+                lineage_checked_at = lineage_at
             parse_event(state_db, next_event, ledger_db=ledger_db)
             event_parsed += 1
             if event_parsed % 50000 == 0:
@@ -750,7 +782,8 @@ def catch_up(ledger_db, state_db, watcher=None):
 def search_matching_event(ledger_db, state_db):
     state_db_cursor = state_db.cursor()
     state_db_cursor.execute(
-        "SELECT * FROM parsed_events WHERE event = 'BLOCK_PARSED' ORDER BY event_index DESC LIMIT -1 OFFSET 1"
+        "SELECT * FROM parsed_events INDEXED BY parsed_events_event_index_idx "
+        "WHERE event = 'BLOCK_PARSED' ORDER BY event_index DESC"
     )
     matching_event = None
     for parsed_event in state_db_cursor:
@@ -768,10 +801,11 @@ def search_matching_event(ledger_db, state_db):
     return matching_event
 
 
-def check_reorg(ledger_db, state_db):
+def check_reorg(ledger_db, state_db, stage_rebuild=None):
     last_event_parsed = fetch_one(
         state_db,
-        "SELECT * FROM parsed_events WHERE event = 'BLOCK_PARSED' ORDER BY event_index DESC LIMIT 1 OFFSET 1",
+        "SELECT * FROM parsed_events INDEXED BY parsed_events_event_index_idx "
+        "WHERE event = 'BLOCK_PARSED' ORDER BY event_index DESC LIMIT 1",
     )
     if last_event_parsed is None:
         return
@@ -787,7 +821,30 @@ def check_reorg(ledger_db, state_db):
             target_block_index = matching_event["block_index"] + 1
         logger.warning("Blockchain reorganization detected at Block %s", target_block_index)
         logger.info("Rolling back to block: %s", target_block_index)
-        dbbuilder.rollback_state_db(state_db, block_index=target_block_index)
+        if stage_rebuild is not None:
+            try:
+                stage_rebuild()
+                return True
+            except exceptions.StateDBRebuildCancelled:
+                dbbuilder.discard_staged_state_db()
+                logger.info(
+                    "Staged State DB rebuild cancelled during shutdown; preserving the "
+                    "parent-owned gate across any child restart."
+                )
+                return True
+            except Exception:  # pylint: disable=broad-except
+                dbbuilder.discard_staged_state_db()
+                logger.exception(
+                    "Staged State DB rebuild failed; falling back to in-place rollback."
+                )
+        try:
+            dbbuilder.rollback_state_db(state_db, block_index=target_block_index)
+        except Exception:
+            logger.exception("In-place State DB rollback failed while API remained gated.")
+            raise
+        else:
+            CurrentState().set_state_db_rebuilding(False)
+    return False
 
 
 def parse_next_event(ledger_db, state_db):
@@ -800,29 +857,75 @@ def parse_next_event(ledger_db, state_db):
 
 
 class APIWatcher(threading.Thread):
-    def __init__(self, state_db):
+    def __init__(self, state_db, state_db_rebuild_ready_event=None, fatal_event=None):
         threading.Thread.__init__(self, name="Watcher")
         logger.debug("Initializing API Watcher...")
         self.state_db = None
         self.ledger_db = None
         self.current_state_thread = None
+        self.state_db_rebuild_ready_event = state_db_rebuild_ready_event
+        self.fatal_event = fatal_event
         self.stop_event = threading.Event()  # Add stop event
+        self.rebuild_cancel_event = threading.Event()
         self.state_db = state_db
         self.ledger_db = database.get_db_connection(
             config.DATABASE, read_only=True, check_wal=False
         )
         update_last_parsed_events_cache(self.state_db, event=None)
 
+    def stage_state_db_rebuild(self):
+        if self.state_db_rebuild_ready_event is None:
+            raise exceptions.APIWatcherError("No State DB rebuild coordinator is configured")
+        CurrentState().set_state_db_rebuilding(True)
+        self.rebuild_cancel_event.clear()
+        rebuild_deadline = threading.Timer(
+            config.DEFAULT_STATE_DB_REBUILD_MAX_READY_SECONDS,
+            self._cancel_timed_out_rebuild,
+        )
+        rebuild_deadline.daemon = True
+        rebuild_deadline.start()
+        try:
+            dbbuilder.stage_state_db_rebuild(
+                stop_event=AnyStopEvent(self.stop_event, self.rebuild_cancel_event)
+            )
+        except Exception as error:
+            if self.stop_event.is_set():
+                raise exceptions.StateDBRebuildCancelled() from error
+            if self.rebuild_cancel_event.is_set():
+                raise exceptions.DatabaseError("State DB rebuild exceeded its deadline") from error
+            raise
+        finally:
+            rebuild_deadline.cancel()
+        self.state_db_rebuild_ready_event.set()
+        self.stop_event.set()
+
+    def _cancel_timed_out_rebuild(self):
+        logger.error("State DB rebuild exceeded its deadline; restarting the API child.")
+        self.rebuild_cancel_event.set()
+        if self.fatal_event is not None:
+            self.fatal_event.set()
+
     def run(self):
         logger.info("Starting API Watcher thread...")
         try:
             catch_up(self.ledger_db, self.state_db, self)
             if not self.stop_event.is_set():
+                # A parent-owned rebuild gate survives the activation restart.
+                # Clear it only after the replacement has been checked against
+                # the live Ledger DB and caught up, never merely because a new
+                # API child started.
+                CurrentState().set_state_db_rebuilding(False)
                 self.follow()
         except apsw.InterruptError:
             if not self.stop_event.is_set():
-                raise
+                logger.exception("API Watcher was interrupted unexpectedly.")
+                if self.fatal_event is not None:
+                    self.fatal_event.set()
             logger.debug("API Watcher query interrupted during shutdown.")
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("API Watcher failed; requesting API child restart.")
+            if self.fatal_event is not None:
+                self.fatal_event.set()
         finally:
             if self.state_db is not None:
                 self.state_db.close()
@@ -832,15 +935,27 @@ class APIWatcher(threading.Thread):
                 self.current_state_thread.stop()
 
     def follow(self):
-        no_check_reorg_since = 0
+        lineage_checked_at = None
         while not self.stop_event.is_set():
-            try:
-                parse_next_event(self.ledger_db, self.state_db)
-            except exceptions.NoEventToParse:
-                if time.time() - no_check_reorg_since > 5:
-                    check_reorg(self.ledger_db, self.state_db)
-                    no_check_reorg_since = time.time()
+            next_event = get_next_event_to_parse(self.ledger_db, self.state_db)
+            if next_event is None:
+                rebuild_staged = check_reorg(
+                    self.ledger_db, self.state_db, self.stage_state_db_rebuild
+                )
+                if rebuild_staged:
+                    break
                 self.stop_event.wait(timeout=0.1)
+                continue
+            ledger_data_version = get_ledger_data_version(self.ledger_db)
+            lineage_at = (next_event["block_index"], ledger_data_version)
+            if lineage_at != lineage_checked_at:
+                rebuild_staged = check_reorg(
+                    self.ledger_db, self.state_db, self.stage_state_db_rebuild
+                )
+                if rebuild_staged:
+                    break
+                lineage_checked_at = lineage_at
+            parse_event(self.state_db, next_event, ledger_db=self.ledger_db)
             if self.stop_event.is_set():
                 break
 

--- a/counterparty-core/counterpartycore/lib/api/dbbuilder.py
+++ b/counterparty-core/counterpartycore/lib/api/dbbuilder.py
@@ -1,18 +1,34 @@
+import hashlib
 import importlib.util
+import json
 import logging
 import os
+import shutil
 import sys
 import time
 
 from yoyo.migrations import topological_sort
 
-from counterpartycore.lib import config
+from counterpartycore.lib import config, exceptions
 from counterpartycore.lib.cli import log
 from counterpartycore.lib.utils import database
 
 logger = logging.getLogger(config.LOGGER_NAME)
 
+STAGED_STATE_DB_SUFFIX = ".rebuild"
+STAGED_STATE_DB_READY_SUFFIX = ".ready"
+PREVIOUS_STATE_DB_SUFFIX = ".previous"
+LAST_LEDGER_BLOCK_EVENT_SQL = (
+    "SELECT message_index, event_hash, block_index FROM messages NOT INDEXED "
+    "WHERE event = 'BLOCK_PARSED' ORDER BY message_index DESC LIMIT 1"
+)
+
 MIGRATIONS_AFTER_ROLLBACK = [
+    # Rebuild address_events from the same Ledger tip as parsed_events. Leaving
+    # 0001 out causes 0012 to transform only the ancestor rows that survived
+    # rollback while 0002 advances parsed_events to the new tip, permanently
+    # preventing catch-up from restoring the missing address rows.
+    "0001.create_and_populate_address_events",
     # 0002 / 0003 are included so that pre-existing state DBs built before the
     # compact-hash storage migration get rebuilt with the ``hex_lower(...)``
     # projection on the next rollback:
@@ -42,6 +58,509 @@ ROLLBACKABLE_TABLES = [
     "address_events",
     "parsed_events",
 ]
+
+
+def _database_files(db_file):
+    return [db_file, f"{db_file}-wal", f"{db_file}-shm"]
+
+
+def _remove_database_files(db_file):
+    for path in [*_database_files(db_file), f"{db_file}-journal"]:
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+
+
+def staged_state_db_path():
+    return f"{config.STATE_DATABASE}{STAGED_STATE_DB_SUFFIX}"
+
+
+def staged_state_db_ready_path():
+    return f"{staged_state_db_path()}{STAGED_STATE_DB_READY_SUFFIX}"
+
+
+def previous_state_db_path():
+    return f"{config.STATE_DATABASE}{PREVIOUS_STATE_DB_SUFFIX}"
+
+
+def staged_ledger_snapshot_path():
+    return f"{staged_state_db_path()}.ledger-snapshot"
+
+
+def discard_staged_state_db():
+    _remove_database_files(staged_state_db_path())
+    _remove_database_files(staged_ledger_snapshot_path())
+    for path in (staged_state_db_ready_path(), f"{staged_state_db_ready_path()}.tmp"):
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+
+
+def _check_cancelled(stop_event):
+    if stop_event is not None and stop_event.is_set():
+        raise exceptions.StateDBRebuildCancelled("State DB rebuild cancelled during shutdown")
+
+
+def _fsync_file(path):
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _fsync_directory(path):
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _migration_digest():
+    digest = hashlib.sha256()
+    for name in sorted(os.listdir(config.STATE_DB_MIGRATIONS_DIR)):
+        if not name.endswith((".py", ".sql")):
+            continue
+        path = os.path.join(config.STATE_DB_MIGRATIONS_DIR, name)
+        digest.update(name.encode())
+        with open(path, "rb") as migration_file:
+            digest.update(migration_file.read())
+    return digest.hexdigest()
+
+
+def _ensure_staged_rebuild_space():
+    data_dir = os.path.dirname(config.STATE_DATABASE) or "."
+    ledger_size = os.path.getsize(config.DATABASE)
+    state_size = os.path.getsize(config.STATE_DATABASE)
+    safety_margin = 4 * 1024**3
+    required = ledger_size + state_size + safety_margin
+    free = shutil.disk_usage(data_dir).free
+    previous_size = sum(
+        os.path.getsize(path)
+        for path in [
+            *_database_files(previous_state_db_path()),
+            f"{previous_state_db_path()}-journal",
+        ]
+        if os.path.exists(path)
+    )
+    if free + previous_size < required:
+        raise exceptions.DatabaseError(
+            "Insufficient free space for nonblocking State DB rebuild: "
+            f"need {required} bytes, have {free} bytes free and "
+            f"{previous_size} bytes reclaimable"
+        )
+    return free < required
+
+
+def _backup_ledger_database(destination_path, stop_event=None):
+    """Create a transactionally consistent ledger snapshot for migrations."""
+    _remove_database_files(destination_path)
+    source = database.get_db_connection(config.DATABASE, read_only=True, check_wal=False)
+    destination = database.get_db_connection(destination_path, read_only=False, check_wal=False)
+    try:
+        source.setbusytimeout(60_000)
+        destination.setbusytimeout(60_000)
+        # The destination is private and immutable after this copy. Do not
+        # inherit APSW's WAL best-practice mode: a full-database backup in one
+        # transaction otherwise accumulates an enormous WAL (observed to
+        # plateau around 8 GiB) before any checkpoint is possible.
+        destination.execute("PRAGMA journal_mode=DELETE").fetchone()
+        # Pin one WAL snapshot for the entire copy. Without an explicit source
+        # read transaction, SQLite can restart backup progress whenever the
+        # live parser changes a source page (mempool traffic can otherwise
+        # starve a small-step backup indefinitely).
+        source.execute("BEGIN")
+        source.execute("SELECT rootpage FROM sqlite_master LIMIT 1").fetchone()
+        last_progress = -10
+        with destination.backup("main", source, "main") as backup:
+            while not backup.done:
+                _check_cancelled(stop_event)
+                # Keep individual copy calls small: APSW's backup step holds
+                # the Python runtime while copying pages. Large 32 MiB steps
+                # made even the in-memory dedicated health server pause for
+                # several seconds on production-sized databases.
+                backup.step(256)
+                time.sleep(0)
+                if backup.pagecount:
+                    progress = int(100 * (backup.pagecount - backup.remaining) / backup.pagecount)
+                    if progress >= last_progress + 10:
+                        logger.info("Ledger snapshot copy %d%% complete.", progress)
+                        last_progress = progress
+    finally:
+        try:
+            source.execute("ROLLBACK")
+        except Exception as error:  # pylint: disable=broad-except
+            logger.debug("Could not close Ledger DB snapshot transaction: %s", error)
+        destination.close()
+        source.close()
+
+
+def _checkpoint_database(db_file):
+    connection = database.get_db_connection(db_file, read_only=False, check_wal=False)
+    try:
+        checkpoint = connection.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        if checkpoint is not None:
+            values = list(checkpoint.values()) if isinstance(checkpoint, dict) else checkpoint
+            if values[0] != 0:
+                raise exceptions.DatabaseError(
+                    f"Could not checkpoint State DB before activation: {checkpoint!r}"
+                )
+    finally:
+        connection.close()
+
+
+def _replacement_manifest(staged_db, ledger_snapshot, stop_event=None):
+    ledger_db = database.get_db_connection(ledger_snapshot, read_only=True, check_wal=False)
+    state_db = None
+    try:
+        state_db = database.get_db_connection(staged_db, read_only=True, check_wal=False)
+        if stop_event is not None:
+
+            def progress_handler():
+                return 1 if stop_event.is_set() else 0
+
+            ledger_db.set_progress_handler(progress_handler, 10_000)
+            state_db.set_progress_handler(progress_handler, 10_000)
+        _check_cancelled(stop_event)
+        ledger_last = ledger_db.execute(
+            "SELECT message_index, event_hash, block_index FROM messages "
+            "ORDER BY message_index DESC LIMIT 1"
+        ).fetchone()
+        state_last = state_db.execute(
+            "SELECT event_index, event_hash, block_index FROM parsed_events "
+            "ORDER BY event_index DESC LIMIT 1"
+        ).fetchone()
+        ledger_block = ledger_db.execute(LAST_LEDGER_BLOCK_EVENT_SQL).fetchone()
+        state_block = state_db.execute(
+            "SELECT event_index, event_hash, block_index FROM parsed_events "
+            "INDEXED BY parsed_events_event_index_idx WHERE event = 'BLOCK_PARSED' "
+            "ORDER BY event_index DESC LIMIT 1"
+        ).fetchone()
+        ledger_count = ledger_db.execute("SELECT COUNT(*) AS count FROM messages").fetchone()[
+            "count"
+        ]
+        state_count = state_db.execute("SELECT COUNT(*) AS count FROM parsed_events").fetchone()[
+            "count"
+        ]
+    finally:
+        if stop_event is not None and state_db is not None:
+            state_db.set_progress_handler(None, 0)
+            ledger_db.set_progress_handler(None, 0)
+        if state_db is not None:
+            state_db.close()
+        ledger_db.close()
+
+    if ledger_last is None or state_last is None or ledger_block is None or state_block is None:
+        raise exceptions.DatabaseError("Replacement State DB lineage rows are incomplete")
+    if (
+        state_last["event_index"] != ledger_last["message_index"]
+        or state_last["event_hash"] != ledger_last["event_hash"]
+        or state_last["block_index"] != ledger_last["block_index"]
+        or state_block["event_index"] != ledger_block["message_index"]
+        or state_block["event_hash"] != ledger_block["event_hash"]
+        or state_block["block_index"] != ledger_block["block_index"]
+        or state_count != ledger_count
+    ):
+        raise exceptions.DatabaseError("Replacement State DB does not match its Ledger snapshot")
+    return {
+        "source_event_index": ledger_last["message_index"],
+        "source_event_hash": ledger_last["event_hash"],
+        "source_event_block_index": ledger_last["block_index"],
+        "source_block_event_index": ledger_block["message_index"],
+        "source_block_event_hash": ledger_block["event_hash"],
+        "source_block_index": ledger_block["block_index"],
+        "source_message_count": ledger_count,
+        "migration_digest": _migration_digest(),
+        "builder_commit": config.CURRENT_COMMIT,
+        "version": config.VERSION_STRING,
+        "staged_size": os.path.getsize(staged_db),
+        "created_at": time.time(),
+    }
+
+
+def _write_ready_manifest(ready_path, manifest):
+    marker_tmp = f"{ready_path}.tmp"
+    try:
+        os.unlink(marker_tmp)
+    except FileNotFoundError:
+        pass
+    marker_fd = os.open(marker_tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        os.write(marker_fd, json.dumps(manifest, sort_keys=True).encode() + b"\n")
+        os.fsync(marker_fd)
+    finally:
+        os.close(marker_fd)
+    os.replace(marker_tmp, ready_path)
+    _fsync_directory(os.path.dirname(ready_path) or ".")
+
+
+def _read_ready_manifest(ready_path):
+    try:
+        with open(ready_path, encoding="utf-8") as marker_file:
+            manifest = json.load(marker_file)
+    except (OSError, ValueError, TypeError) as error:
+        raise exceptions.DatabaseError(f"Invalid State DB rebuild manifest: {error}") from error
+    required = {
+        "source_event_index",
+        "source_event_hash",
+        "source_event_block_index",
+        "source_block_event_index",
+        "source_block_event_hash",
+        "source_block_index",
+        "source_message_count",
+        "migration_digest",
+        "builder_commit",
+        "version",
+        "staged_size",
+    }
+    if not isinstance(manifest, dict) or not required <= manifest.keys():
+        raise exceptions.DatabaseError("State DB rebuild manifest is incomplete")
+    return manifest
+
+
+def _manifest_matches_live_ledger(manifest):
+    ledger_db = database.get_db_connection(config.DATABASE, read_only=True, check_wal=False)
+    try:
+        event = ledger_db.execute(
+            "SELECT event_hash, block_index FROM messages WHERE message_index = ?",
+            (manifest["source_event_index"],),
+        ).fetchone()
+        block_event = ledger_db.execute(
+            "SELECT event_hash, block_index FROM messages WHERE message_index = ?",
+            (manifest["source_block_event_index"],),
+        ).fetchone()
+    finally:
+        ledger_db.close()
+    return (
+        event is not None
+        and event["event_hash"] == manifest["source_event_hash"]
+        and event["block_index"] == manifest["source_event_block_index"]
+        and block_event is not None
+        and block_event["event_hash"] == manifest["source_block_event_hash"]
+        and block_event["block_index"] == manifest["source_block_index"]
+    )
+
+
+def _state_db_matches_manifest(db_file, manifest, check_integrity=False):
+    if os.path.getsize(db_file) != manifest["staged_size"]:
+        return False
+    state_db = database.get_db_connection(db_file, read_only=True, check_wal=False)
+    try:
+        if check_integrity:
+            check_result = state_db.execute("PRAGMA quick_check(1)").fetchone()
+            check_value = (
+                next(iter(check_result.values()))
+                if isinstance(check_result, dict)
+                else check_result[0]
+            )
+            if check_value != "ok":
+                return False
+        state_last = state_db.execute(
+            "SELECT event_index, event_hash, block_index FROM parsed_events "
+            "INDEXED BY parsed_events_event_index_idx ORDER BY event_index DESC LIMIT 1"
+        ).fetchone()
+        state_block = state_db.execute(
+            "SELECT event_index, event_hash, block_index FROM parsed_events "
+            "INDEXED BY parsed_events_event_index_idx WHERE event = 'BLOCK_PARSED' "
+            "ORDER BY event_index DESC LIMIT 1"
+        ).fetchone()
+        state_count = state_db.execute("SELECT COUNT(*) AS count FROM parsed_events").fetchone()[
+            "count"
+        ]
+    finally:
+        state_db.close()
+    return (
+        state_last is not None
+        and state_last["event_index"] == manifest["source_event_index"]
+        and state_last["event_hash"] == manifest["source_event_hash"]
+        and state_last["block_index"] == manifest["source_event_block_index"]
+        and state_block is not None
+        and state_block["event_index"] == manifest["source_block_event_index"]
+        and state_block["event_hash"] == manifest["source_block_event_hash"]
+        and state_block["block_index"] == manifest["source_block_index"]
+        and state_count == manifest["source_message_count"]
+    )
+
+
+def _manifest_is_current(manifest, state_db_path, check_integrity=False):
+    return (
+        manifest["version"] == config.VERSION_STRING
+        and manifest["builder_commit"] == config.CURRENT_COMMIT
+        and manifest["migration_digest"] == _migration_digest()
+        and _state_db_matches_manifest(
+            state_db_path,
+            manifest,
+            check_integrity=check_integrity,
+        )
+        and _manifest_matches_live_ledger(manifest)
+    )
+
+
+def stage_state_db_rebuild(stop_event=None):
+    """Build and verify a replacement State DB without touching the live one."""
+    staged_db = staged_state_db_path()
+    ready_path = staged_state_db_ready_path()
+    ledger_snapshot = staged_ledger_snapshot_path()
+    started_at = time.monotonic()
+
+    discard_staged_state_db()
+    reclaim_previous = _ensure_staged_rebuild_space()
+    _check_cancelled(stop_event)
+    if reclaim_previous:
+        # Release the one-generation recovery copy only when staging truly
+        # needs its bytes and only after preflight/cancellation checks pass.
+        _remove_database_files(previous_state_db_path())
+
+    logger.warning("Copying live Ledger DB to %s for a stable rebuild snapshot.", ledger_snapshot)
+    _backup_ledger_database(ledger_snapshot, stop_event=stop_event)
+    _check_cancelled(stop_event)
+
+    logger.warning("Building replacement State DB at %s; live API DB remains online.", staged_db)
+    previous_ledger_source = config.STATE_DB_LEDGER_SOURCE_DATABASE
+    config.STATE_DB_LEDGER_SOURCE_DATABASE = ledger_snapshot
+    try:
+        database.apply_outstanding_migration(
+            staged_db,
+            config.STATE_DB_MIGRATIONS_DIR,
+            stop_event=stop_event,
+        )
+    finally:
+        config.STATE_DB_LEDGER_SOURCE_DATABASE = previous_ledger_source
+
+    staged_connection = database.get_db_connection(staged_db, read_only=False, check_wal=False)
+    try:
+        if stop_event is not None:
+            staged_connection.set_progress_handler(
+                lambda: 1 if stop_event.is_set() else 0,
+                10_000,
+            )
+        check_result = staged_connection.execute("PRAGMA quick_check(1)").fetchone()
+        if check_result is None:
+            raise exceptions.DatabaseError("Replacement State DB quick_check returned no result")
+        check_value = (
+            next(iter(check_result.values())) if isinstance(check_result, dict) else check_result[0]
+        )
+        if check_value != "ok":
+            raise exceptions.DatabaseError(
+                f"Replacement State DB failed quick_check: {check_result!r}"
+            )
+    finally:
+        if stop_event is not None:
+            staged_connection.set_progress_handler(None, 0)
+        staged_connection.close()
+    _check_cancelled(stop_event)
+    _checkpoint_database(staged_db)
+    _fsync_file(staged_db)
+    manifest = _replacement_manifest(staged_db, ledger_snapshot, stop_event=stop_event)
+    _remove_database_files(ledger_snapshot)
+
+    # The marker is created only after the replacement DB is closed, checked,
+    # and checkpointed. An interrupted build therefore cannot be activated.
+    _write_ready_manifest(ready_path, manifest)
+    logger.warning(
+        "Replacement State DB ready for activation after %.2fs.",
+        time.monotonic() - started_at,
+    )
+
+
+def activate_staged_state_db():
+    """Atomically activate a verified staged DB during API-child startup.
+
+    The old database is retained as ``.previous``. If activation is
+    interrupted between the two atomic renames, the ready marker and staged
+    file remain and the next startup completes the operation.
+    """
+    staged_db = staged_state_db_path()
+    ready_path = staged_state_db_ready_path()
+    previous_db = previous_state_db_path()
+
+    if not os.path.exists(ready_path):
+        # A partial build has no marker and is never eligible for activation.
+        discard_staged_state_db()
+        return False
+
+    if not os.path.exists(staged_db):
+        # The staged file can disappear because activation completed, but it can
+        # also be lost or manually removed. Consume the durable marker only if
+        # the live DB is exactly the staged lineage described by its manifest.
+        if os.path.exists(config.STATE_DATABASE):
+            try:
+                manifest = _read_ready_manifest(ready_path)
+                if _manifest_is_current(
+                    manifest,
+                    config.STATE_DATABASE,
+                    check_integrity=True,
+                ):
+                    _remove_database_files(staged_db)
+                    os.unlink(ready_path)
+                    _fsync_directory(os.path.dirname(config.STATE_DATABASE) or ".")
+                    return True
+            except Exception as error:  # pylint: disable=broad-except
+                logger.error("Could not validate interrupted State DB activation: %s", error)
+        raise exceptions.DatabaseError(
+            "State DB activation marker exists, but the staged database is missing and the "
+            "live database does not match its manifest"
+        )
+
+    try:
+        manifest = _read_ready_manifest(ready_path)
+        valid_manifest = _manifest_is_current(manifest, staged_db)
+    except Exception as error:  # pylint: disable=broad-except
+        logger.error("Discarding staged State DB with invalid manifest: %s", error)
+        valid_manifest = False
+    if not valid_manifest:
+        logger.warning("Staged State DB lineage is stale or invalid; keeping live State DB.")
+        if not os.path.exists(config.STATE_DATABASE) and os.path.exists(previous_db):
+            os.replace(previous_db, config.STATE_DATABASE)
+            _fsync_directory(os.path.dirname(config.STATE_DATABASE) or ".")
+        discard_staged_state_db()
+        return False
+
+    live_moved = False
+    try:
+        if os.path.exists(config.STATE_DATABASE):
+            # The old API child is fully stopped before activation. Fold every
+            # committed WAL frame into the main file so the recovery copy is
+            # self-contained and a crash between renames cannot pair the new
+            # database with the old database's WAL.
+            _checkpoint_database(config.STATE_DATABASE)
+            _remove_database_files(previous_db)
+            os.replace(config.STATE_DATABASE, previous_db)
+            live_moved = True
+        # Complete sidecar cleanup even when resuming an activation that
+        # crashed immediately after moving the old main file.
+        for suffix in ("-wal", "-shm"):
+            live_sidecar = f"{config.STATE_DATABASE}{suffix}"
+            if os.path.exists(live_sidecar):
+                os.replace(live_sidecar, f"{previous_db}{suffix}")
+        _fsync_directory(os.path.dirname(config.STATE_DATABASE) or ".")
+        os.replace(staged_db, config.STATE_DATABASE)
+        # A successful checkpoint should leave no WAL/SHM, but move either one
+        # if SQLite retained it so no committed data can be separated.
+        for suffix in ("-wal", "-shm"):
+            staged_path = f"{staged_db}{suffix}"
+            if os.path.exists(staged_path):
+                os.replace(staged_path, f"{config.STATE_DATABASE}{suffix}")
+        _fsync_directory(os.path.dirname(config.STATE_DATABASE) or ".")
+        os.unlink(ready_path)
+        _fsync_directory(os.path.dirname(config.STATE_DATABASE) or ".")
+    except Exception:
+        if live_moved and not os.path.exists(config.STATE_DATABASE):
+            for previous_path, live_path in zip(
+                _database_files(previous_db),
+                _database_files(config.STATE_DATABASE),
+                strict=True,
+            ):
+                if os.path.exists(previous_path):
+                    os.replace(previous_path, live_path)
+            _fsync_directory(os.path.dirname(config.STATE_DATABASE) or ".")
+        raise
+
+    logger.warning("Activated rebuilt State DB; previous database retained at %s.", previous_db)
+    return True
 
 
 def filter_migrations(migrations, wanted_ids):

--- a/counterparty-core/counterpartycore/lib/api/healthz.py
+++ b/counterparty-core/counterpartycore/lib/api/healthz.py
@@ -93,6 +93,23 @@ def check_server_health(db, check_type: str = "light"):
     Health check route.
     :param check_type: Type of health check to perform. Options are 'light' and 'heavy' (e.g. light)
     """
+    if CurrentState().state_db_rebuilding():
+        if (
+            CurrentState().state_db_rebuild_cache_cold()
+            or config.DISABLE_API_CACHE
+            or config.API_PASSWORD is not None
+        ):
+            raise exceptions.StateDBRebuildUnavailable(
+                "State DB is rebuilding without a usable stale-response cache"
+            )
+        if (
+            CurrentState().state_db_rebuild_age()
+            > config.DEFAULT_STATE_DB_REBUILD_MAX_READY_SECONDS
+        ):
+            raise exceptions.StateDBRebuildUnavailable(
+                "State DB rebuild exceeded its maximum stale-serving age"
+            )
+        return {"status": "Degraded", "reason": "state_db_rebuilding"}
     if not healthz(db, check_type):
         return {"status": "Unhealthy"}
     return {"status": "Healthy"}

--- a/counterparty-core/counterpartycore/lib/api/healthz_server.py
+++ b/counterparty-core/counterpartycore/lib/api/healthz_server.py
@@ -111,6 +111,10 @@ class HealthSampler(threading.Thread):
         backend_height_provider=None,
         block_time_provider=None,
         api_only_provider=None,
+        state_db_rebuilding_provider=None,
+        state_db_rebuild_age_provider=None,
+        state_db_stale_cache_available_provider=None,
+        state_db_rebuild_max_ready_seconds=None,
     ):
         super().__init__(name="HealthSampler", daemon=True)
         self.dispatcher = dispatcher
@@ -152,6 +156,22 @@ class HealthSampler(threading.Thread):
         self._api_only_provider = api_only_provider or (
             lambda: bool(getattr(config, "API_ONLY", False))
         )
+        self._state_db_rebuilding_provider = (
+            state_db_rebuilding_provider or CurrentState().state_db_rebuilding
+        )
+        self._state_db_rebuild_age_provider = (
+            state_db_rebuild_age_provider or CurrentState().state_db_rebuild_age
+        )
+        self._state_db_stale_cache_available_provider = state_db_stale_cache_available_provider or (
+            lambda: not CurrentState().state_db_rebuild_cache_cold()
+            and not config.DISABLE_API_CACHE
+            and config.API_PASSWORD is None
+        )
+        self.state_db_rebuild_max_ready_seconds = (
+            state_db_rebuild_max_ready_seconds
+            if state_db_rebuild_max_ready_seconds is not None
+            else config.DEFAULT_STATE_DB_REBUILD_MAX_READY_SECONDS
+        )
 
         self.stop_event = threading.Event()
         self._snapshot = HealthSnapshot(
@@ -191,8 +211,8 @@ class HealthSampler(threading.Thread):
                         own_db = database.get_db_connection(
                             config.STATE_DATABASE, read_only=True, check_wal=False
                         )
-                        self._last_parsed_provider = (
-                            lambda db=own_db: apiwatcher.get_last_block_parsed(db)
+                        self._last_parsed_provider = lambda db=own_db: (
+                            apiwatcher.get_last_block_parsed(db)
                         )
                     except Exception as e:  # pylint: disable=broad-except
                         logger.debug("healthz: state DB not ready yet: %s", e)
@@ -227,7 +247,10 @@ class HealthSampler(threading.Thread):
         caught_up, lag, ledger_reason, backend_height, last_parsed = self._compute_caught_up(now)
         ready = caught_up and not over_saturated
         if ready:
-            reason = None
+            # ``state_db_rebuilding`` is ready-but-degraded: the live DB is a
+            # consistent stale snapshot and must remain routable on singleton
+            # deployments while its replacement is built off to the side.
+            reason = ledger_reason
         elif not caught_up:
             reason = ledger_reason
         else:
@@ -317,6 +340,8 @@ class HealthSampler(threading.Thread):
             # API-only nodes serve a static/frozen ledger and do not track the backend tip.
             return True, None, None, None, None
 
+        rebuilding = self._state_db_rebuilding_provider()
+
         backend_height = self._backend_height_provider()
         last_parsed = None
         if self._last_parsed_provider is not None:
@@ -330,6 +355,20 @@ class HealthSampler(threading.Thread):
         ):
             self._last_parsed_value = last_parsed
             self._last_parsed_advanced_at = now
+
+        if rebuilding:
+            lag = (
+                backend_height - last_parsed
+                if backend_height is not None and last_parsed is not None
+                else None
+            )
+            if last_parsed is None:
+                return False, lag, "state_db_unavailable", backend_height, last_parsed
+            if not self._state_db_stale_cache_available_provider():
+                return False, lag, "state_db_stale_cache_unavailable", backend_height, last_parsed
+            if self._state_db_rebuild_age_provider() > self.state_db_rebuild_max_ready_seconds:
+                return False, lag, "state_db_rebuild_stale", backend_height, last_parsed
+            return True, lag, "state_db_rebuilding", backend_height, last_parsed
 
         if not backend_height:  # None (starting) or 0
             return False, None, "starting", backend_height, last_parsed
@@ -423,6 +462,8 @@ class HealthRequestHandler(BaseHTTPRequestHandler):
     def _readiness(self):
         snap = self.server.sampler.current_snapshot()
         if snap.ready:
+            if snap.reason == "state_db_rebuilding":
+                return 200, {"status": "degraded", "reason": snap.reason}
             return 200, {"status": "ready"}
         body = {"status": "degraded", "reason": snap.reason}
         if snap.backend_height is not None:

--- a/counterparty-core/counterpartycore/lib/api/migrations/0001.create_and_populate_address_events.py
+++ b/counterparty-core/counterpartycore/lib/api/migrations/0001.create_and_populate_address_events.py
@@ -51,7 +51,7 @@ def apply(db):
         > 0
     )
     if not attached:
-        db.execute("ATTACH DATABASE ? AS ledger_db", (config.DATABASE,))
+        db.execute("ATTACH DATABASE ? AS ledger_db", (config.state_db_ledger_source_database(),))
 
     cursor = db.cursor()
 

--- a/counterparty-core/counterpartycore/lib/api/migrations/0002.create_and_populate_parsed_events.py
+++ b/counterparty-core/counterpartycore/lib/api/migrations/0002.create_and_populate_parsed_events.py
@@ -59,7 +59,7 @@ def apply(db):
         > 0
     )
     if not attached:
-        db.execute("ATTACH DATABASE ? AS ledger_db", (config.DATABASE,))
+        db.execute("ATTACH DATABASE ? AS ledger_db", (config.state_db_ledger_source_database(),))
 
     sqls = [
         """

--- a/counterparty-core/counterpartycore/lib/api/migrations/0003.create_and_populate_all_expirations.py
+++ b/counterparty-core/counterpartycore/lib/api/migrations/0003.create_and_populate_all_expirations.py
@@ -56,7 +56,7 @@ def apply(db):
         > 0
     )
     if not attached:
-        db.execute("ATTACH DATABASE ? AS ledger_db", (config.DATABASE,))
+        db.execute("ATTACH DATABASE ? AS ledger_db", (config.state_db_ledger_source_database(),))
 
     sqls = [
         """

--- a/counterparty-core/counterpartycore/lib/api/migrations/0004.create_and_populate_assets_info.py
+++ b/counterparty-core/counterpartycore/lib/api/migrations/0004.create_and_populate_assets_info.py
@@ -32,7 +32,7 @@ def apply(db):
         > 0
     )
     if not attached:
-        db.execute("ATTACH DATABASE ? AS ledger_db", (config.DATABASE,))
+        db.execute("ATTACH DATABASE ? AS ledger_db", (config.state_db_ledger_source_database(),))
 
     db.execute("""
         CREATE TABLE assets_info(
@@ -134,7 +134,11 @@ def apply(db):
     cursor = db.cursor()
     cursor.execute(sql)
 
-    ledger_db = database.get_db_connection(config.DATABASE)
+    ledger_db = database.get_db_connection(config.state_db_ledger_source_database())
+    try:
+        xcp_supply = ledger.supplies.xcp_supply(ledger_db)
+    finally:
+        ledger_db.close()
     cursor.execute(
         """
         INSERT INTO assets_info (
@@ -149,7 +153,7 @@ def apply(db):
             "asset": "XCP",
             "divisible": True,
             "locked": True,
-            "supply": ledger.supplies.xcp_supply(ledger_db),
+            "supply": xcp_supply,
             "description": "The Counterparty protocol native currency",
             "first_issuance_block_index": 278319,
             "last_issuance_block_index": 283810,

--- a/counterparty-core/counterpartycore/lib/api/migrations/0005.create_and_populate_events_count.py
+++ b/counterparty-core/counterpartycore/lib/api/migrations/0005.create_and_populate_events_count.py
@@ -31,7 +31,7 @@ def apply(db):
         > 0
     )
     if not attached:
-        db.execute("ATTACH DATABASE ? AS ledger_db", (config.DATABASE,))
+        db.execute("ATTACH DATABASE ? AS ledger_db", (config.state_db_ledger_source_database(),))
 
     db.execute("""
         CREATE TABLE events_count(

--- a/counterparty-core/counterpartycore/lib/api/migrations/0006.create_and_populate_consolidated_tables.py
+++ b/counterparty-core/counterpartycore/lib/api/migrations/0006.create_and_populate_consolidated_tables.py
@@ -208,7 +208,7 @@ def apply(db):
         > 0
     )
     if not attached:
-        db.execute("ATTACH DATABASE ? AS ledger_db", (config.DATABASE,))
+        db.execute("ATTACH DATABASE ? AS ledger_db", (config.state_db_ledger_source_database(),))
 
     for table in CONSOLIDATED_TABLES:
         build_consolidated_table(db, table)

--- a/counterparty-core/counterpartycore/lib/api/migrations/0009.create_and_populate_transaction_types_count.py
+++ b/counterparty-core/counterpartycore/lib/api/migrations/0009.create_and_populate_transaction_types_count.py
@@ -31,7 +31,7 @@ def apply(db):
         > 0
     )
     if not attached:
-        db.execute("ATTACH DATABASE ? AS ledger_db", (config.DATABASE,))
+        db.execute("ATTACH DATABASE ? AS ledger_db", (config.state_db_ledger_source_database(),))
 
     db.execute("""
         CREATE TABLE transaction_types_count(

--- a/counterparty-core/counterpartycore/lib/api/migrations/0012.add_event_column_to_address_events.py
+++ b/counterparty-core/counterpartycore/lib/api/migrations/0012.add_event_column_to_address_events.py
@@ -40,7 +40,7 @@ def apply(db):
         > 0
     )
     if not attached:
-        db.execute("ATTACH DATABASE ? AS ledger_db", (config.DATABASE,))
+        db.execute("ATTACH DATABASE ? AS ledger_db", (config.state_db_ledger_source_database(),))
 
     cursor = db.cursor()
 

--- a/counterparty-core/counterpartycore/lib/api/migrations/0014.add_pool_consolidated_tables.py
+++ b/counterparty-core/counterpartycore/lib/api/migrations/0014.add_pool_consolidated_tables.py
@@ -123,7 +123,7 @@ def apply(db):
         > 0
     )
     if not attached:
-        db.execute("ATTACH DATABASE ? AS ledger_db", (config.DATABASE,))
+        db.execute("ATTACH DATABASE ? AS ledger_db", (config.state_db_ledger_source_database(),))
 
     # Check which pool tables exist in ledger DB (they won't pre-activation)
     ledger_tables = {

--- a/counterparty-core/counterpartycore/lib/cli/server.py
+++ b/counterparty-core/counterpartycore/lib/cli/server.py
@@ -96,6 +96,7 @@ class CounterpartyServer(threading.Thread):
         self.asset_conservation_checker = None
         self.db = None
         self.api_stop_event = None
+        self.state_db_rebuild_ready_event = None
         self.backend_height_thread = None
         self.log_stream = log_stream
         self.periodic_profiler = None
@@ -199,8 +200,11 @@ class CounterpartyServer(threading.Thread):
 
         # API Server v2
         self.api_stop_event = multiprocessing.Event()
+        self.state_db_rebuild_ready_event = multiprocessing.Event()
         self.apiserver_v2 = api_v2.APIServer(
-            self.api_stop_event, self.backend_height_thread.shared_backend_height
+            self.api_stop_event,
+            self.backend_height_thread.shared_backend_height,
+            self.state_db_rebuild_ready_event,
         )
         self.apiserver_v2.start(self.args, self.log_stream)
         while not self.apiserver_v2.is_ready():
@@ -209,6 +213,7 @@ class CounterpartyServer(threading.Thread):
                 logger.error("API server stopped unexpectedly.")
                 return
             time.sleep(0.1)
+        self.apiserver_v2.start_rebuild_monitor(self.args, self.log_stream)
 
         if self.args.api_only:
             # Loop must check the event so stop() actually exits the loop;

--- a/counterparty-core/counterpartycore/lib/config.py
+++ b/counterparty-core/counterpartycore/lib/config.py
@@ -161,6 +161,10 @@ DEFAULT_HEALTHZ_SATURATION_GRACE_SECONDS = 5
 # Liveness fails only if the health sampler heartbeat is staler than this (a
 # genuine deadlock of the health process), never on ledger lag or saturation.
 DEFAULT_HEALTHZ_LIVENESS_HEARTBEAT_TIMEOUT_SECONDS = 30
+# A normal production-sized staged rebuild takes about 40 minutes. Keep stale
+# cache hits routable for at most two hours; after that readiness must alert
+# rather than advertising an indefinitely wedged recovery as healthy.
+DEFAULT_STATE_DB_REBUILD_MAX_READY_SECONDS = 2 * 60 * 60
 
 UNSPENDABLE_REGTEST = "mvCounterpartyXXXXXXXXXXXXXXW24Hef"
 UNSPENDABLE_TESTNET3 = "mvCounterpartyXXXXXXXXXXXXXXW24Hef"
@@ -335,6 +339,15 @@ DEFAULT_UTXO_VALUE = 546
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 LEDGER_DB_MIGRATIONS_DIR = os.path.join(CURRENT_DIR, "ledger", "migrations")
 STATE_DB_MIGRATIONS_DIR = os.path.join(CURRENT_DIR, "api", "migrations")
+# A staged State DB rebuild reads from an immutable SQLite backup so the live
+# ledger writer cannot invalidate a long-running migration snapshot. Normal
+# migrations leave this unset and read DATABASE directly.
+STATE_DB_LEDGER_SOURCE_DATABASE = None
+
+
+def state_db_ledger_source_database():
+    return STATE_DB_LEDGER_SOURCE_DATABASE or globals()["DATABASE"]
+
 
 PROFILE_INTERVAL_MINUTES = 15
 

--- a/counterparty-core/counterpartycore/lib/exceptions.py
+++ b/counterparty-core/counterpartycore/lib/exceptions.py
@@ -34,6 +34,14 @@ class ComposeError(MessageError):
     pass
 
 
+class StateDBRebuildCancelled(DatabaseError):
+    """Raised when shutdown cancels an in-progress staged State DB rebuild."""
+
+
+class StateDBRebuildUnavailable(DatabaseError):
+    """Raised when a request requires fresh state during a staged rebuild."""
+
+
 class UnpackError(MessageError):
     pass
 

--- a/counterparty-core/counterpartycore/lib/ledger/currentstate.py
+++ b/counterparty-core/counterpartycore/lib/ledger/currentstate.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from counterpartycore.lib import config
 from counterpartycore.lib.ledger import blocks
@@ -90,6 +91,58 @@ class CurrentState(metaclass=helpers.SingletonMeta):
 
     def stopping(self):
         return self.state.get("STOPPING", False)
+
+    def set_state_db_rebuilding(self, rebuilding):
+        shared_value = self.state.get("STATE_DB_REBUILDING_VALUE")
+        shared_started_at = self.state.get("STATE_DB_REBUILD_STARTED_AT_VALUE")
+        shared_cache_cold = self.state.get("STATE_DB_REBUILD_CACHE_COLD_VALUE")
+        if shared_value is not None:
+            if rebuilding:
+                if not shared_value.value or not shared_started_at.value:
+                    shared_started_at.value = time.time()
+                shared_value.value = True
+            else:
+                shared_value.value = False
+                shared_started_at.value = 0.0
+                if shared_cache_cold is not None:
+                    shared_cache_cold.value = False
+        else:
+            if rebuilding:
+                if not self.state.get("STATE_DB_REBUILDING", False):
+                    self.state["STATE_DB_REBUILD_STARTED_AT"] = time.time()
+                self.state["STATE_DB_REBUILDING"] = True
+            else:
+                self.state["STATE_DB_REBUILDING"] = False
+                self.state["STATE_DB_REBUILD_STARTED_AT"] = 0.0
+
+    def set_state_db_rebuild_shared_values(
+        self,
+        rebuilding_value,
+        started_at_value,
+        cache_cold_value=None,
+    ):
+        self.state["STATE_DB_REBUILDING_VALUE"] = rebuilding_value
+        self.state["STATE_DB_REBUILD_STARTED_AT_VALUE"] = started_at_value
+        self.state["STATE_DB_REBUILD_CACHE_COLD_VALUE"] = cache_cold_value
+
+    def state_db_rebuilding(self):
+        shared_value = self.state.get("STATE_DB_REBUILDING_VALUE")
+        if shared_value is not None:
+            return bool(shared_value.value)
+        return self.state.get("STATE_DB_REBUILDING", False)
+
+    def state_db_rebuild_age(self):
+        shared_started_at = self.state.get("STATE_DB_REBUILD_STARTED_AT_VALUE")
+        started_at = (
+            shared_started_at.value
+            if shared_started_at is not None
+            else self.state.get("STATE_DB_REBUILD_STARTED_AT", 0.0)
+        )
+        return max(0.0, time.time() - started_at) if started_at else 0.0
+
+    def state_db_rebuild_cache_cold(self):
+        shared_cache_cold = self.state.get("STATE_DB_REBUILD_CACHE_COLD_VALUE")
+        return bool(shared_cache_cold.value) if shared_cache_cold is not None else False
 
 
 class ConsensusHashBuilder(metaclass=helpers.SingletonMeta):

--- a/counterparty-core/counterpartycore/lib/utils/database.py
+++ b/counterparty-core/counterpartycore/lib/utils/database.py
@@ -879,56 +879,72 @@ def _wal_size(db_file):
         return 0
 
 
-def apply_outstanding_migration(db_file, migration_dir):
+def apply_outstanding_migration(db_file, migration_dir, stop_event=None):
     total_started_at = time.monotonic()
     wal_size_before = _wal_size(db_file)
     logger.info("Checking migrations for %s (WAL: %d bytes)...", db_file, wal_size_before)
 
     phase_started_at = time.monotonic()
     backend = get_backend(f"sqlite:///{db_file}")
+    if stop_event is not None:
+        backend.connection.set_progress_handler(
+            lambda: 1 if stop_event.is_set() else 0,
+            10_000,
+        )
     logger.info(
         "Migration backend opened for %s in %.2fs.",
         db_file,
         time.monotonic() - phase_started_at,
     )
 
-    phase_started_at = time.monotonic()
-    migrations = read_migrations(migration_dir)
-    to_apply = backend.to_apply(migrations)
-    logger.info(
-        "Migration discovery completed for %s in %.2fs; %d pending.",
-        db_file,
-        time.monotonic() - phase_started_at,
-        len(to_apply),
-    )
-    needs_vacuum = any(any(name in m.id for name in _VACUUM_AFTER_MIGRATIONS) for m in to_apply)
-
-    phase_started_at = time.monotonic()
     try:
-        backend.apply_migrations(to_apply)
-    except LockTimeout:
-        logger.warning("Migration lock timeout for %s. Breaking lock and retrying...", db_file)
-        backend.break_lock()
+        phase_started_at = time.monotonic()
+        migrations = read_migrations(migration_dir)
         to_apply = backend.to_apply(migrations)
-        backend.apply_migrations(to_apply)
-    logger.info(
-        "Migration apply completed for %s in %.2fs.",
-        db_file,
-        time.monotonic() - phase_started_at,
-    )
+        logger.info(
+            "Migration discovery completed for %s in %.2fs; %d pending.",
+            db_file,
+            time.monotonic() - phase_started_at,
+            len(to_apply),
+        )
+        needs_vacuum = any(
+            any(name in migration.id for name in _VACUUM_AFTER_MIGRATIONS) for migration in to_apply
+        )
 
-    phase_started_at = time.monotonic()
-    backend.connection.close()
-    logger.info(
-        "Migration backend closed for %s in %.2fs.",
-        db_file,
-        time.monotonic() - phase_started_at,
-    )
+        phase_started_at = time.monotonic()
+        try:
+            backend.apply_migrations(to_apply)
+        except LockTimeout:
+            logger.warning("Migration lock timeout for %s. Breaking lock and retrying...", db_file)
+            backend.break_lock()
+            to_apply = backend.to_apply(migrations)
+            backend.apply_migrations(to_apply)
+        logger.info(
+            "Migration apply completed for %s in %.2fs.",
+            db_file,
+            time.monotonic() - phase_started_at,
+        )
+    finally:
+        phase_started_at = time.monotonic()
+        if stop_event is not None:
+            backend.connection.set_progress_handler(None, 0)
+        backend.connection.close()
+        logger.info(
+            "Migration backend closed for %s in %.2fs.",
+            db_file,
+            time.monotonic() - phase_started_at,
+        )
     if needs_vacuum:
         logger.info("Running VACUUM after compact-hash migration to reclaim disk space...")
         conn = apsw.Connection(db_file)
-        conn.cursor().execute("VACUUM")
-        conn.close()
+        try:
+            if stop_event is not None:
+                conn.set_progress_handler(lambda: 1 if stop_event.is_set() else 0, 10_000)
+            conn.cursor().execute("VACUUM")
+        finally:
+            if stop_event is not None:
+                conn.set_progress_handler(None, 0)
+            conn.close()
         logger.info("VACUUM completed.")
     logger.info(
         "Migration check completed for %s in %.2fs (WAL: %d -> %d bytes).",

--- a/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
@@ -1,4 +1,5 @@
 import json
+import multiprocessing
 from unittest.mock import Mock, call, patch
 
 import pytest
@@ -9,6 +10,14 @@ from counterpartycore.lib.messages import dispense, dividend, sweep
 from counterpartycore.lib.parser import blocks
 from counterpartycore.lib.utils import hashcodec, helpers
 from counterpartycore.test.mocks.counterpartydbs import ProtocolChangesDisabled
+
+REAL_IS_SERVER_READY = apiserver.is_server_ready
+
+
+def _set_rebuild_state_in_spawned_process(rebuilding_value, started_at_value):
+    current_state = ledger.currentstate.CurrentState()
+    current_state.set_state_db_rebuild_shared_values(rebuilding_value, started_at_value)
+    current_state.set_state_db_rebuilding(True)
 
 
 def test_api_server_stop_waits_for_graceful_exit():
@@ -48,6 +57,149 @@ def test_api_server_stop_reports_process_that_survives_kill():
         server.stop()
 
     critical.assert_called_once()
+
+
+def test_api_server_restart_replaces_child_and_waits_until_ready():
+    server = apiserver.APIServer(Mock(), Mock())
+    server.stop_event.is_set.return_value = False
+    old_process = Mock()
+    old_process.is_alive.return_value = False
+    server.process = old_process
+    server.restart_args = Mock()
+    server.restart_log_stream = Mock()
+
+    def start_replacement(_args, _log_stream):
+        server.process = Mock()
+        server.process.is_alive.return_value = True
+        server.server_ready_value.value = 1
+
+    server._start_process = Mock(side_effect=start_replacement)
+
+    server.restart()
+
+    server._start_process.assert_called_once_with(server.restart_args, server.restart_log_stream)
+    assert server.is_ready()
+
+
+def test_api_server_remains_ready_while_state_db_rebuilds():
+    current_state = ledger.currentstate.CurrentState()
+    current_state.set_state_db_rebuilding(True)
+    try:
+        assert REAL_IS_SERVER_READY() is True
+    finally:
+        current_state.set_state_db_rebuilding(False)
+
+
+def test_api_server_becomes_unready_when_state_db_rebuild_is_stale():
+    current_state = ledger.currentstate.CurrentState()
+    current_state.set_state_db_rebuilding(True)
+    try:
+        with patch.object(
+            current_state,
+            "state_db_rebuild_age",
+            return_value=config.DEFAULT_STATE_DB_REBUILD_MAX_READY_SECONDS + 1,
+        ):
+            assert REAL_IS_SERVER_READY() is False
+    finally:
+        current_state.set_state_db_rebuilding(False)
+
+
+def test_state_db_rebuild_flag_uses_shared_memory():
+    context = multiprocessing.get_context("spawn")
+    rebuilding_value = context.Value("b", 0)
+    started_at_value = context.Value("d", 0.0)
+    current_state = ledger.currentstate.CurrentState()
+    current_state.set_state_db_rebuild_shared_values(rebuilding_value, started_at_value)
+
+    process = context.Process(
+        target=_set_rebuild_state_in_spawned_process,
+        args=(rebuilding_value, started_at_value),
+    )
+    process.start()
+    process.join(timeout=10)
+
+    assert process.exitcode == 0
+    assert rebuilding_value.value == 1
+    assert started_at_value.value > 0
+    assert current_state.state_db_rebuilding() is True
+    assert current_state.state_db_rebuild_age() >= 0
+    original_started_at = started_at_value.value
+    current_state.set_state_db_rebuilding(True)
+    assert started_at_value.value == original_started_at
+    current_state.set_state_db_rebuilding(False)
+
+
+def test_rebuild_monitor_restarts_an_unexpectedly_dead_api_child():
+    server = apiserver.APIServer(Mock(), Mock(), state_db_rebuild_ready_event=Mock())
+    server.stop_event.is_set.side_effect = [False, False, True]
+    server.state_db_rebuild_ready_event.wait.return_value = False
+    server.process = Mock()
+    server.process.is_alive.return_value = False
+    server.restart = Mock()
+
+    server._monitor_rebuilt_state_db()
+
+    server.restart.assert_called_once_with(activating_rebuild=False)
+
+
+def test_rebuild_monitor_restarts_api_child_after_critical_watcher_failure():
+    server = apiserver.APIServer(Mock(), Mock(), state_db_rebuild_ready_event=Mock())
+    server.stop_event.is_set.side_effect = [False, False, True]
+    server.state_db_rebuild_ready_event.wait.return_value = False
+    server.process = Mock()
+    server.process.is_alive.return_value = True
+    server.api_child_fatal_event.set()
+    server.restart = Mock()
+
+    server._monitor_rebuilt_state_db()
+
+    server.restart.assert_called_once_with(activating_rebuild=False)
+
+
+def test_state_db_rebuild_serves_only_stale_safe_requests(apiv2_client, defaults, monkeypatch):
+    current_state = ledger.currentstate.CurrentState()
+    monkeypatch.setattr(config, "DISABLE_API_CACHE", False)
+    blockcache.BLOCK_CACHE.clear()
+    try:
+        seeded = apiv2_client.get("/v2/assets/XCP?verbose=false")
+        assert seeded.status_code == 200
+        current_state.set_state_db_rebuilding(True)
+        state_pool_connection = apiserver.StateDBConnectionPool().connection
+        ledger_pool_connection = apiserver.LedgerDBConnectionPool().connection
+        with patch.object(
+            apiserver.StateDBConnectionPool(), "connection", wraps=state_pool_connection
+        ) as state_connection:
+            with patch.object(
+                apiserver.LedgerDBConnectionPool(), "connection", wraps=ledger_pool_connection
+            ) as ledger_connection:
+                cached_read = apiv2_client.get("/v2/assets/XCP?verbose=false")
+        state_connection.assert_not_called()
+        ledger_connection.assert_not_called()
+        cache_miss = apiv2_client.get("/v2/assets/XCP?verbose=true")
+        api_root = apiv2_client.get("/v2/")
+        public_health = apiv2_client.get("/v2/healthz")
+        compose = apiv2_client.get(f"/v2/addresses/{defaults['addresses'][0]}/compose/issuance")
+        mempool = apiv2_client.get("/v2/mempool/events")
+        bitcoin = apiv2_client.get("/v2/bitcoin/getmempoolinfo")
+        transaction_info = apiv2_client.get("/v2/transactions/info")
+        post = apiv2_client.post("/v2/bitcoin/transactions", data={"rawtx": "00"})
+    finally:
+        current_state.set_state_db_rebuilding(False)
+        blockcache.BLOCK_CACHE.clear()
+
+    assert cached_read.status_code == 200
+    assert cached_read.headers["X-COUNTERPARTY-STALE"] == "true"
+    assert cache_miss.status_code == 503
+    assert "no safe pre-reorg cached response" in cache_miss.json["error"]
+    assert public_health.status_code == 200
+    assert public_health.json["result"] == {
+        "status": "Degraded",
+        "reason": "state_db_rebuilding",
+    }
+    assert api_root.status_code == 503
+    for response in (compose, mempool, bitcoin, transaction_info, post):
+        assert response.status_code == 503
+        assert "requires fresh state" in response.json["error"]
 
 
 def test_apiserver_root(apiv2_client, current_block_index):

--- a/counterparty-core/counterpartycore/test/units/api/apiwatcher_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiwatcher_test.py
@@ -13,8 +13,11 @@ import re
 import threading
 from unittest.mock import MagicMock
 
+import apsw
 import pytest
 from counterpartycore.lib.api import apiwatcher
+from counterpartycore.lib.ledger.currentstate import CurrentState
+from counterpartycore.lib.utils import database
 
 
 def test_api_watcher_stop_interrupts_sqlite_connections():
@@ -24,6 +27,7 @@ def test_api_watcher_stop_interrupts_sqlite_connections():
     watcher.state_db = MagicMock()
     watcher.ledger_db = MagicMock()
     watcher.current_state_thread = None
+    watcher.fatal_event = None
     watcher.join = MagicMock()
     watcher.is_alive = MagicMock(return_value=False)
 
@@ -52,6 +56,178 @@ def test_api_watcher_handles_shutdown_interrupt(monkeypatch):
 
     watcher.state_db.close.assert_called_once_with()
     watcher.ledger_db.close.assert_called_once_with()
+
+
+def test_api_watcher_stages_rebuild_and_requests_coordinated_restart(monkeypatch):
+    watcher = apiwatcher.APIWatcher.__new__(apiwatcher.APIWatcher)
+    threading.Thread.__init__(watcher, name="Watcher")
+    watcher.stop_event = threading.Event()
+    watcher.rebuild_cancel_event = threading.Event()
+    watcher.state_db_rebuild_ready_event = MagicMock()
+    watcher.fatal_event = None
+    stage = MagicMock()
+    monkeypatch.setattr(apiwatcher.dbbuilder, "stage_state_db_rebuild", stage)
+    CurrentState().set_state_db_rebuilding(False)
+
+    watcher.stage_state_db_rebuild()
+
+    cancel_event = stage.call_args.kwargs["stop_event"]
+    assert cancel_event.events == (watcher.stop_event, watcher.rebuild_cancel_event)
+    watcher.state_db_rebuild_ready_event.set.assert_called_once_with()
+    assert watcher.stop_event.is_set()
+    assert CurrentState().state_db_rebuilding() is True
+    CurrentState().set_state_db_rebuilding(False)
+
+
+def test_api_watcher_translates_shutdown_during_rebuild_to_cancellation(monkeypatch):
+    watcher = apiwatcher.APIWatcher.__new__(apiwatcher.APIWatcher)
+    threading.Thread.__init__(watcher, name="Watcher")
+    watcher.stop_event = threading.Event()
+    watcher.rebuild_cancel_event = threading.Event()
+    watcher.state_db_rebuild_ready_event = MagicMock()
+    watcher.fatal_event = None
+
+    def cancelled_rebuild(stop_event):
+        watcher.stop_event.set()
+        assert stop_event.is_set()
+        raise RuntimeError("sqlite interrupted")
+
+    monkeypatch.setattr(apiwatcher.dbbuilder, "stage_state_db_rebuild", cancelled_rebuild)
+
+    with pytest.raises(apiwatcher.exceptions.StateDBRebuildCancelled):
+        watcher.stage_state_db_rebuild()
+
+    watcher.state_db_rebuild_ready_event.set.assert_not_called()
+    CurrentState().set_state_db_rebuilding(False)
+
+
+def test_follow_checks_lineage_before_appending_new_branch_event(monkeypatch):
+    watcher = apiwatcher.APIWatcher.__new__(apiwatcher.APIWatcher)
+    threading.Thread.__init__(watcher, name="Watcher")
+    watcher.stop_event = threading.Event()
+    watcher.state_db = MagicMock()
+    watcher.ledger_db = MagicMock()
+    watcher.state_db_rebuild_ready_event = MagicMock()
+    watcher.fatal_event = None
+    event = {"message_index": 999, "block_index": 500, "event": "CREDIT"}
+    monkeypatch.setattr(apiwatcher, "get_next_event_to_parse", MagicMock(return_value=event))
+    monkeypatch.setattr(apiwatcher, "get_ledger_data_version", MagicMock(return_value=1))
+    check = MagicMock(return_value=True)
+    monkeypatch.setattr(apiwatcher, "check_reorg", check)
+    parse = MagicMock()
+    monkeypatch.setattr(apiwatcher, "parse_event", parse)
+
+    watcher.follow()
+
+    check.assert_called_once_with(
+        watcher.ledger_db,
+        watcher.state_db,
+        watcher.stage_state_db_rebuild,
+    )
+    parse.assert_not_called()
+
+
+def test_follow_rechecks_lineage_when_ledger_changes_mid_block(monkeypatch):
+    watcher = apiwatcher.APIWatcher.__new__(apiwatcher.APIWatcher)
+    threading.Thread.__init__(watcher, name="Watcher")
+    watcher.stop_event = threading.Event()
+    watcher.state_db = MagicMock()
+    watcher.ledger_db = MagicMock()
+    watcher.state_db_rebuild_ready_event = MagicMock()
+    watcher.fatal_event = None
+    events = [
+        {"message_index": 100, "block_index": 500, "event": "CREDIT"},
+        {"message_index": 101, "block_index": 500, "event": "DEBIT"},
+    ]
+    monkeypatch.setattr(
+        apiwatcher,
+        "get_next_event_to_parse",
+        MagicMock(side_effect=[*events, None]),
+    )
+    monkeypatch.setattr(
+        apiwatcher,
+        "get_ledger_data_version",
+        MagicMock(side_effect=[1, 2]),
+    )
+    check = MagicMock(side_effect=[False, True])
+    monkeypatch.setattr(apiwatcher, "check_reorg", check)
+    parse = MagicMock()
+    monkeypatch.setattr(apiwatcher, "parse_event", parse)
+
+    watcher.follow()
+
+    parse.assert_called_once_with(watcher.state_db, events[0], ledger_db=watcher.ledger_db)
+    assert check.call_count == 2
+
+
+def test_api_watcher_failure_requests_parent_restart(monkeypatch):
+    watcher = apiwatcher.APIWatcher.__new__(apiwatcher.APIWatcher)
+    threading.Thread.__init__(watcher, name="Watcher")
+    watcher.stop_event = threading.Event()
+    watcher.state_db = MagicMock()
+    watcher.ledger_db = MagicMock()
+    watcher.current_state_thread = None
+    watcher.fatal_event = MagicMock()
+    monkeypatch.setattr(apiwatcher, "catch_up", MagicMock(side_effect=RuntimeError("boom")))
+
+    watcher.run()
+
+    watcher.fatal_event.set.assert_called_once_with()
+
+
+def test_rebuild_timeout_cancels_work_and_requests_parent_restart():
+    watcher = apiwatcher.APIWatcher.__new__(apiwatcher.APIWatcher)
+    watcher.rebuild_cancel_event = threading.Event()
+    watcher.fatal_event = MagicMock()
+
+    watcher._cancel_timed_out_rebuild()
+
+    assert watcher.rebuild_cancel_event.is_set()
+    watcher.fatal_event.set.assert_called_once_with()
+
+
+@pytest.mark.parametrize("new_branch_event_count", [0, 2, 5])
+def test_same_height_one_block_reorg_is_detected_for_any_event_count(new_branch_event_count):
+    ledger_db = apsw.Connection(":memory:")
+    state_db = apsw.Connection(":memory:")
+    ledger_db.set_row_trace(database.rowtracer)
+    state_db.set_row_trace(database.rowtracer)
+    ledger_db.execute(
+        "CREATE TABLE messages (message_index INTEGER PRIMARY KEY, block_index INTEGER, "
+        "event_hash TEXT, event TEXT)"
+    )
+    state_db.execute(
+        "CREATE TABLE parsed_events (event_index INTEGER PRIMARY KEY, block_index INTEGER, "
+        "event_hash TEXT, event TEXT)"
+    )
+    state_db.execute("CREATE INDEX parsed_events_event_index_idx ON parsed_events (event_index)")
+    common = (10, 99, "common", "BLOCK_PARSED")
+    ledger_db.execute("INSERT INTO messages VALUES (?, ?, ?, ?)", common)
+    state_db.execute("INSERT INTO parsed_events VALUES (?, ?, ?, ?)", common)
+    for index in range(11, 13):
+        state_db.execute(
+            "INSERT INTO parsed_events VALUES (?, 100, ?, 'CREDIT')",
+            (index, f"old-{index}"),
+        )
+    state_db.execute("INSERT INTO parsed_events VALUES (13, 100, 'old-block', 'BLOCK_PARSED')")
+    for offset in range(new_branch_event_count):
+        message_index = 11 + offset
+        ledger_db.execute(
+            "INSERT INTO messages VALUES (?, 100, ?, 'CREDIT')",
+            (message_index, f"new-{message_index}"),
+        )
+    ledger_db.execute(
+        "INSERT INTO messages VALUES (?, 100, 'new-block', 'BLOCK_PARSED')",
+        (11 + new_branch_event_count,),
+    )
+    stage_rebuild = MagicMock()
+
+    try:
+        assert apiwatcher.check_reorg(ledger_db, state_db, stage_rebuild=stage_rebuild) is True
+    finally:
+        state_db.close()
+        ledger_db.close()
+    stage_rebuild.assert_called_once_with()
 
 
 def test_get_last_block_parsed_preserves_event_order_and_uses_event_index(state_db):

--- a/counterparty-core/counterpartycore/test/units/api/dbbuilder_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/dbbuilder_test.py
@@ -1,5 +1,12 @@
+import os
+import threading
+from unittest.mock import MagicMock
+
+import apsw
+import pytest
+from counterpartycore.lib import config, exceptions
 from counterpartycore.lib.api import dbbuilder
-from counterpartycore.lib.utils import hashcodec
+from counterpartycore.lib.utils import database, hashcodec
 from counterpartycore.lib.utils.database import (
     ADDRESS_INDEX_COLUMN_NAMES,
     ASSET_INDEX_COLUMN_NAMES,
@@ -41,6 +48,347 @@ def column_exists(db, table_name, column_name):
     """Check if a column exists in a table."""
     columns = db.execute(f"PRAGMA table_info({table_name})").fetchall()
     return any(col["name"] == column_name for col in columns)
+
+
+def _create_marker_database(path, value):
+    db = apsw.Connection(str(path))
+    db.execute("CREATE TABLE marker (value TEXT)")
+    db.execute("INSERT INTO marker VALUES (?)", (value,))
+    db.close()
+
+
+def _read_marker_database(path):
+    db = apsw.Connection(str(path), flags=apsw.SQLITE_OPEN_READONLY)
+    try:
+        return db.execute("SELECT value FROM marker").fetchone()[0]
+    finally:
+        db.close()
+
+
+def test_staged_state_db_rebuild_does_not_touch_live_database(tmp_path, monkeypatch, ledger_db):
+    live_db = tmp_path / "state.db"
+    _create_marker_database(live_db, "live")
+    monkeypatch.setattr(config, "STATE_DATABASE", str(live_db))
+    observed = {}
+
+    def fake_apply(staged_path, _migration_dir, **_kwargs):
+        observed["ledger_source"] = config.state_db_ledger_source_database()
+        assert os.path.exists(observed["ledger_source"])
+        assert not os.path.exists(f"{observed['ledger_source']}-wal")
+        _create_marker_database(staged_path, "rebuilt")
+
+    monkeypatch.setattr(database, "apply_outstanding_migration", fake_apply)
+    monkeypatch.setattr(
+        dbbuilder,
+        "_replacement_manifest",
+        lambda staged_path, _ledger_path, stop_event=None: {
+            "staged_size": os.path.getsize(staged_path)
+        },
+    )
+
+    dbbuilder.stage_state_db_rebuild()
+
+    assert _read_marker_database(live_db) == "live"
+    assert _read_marker_database(dbbuilder.staged_state_db_path()) == "rebuilt"
+    assert observed["ledger_source"].endswith(".ledger-snapshot")
+    assert not os.path.exists(observed["ledger_source"])
+    assert os.path.exists(dbbuilder.staged_state_db_ready_path())
+
+
+def test_activate_staged_state_db_retains_previous_database(tmp_path, monkeypatch):
+    live_db = tmp_path / "state.db"
+    staged_db = tmp_path / "state.db.rebuild"
+    ready_path = tmp_path / "state.db.rebuild.ready"
+    _create_marker_database(live_db, "live")
+    _create_marker_database(staged_db, "rebuilt")
+    monkeypatch.setattr(config, "STATE_DATABASE", str(live_db))
+    manifest = {
+        "version": config.VERSION_STRING,
+        "migration_digest": "digest",
+        "staged_size": os.path.getsize(staged_db),
+    }
+    ready_path.write_text("{}\n")
+    monkeypatch.setattr(dbbuilder, "_read_ready_manifest", lambda _path: manifest)
+    monkeypatch.setattr(dbbuilder, "_manifest_is_current", lambda _manifest, _path, **_kwargs: True)
+    fsync_directory = MagicMock()
+    monkeypatch.setattr(dbbuilder, "_fsync_directory", fsync_directory)
+
+    assert dbbuilder.activate_staged_state_db() is True
+
+    assert _read_marker_database(live_db) == "rebuilt"
+    assert _read_marker_database(dbbuilder.previous_state_db_path()) == "live"
+    assert not ready_path.exists()
+    assert fsync_directory.call_count == 3
+
+
+@pytest.mark.parametrize("failing_barrier", [1, 2, 3])
+def test_activation_is_recoverable_at_every_directory_barrier(
+    tmp_path, monkeypatch, failing_barrier
+):
+    live_db = tmp_path / "state.db"
+    staged_db = tmp_path / "state.db.rebuild"
+    ready_path = tmp_path / "state.db.rebuild.ready"
+    _create_marker_database(live_db, "live")
+    _create_marker_database(staged_db, "rebuilt")
+    ready_path.write_text("{}\n")
+    monkeypatch.setattr(config, "STATE_DATABASE", str(live_db))
+    monkeypatch.setattr(dbbuilder, "_read_ready_manifest", lambda _path: {})
+    monkeypatch.setattr(dbbuilder, "_manifest_is_current", lambda _manifest, _path, **_kwargs: True)
+    barrier_calls = 0
+
+    def fail_selected_barrier(_path):
+        nonlocal barrier_calls
+        barrier_calls += 1
+        if barrier_calls == failing_barrier:
+            raise OSError("simulated power-loss boundary")
+
+    monkeypatch.setattr(dbbuilder, "_fsync_directory", fail_selected_barrier)
+    with pytest.raises(OSError, match="power-loss boundary"):
+        dbbuilder.activate_staged_state_db()
+
+    monkeypatch.setattr(dbbuilder, "_fsync_directory", lambda _path: None)
+    dbbuilder.activate_staged_state_db()
+
+    assert _read_marker_database(live_db) == "rebuilt"
+    assert _read_marker_database(dbbuilder.previous_state_db_path()) == "live"
+    assert not ready_path.exists()
+
+
+def test_missing_staged_database_requires_live_manifest_match(tmp_path, monkeypatch):
+    live_db = tmp_path / "state.db"
+    ready_path = tmp_path / "state.db.rebuild.ready"
+    _create_marker_database(live_db, "rebuilt")
+    ready_path.write_text("{}\n")
+    monkeypatch.setattr(config, "STATE_DATABASE", str(live_db))
+    monkeypatch.setattr(dbbuilder, "_read_ready_manifest", lambda _path: {})
+    monkeypatch.setattr(
+        dbbuilder, "_manifest_is_current", lambda _manifest, _path, **_kwargs: False
+    )
+
+    with pytest.raises(exceptions.DatabaseError, match="does not match its manifest"):
+        dbbuilder.activate_staged_state_db()
+
+    assert ready_path.exists()
+    assert _read_marker_database(live_db) == "rebuilt"
+
+
+def test_incomplete_staged_state_db_is_never_activated(tmp_path, monkeypatch):
+    live_db = tmp_path / "state.db"
+    staged_db = tmp_path / "state.db.rebuild"
+    _create_marker_database(live_db, "live")
+    _create_marker_database(staged_db, "partial")
+    ledger_snapshot = tmp_path / "state.db.rebuild.ledger-snapshot"
+    _create_marker_database(ledger_snapshot, "partial-ledger")
+    (tmp_path / "state.db.rebuild-journal").write_text("journal")
+    (tmp_path / "state.db.rebuild.ready.tmp").write_text("partial marker")
+    monkeypatch.setattr(config, "STATE_DATABASE", str(live_db))
+
+    assert dbbuilder.activate_staged_state_db() is False
+
+    assert _read_marker_database(live_db) == "live"
+    assert not staged_db.exists()
+    assert not ledger_snapshot.exists()
+    assert not (tmp_path / "state.db.rebuild-journal").exists()
+    assert not (tmp_path / "state.db.rebuild.ready.tmp").exists()
+
+
+def test_failed_space_preflight_retains_previous_recovery_copy(tmp_path, monkeypatch):
+    live_db = tmp_path / "state.db"
+    previous_db = tmp_path / "state.db.previous"
+    _create_marker_database(live_db, "live")
+    _create_marker_database(previous_db, "previous")
+    monkeypatch.setattr(config, "STATE_DATABASE", str(live_db))
+
+    def fail_preflight():
+        assert previous_db.exists()
+        raise exceptions.DatabaseError("insufficient space")
+
+    monkeypatch.setattr(dbbuilder, "_ensure_staged_rebuild_space", fail_preflight)
+
+    with pytest.raises(exceptions.DatabaseError, match="insufficient space"):
+        dbbuilder.stage_state_db_rebuild()
+    assert previous_db.exists()
+
+
+def test_rebuild_releases_previous_only_when_preflight_requires_it(tmp_path, monkeypatch):
+    live_db = tmp_path / "state.db"
+    previous_db = tmp_path / "state.db.previous"
+    _create_marker_database(live_db, "live")
+    _create_marker_database(previous_db, "previous")
+    monkeypatch.setattr(config, "STATE_DATABASE", str(live_db))
+    monkeypatch.setattr(dbbuilder, "_ensure_staged_rebuild_space", lambda: True)
+
+    def stop_before_backup(_path, stop_event=None):
+        assert not previous_db.exists()
+        raise exceptions.StateDBRebuildCancelled("stop after reclaim assertion")
+
+    monkeypatch.setattr(dbbuilder, "_backup_ledger_database", stop_before_backup)
+
+    with pytest.raises(exceptions.StateDBRebuildCancelled):
+        dbbuilder.stage_state_db_rebuild()
+
+
+def test_stale_manifest_never_replaces_live_database(tmp_path, monkeypatch):
+    live_db = tmp_path / "state.db"
+    staged_db = tmp_path / "state.db.rebuild"
+    ready_path = tmp_path / "state.db.rebuild.ready"
+    _create_marker_database(live_db, "live")
+    _create_marker_database(staged_db, "rebuilt")
+    ready_path.write_text("{}\n")
+    monkeypatch.setattr(config, "STATE_DATABASE", str(live_db))
+    monkeypatch.setattr(
+        dbbuilder,
+        "_read_ready_manifest",
+        lambda _path: {
+            "version": config.VERSION_STRING,
+            "migration_digest": "digest",
+            "staged_size": os.path.getsize(staged_db),
+        },
+    )
+    monkeypatch.setattr(
+        dbbuilder, "_manifest_is_current", lambda _manifest, _path, **_kwargs: False
+    )
+
+    assert dbbuilder.activate_staged_state_db() is False
+    assert _read_marker_database(live_db) == "live"
+    assert not staged_db.exists()
+    assert not ready_path.exists()
+
+
+def test_manifest_lineage_rejects_a_replaced_ledger_branch(tmp_path, monkeypatch):
+    ledger_path = tmp_path / "ledger.db"
+    ledger = apsw.Connection(str(ledger_path))
+    ledger.execute(
+        "CREATE TABLE messages (message_index INTEGER PRIMARY KEY, event_hash TEXT, "
+        "block_index INTEGER, event TEXT)"
+    )
+    ledger.executemany(
+        "INSERT INTO messages VALUES (?, ?, ?, ?)",
+        [
+            (1, "old-block", 100, "BLOCK_PARSED"),
+            (2, "old-tip", 100, "CREDIT"),
+        ],
+    )
+    ledger.close()
+    monkeypatch.setattr(config, "DATABASE", str(ledger_path))
+    manifest = {
+        "source_event_index": 2,
+        "source_event_hash": "old-tip",
+        "source_event_block_index": 100,
+        "source_block_event_index": 1,
+        "source_block_event_hash": "old-block",
+        "source_block_index": 100,
+    }
+
+    assert dbbuilder._manifest_matches_live_ledger(manifest) is True
+
+    ledger = apsw.Connection(str(ledger_path))
+    ledger.execute("UPDATE messages SET event_hash = 'new-block' WHERE message_index = 1")
+    ledger.execute("UPDATE messages SET event_hash = 'new-tip' WHERE message_index = 2")
+    ledger.close()
+
+    assert dbbuilder._manifest_matches_live_ledger(manifest) is False
+
+
+def test_manifest_rejects_a_different_builder_commit(monkeypatch):
+    manifest = {
+        "version": config.VERSION_STRING,
+        "builder_commit": "old-image",
+        "migration_digest": "digest",
+    }
+    monkeypatch.setattr(config, "CURRENT_COMMIT", "new-image")
+    monkeypatch.setattr(dbbuilder, "_migration_digest", lambda: "digest")
+    monkeypatch.setattr(dbbuilder, "_state_db_matches_manifest", lambda _path, _manifest: True)
+    monkeypatch.setattr(dbbuilder, "_manifest_matches_live_ledger", lambda _manifest: True)
+
+    assert dbbuilder._manifest_is_current(manifest, "state.db") is False
+
+
+def test_latest_ledger_block_manifest_query_avoids_temp_sort():
+    ledger_db = apsw.Connection(":memory:")
+    ledger_db.set_row_trace(database.rowtracer)
+    ledger_db.execute(
+        "CREATE TABLE messages (message_index INTEGER PRIMARY KEY, event_hash TEXT, "
+        "block_index INTEGER, event TEXT)"
+    )
+    ledger_db.execute("CREATE INDEX messages_event_idx ON messages (event)")
+    plan = ledger_db.execute(
+        f"EXPLAIN QUERY PLAN {dbbuilder.LAST_LEDGER_BLOCK_EVENT_SQL}"
+    ).fetchall()
+    ledger_db.close()
+
+    assert not any("USE TEMP B-TREE" in row["detail"] for row in plan)
+
+
+def test_ledger_snapshot_backup_is_cancellable(tmp_path, monkeypatch):
+    ledger_path = tmp_path / "ledger.db"
+    ledger = apsw.Connection(str(ledger_path))
+    ledger.execute("CREATE TABLE data (value TEXT)")
+    ledger.executemany("INSERT INTO data VALUES (?)", [("x" * 1024,)] * 1_000)
+    ledger.close()
+    monkeypatch.setattr(config, "DATABASE", str(ledger_path))
+    stop_event = threading.Event()
+    stop_event.set()
+
+    with pytest.raises(exceptions.StateDBRebuildCancelled):
+        dbbuilder._backup_ledger_database(
+            str(tmp_path / "snapshot.db"),
+            stop_event=stop_event,
+        )
+
+
+def test_staged_rebuild_from_ledger_is_complete_and_activatable(tmp_path, monkeypatch, ledger_db):
+    live_db = tmp_path / "state.db"
+    _create_marker_database(live_db, "live")
+    monkeypatch.setattr(config, "STATE_DATABASE", str(live_db))
+
+    dbbuilder.stage_state_db_rebuild()
+    staged_db = database.get_db_connection(
+        dbbuilder.staged_state_db_path(), read_only=True, check_wal=False
+    )
+    try:
+        staged_events = staged_db.execute("SELECT COUNT(*) AS count FROM parsed_events").fetchone()[
+            "count"
+        ]
+        ledger_events = ledger_db.execute("SELECT COUNT(*) AS count FROM messages").fetchone()[
+            "count"
+        ]
+        assert staged_events == ledger_events
+        assert table_exists(staged_db, "assets_info")
+        assert table_exists(staged_db, "balances")
+        assert view_exists(staged_db, "orders_info")
+    finally:
+        staged_db.close()
+
+    assert dbbuilder.activate_staged_state_db() is True
+    activated_db = database.get_db_connection(str(live_db), read_only=True, check_wal=False)
+    try:
+        assert table_exists(activated_db, "parsed_events")
+        assert activated_db.execute("PRAGMA quick_check(1)").fetchone()["quick_check"] == "ok"
+    finally:
+        activated_db.close()
+
+
+def test_fallback_rollback_rebuilds_address_events_to_ledger_tip(state_db, ledger_db):
+    expected_count = state_db.execute("SELECT COUNT(*) AS count FROM address_events").fetchone()[
+        "count"
+    ]
+    first_address_block = state_db.execute(
+        "SELECT MIN(block_index) AS block_index FROM address_events"
+    ).fetchone()["block_index"]
+    assert expected_count > 0
+    assert first_address_block is not None
+
+    dbbuilder.rollback_state_db(state_db, block_index=first_address_block)
+
+    assert (
+        state_db.execute("SELECT COUNT(*) AS count FROM address_events").fetchone()["count"]
+        == expected_count
+    )
+    assert (
+        state_db.execute("SELECT COUNT(*) AS count FROM parsed_events").fetchone()["count"]
+        == ledger_db.execute("SELECT COUNT(*) AS count FROM messages").fetchone()["count"]
+    )
 
 
 def test_migration_0001_rollback(state_db, ledger_db):

--- a/counterparty-core/counterpartycore/test/units/api/healthz_server_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/healthz_server_test.py
@@ -45,6 +45,10 @@ def make_sampler(
     last_parsed=100,
     block_time=None,
     api_only=False,
+    rebuilding=False,
+    rebuild_age=60,
+    rebuild_cache_cold=False,
+    rebuild_max_ready_seconds=7200,
     saturation_grace=5,
 ):
     return HealthSampler(
@@ -54,6 +58,10 @@ def make_sampler(
         backend_height_provider=lambda: backend_height,
         block_time_provider=lambda: block_time,
         api_only_provider=lambda: api_only,
+        state_db_rebuilding_provider=lambda: rebuilding,
+        state_db_rebuild_age_provider=lambda: rebuild_age,
+        state_db_stale_cache_available_provider=lambda: not rebuild_cache_cold,
+        state_db_rebuild_max_ready_seconds=rebuild_max_ready_seconds,
     )
 
 
@@ -103,6 +111,50 @@ def test_api_only_skips_lag_axis():
     assert snap.ready is True
     assert snap.reason is None
     assert snap.backend_height is None
+
+
+def test_state_db_rebuild_serves_consistent_stale_snapshot():
+    sampler = make_sampler(backend_height=200, last_parsed=100, rebuilding=True)
+    sampler._tick()
+    snap = sampler.current_snapshot()
+    assert snap.ready is True
+    assert snap.reason == "state_db_rebuilding"
+    assert snap.lag == 100
+
+
+def test_state_db_rebuild_requires_readable_state_db():
+    sampler = make_sampler(backend_height=200, last_parsed=None, rebuilding=True)
+    sampler._tick()
+    snap = sampler.current_snapshot()
+    assert snap.ready is False
+    assert snap.reason == "state_db_unavailable"
+
+
+def test_state_db_rebuild_exceeding_max_age_becomes_unready():
+    sampler = make_sampler(
+        backend_height=200,
+        last_parsed=100,
+        rebuilding=True,
+        rebuild_age=7201,
+        rebuild_max_ready_seconds=7200,
+    )
+    sampler._tick()
+    snap = sampler.current_snapshot()
+    assert snap.ready is False
+    assert snap.reason == "state_db_rebuild_stale"
+
+
+def test_state_db_rebuild_with_cold_replacement_child_is_unready():
+    sampler = make_sampler(
+        backend_height=200,
+        last_parsed=100,
+        rebuilding=True,
+        rebuild_cache_cold=True,
+    )
+    sampler._tick()
+    snap = sampler.current_snapshot()
+    assert snap.ready is False
+    assert snap.reason == "state_db_stale_cache_unavailable"
 
 
 # --------------------------------------------------------------------------------------------
@@ -282,6 +334,27 @@ def test_http_readiness_ok(ready_server):
         code, body = ready_server.get(path)
         assert code == 200
         assert body == {"status": "ready"}
+
+
+def test_http_readiness_rebuilding_is_routable_but_degraded():
+    snapshot = _ready_snapshot()
+    snapshot = HealthSnapshot(
+        ready=True,
+        reason="state_db_rebuilding",
+        backend_height=snapshot.backend_height,
+        last_parsed=snapshot.last_parsed,
+        lag=snapshot.lag,
+        saturated=snapshot.saturated,
+        saturation_seconds=snapshot.saturation_seconds,
+        workers=snapshot.workers,
+    )
+    fx = _HttpServerFixture(FakeSampler(snapshot))
+    try:
+        code, body = fx.get("/healthz/ready")
+        assert code == 200
+        assert body == {"status": "degraded", "reason": "state_db_rebuilding"}
+    finally:
+        fx.close()
 
 
 def test_http_readiness_degraded_behind_backend():

--- a/counterparty-core/counterpartycore/test/units/utils/database_test.py
+++ b/counterparty-core/counterpartycore/test/units/utils/database_test.py
@@ -1301,6 +1301,84 @@ def test_apply_outstanding_migration_logs_phase_timings(temp_db_file):
         os.rmdir(migration_dir)
 
 
+def test_apply_outstanding_migration_installs_cancellation_progress_handler(temp_db_file):
+    migration_dir = tempfile.mkdtemp()
+    mock_backend = MagicMock()
+    mock_backend.to_apply.return_value = []
+    stop_event = MagicMock()
+    stop_event.is_set.return_value = True
+
+    try:
+        with patch("counterpartycore.lib.utils.database.get_backend", return_value=mock_backend):
+            with patch("counterpartycore.lib.utils.database.read_migrations", return_value=[]):
+                apply_outstanding_migration(
+                    temp_db_file,
+                    migration_dir,
+                    stop_event=stop_event,
+                )
+
+        progress_call = mock_backend.connection.set_progress_handler.call_args_list[0]
+        assert progress_call.args[0]() == 1
+        assert progress_call.args[1] == 10_000
+        assert mock_backend.connection.set_progress_handler.call_args_list[-1].args == (None, 0)
+        mock_backend.connection.close.assert_called_once_with()
+    finally:
+        os.rmdir(migration_dir)
+
+
+def test_apply_outstanding_migration_makes_vacuum_cancellable(temp_db_file):
+    migration_dir = tempfile.mkdtemp()
+    migration = MagicMock(id="compact-hash-migration")
+    mock_backend = MagicMock()
+    mock_backend.to_apply.return_value = [migration]
+    vacuum_connection = MagicMock()
+    stop_event = MagicMock()
+    stop_event.is_set.return_value = True
+
+    try:
+        with patch.object(database, "_VACUUM_AFTER_MIGRATIONS", ["compact-hash"]):
+            with patch(
+                "counterpartycore.lib.utils.database.get_backend", return_value=mock_backend
+            ):
+                with patch(
+                    "counterpartycore.lib.utils.database.read_migrations",
+                    return_value=[migration],
+                ):
+                    with patch(
+                        "counterpartycore.lib.utils.database.apsw.Connection",
+                        return_value=vacuum_connection,
+                    ):
+                        apply_outstanding_migration(
+                            temp_db_file,
+                            migration_dir,
+                            stop_event=stop_event,
+                        )
+
+        progress_call = vacuum_connection.set_progress_handler.call_args_list[0]
+        assert progress_call.args[0]() == 1
+        assert progress_call.args[1] == 10_000
+        assert vacuum_connection.set_progress_handler.call_args_list[-1].args == (None, 0)
+        vacuum_connection.close.assert_called_once_with()
+    finally:
+        os.rmdir(migration_dir)
+
+
+def test_apply_outstanding_migration_closes_backend_when_discovery_fails(temp_db_file):
+    migration_dir = tempfile.mkdtemp()
+    mock_backend = MagicMock()
+    mock_backend.to_apply.side_effect = RuntimeError("discovery failed")
+
+    try:
+        with patch("counterpartycore.lib.utils.database.get_backend", return_value=mock_backend):
+            with patch("counterpartycore.lib.utils.database.read_migrations", return_value=[]):
+                with pytest.raises(RuntimeError, match="discovery failed"):
+                    apply_outstanding_migration(temp_db_file, migration_dir)
+
+        mock_backend.connection.close.assert_called_once_with()
+    finally:
+        os.rmdir(migration_dir)
+
+
 # =============================================================================
 # Tests for rollback_all_migrations function (lines 370-373)
 # =============================================================================

--- a/release-notes/release-notes-v11.3.1.md
+++ b/release-notes/release-notes-v11.3.1.md
@@ -12,3 +12,25 @@
   latest `BLOCK_PARSED` event during API watcher initialization. This preserves
   the prior event-order semantics while avoiding a cold full-result sort that
   added minutes to mainnet API startup.
+- Rebuild a replacement State DB alongside the still-serving live database
+  after a reorganization, using a temporary online backup of the Ledger DB so
+  long-running migrations read a stable snapshot. Verify and checkpoint the
+  result against a durable lineage, migration, and builder-commit manifest,
+  then restart only the API child to activate it with ordered directory-fsync
+  barriers. A parent-owned rebuild gate survives crashes and activation
+  restarts and clears only after the replacement catches up. Readiness remains
+  routable-but-degraded while pre-reorg cache hits serve eligible public GETs;
+  cache misses and all
+  compose, mempool, fee, authenticated, POST, and other `no-store` requests
+  fail closed until fresh state is active. A restarted cache-cold child, a
+  disabled cache, and an authenticated-only API report unready rather than
+  overstating availability. One previous State DB is retained for recovery
+  and reclaimed only when a subsequent rebuild needs its space. Rebuild backup,
+  migration, verification, and vacuum work is cancellable on shutdown; partial
+  files and journals are removed. An interrupted, stale, or failed build is
+  never activated and falls back to a complete in-place rollback, including
+  rebuilding address-event history. A rebuild deadline cancels hung work and
+  critical watcher failure triggers an automatic API-child restart.
+  Reorg detection and matching-block searches preserve exact event ordering
+  through the existing event-index scan so cold State DBs do not sort every
+  `BLOCK_PARSED` event first.


### PR DESCRIPTION
## Summary

- keep the existing internally consistent State DB available only through pre-reorg cached public GET hits while a replacement is built from a transactionally stable Ledger snapshot
- fail closed for cache misses, API metadata, compose, mempool, Bitcoin/live routes, authenticated requests, POST, and other fresh-state work
- keep the rebuild gate and age in parent-owned shared memory across Gunicorn workers, API-child crashes, and the deliberate activation restart; clear it only after lineage verification and catch-up
- validate a durable lineage/migration/builder-commit manifest, checkpoint/fsync the replacement, and activate it through ordered rename/fsync barriers
- cancel backup/migration/verification/vacuum work on shutdown; enforce a rebuild watchdog and restart the child after critical watcher failure
- reclaim `.previous` only when preflight proves its bytes are needed, clean every partial sidecar/journal, and rebuild address-event history in the fallback path
- detect latest same-height one-block reorgs and mid-block branch changes before appending events

Closes #3485.

## Failure safety

- incomplete, stale, cross-image, corrupt, or lineage-mismatched builds are never activated
- activation-resume validates a missing-staged/live-present state against the manifest before consuming the marker
- the parent restarts an unexpectedly dead child or failed critical watcher while preserving the gate
- a cache-cold replacement child, disabled cache, authenticated-only API, missing State DB, or over-age rebuild reports unready
- a failed staged build falls back while the API remains gated; migration 0001 is included so `address_events` cannot remain permanently incomplete
- no consensus code is changed

## Production-sized exercise

An isolated GKE pod with no Service/public route used the production 2 CPU / 12 GiB request and 8 CPU / 16 GiB limit on a 60 GB SSD cloned from the retained mainnet snapshot. The trigger was synthetic: one copied `BLOCK_PARSED` hash was altered; it was not a true two-fork reorg.

- 16.9 GB consistent Ledger snapshot: 2m27s
- State DB migration: 2,210.8s
- total staging: 2,398.8s (~40m)
- readiness probes during backup: 61–95ms
- old API child graceful stop: 2.90s
- full API-child switchover: 13.15s
- peak disk use: 88%, 7.1 GB free
- post-activation height: 964039 / 964039

Local tests now add real same-height replacement fixtures with fewer/equal/more events, a mid-block data-version change, stale-builder/lineage rejection, cancellation, repeated rebuild space, every activation fsync boundary, missing-staged recovery, fallback address-event completeness, shared-process gating, cold-cache readiness, and watcher/watchdog restart behavior.

## Validation

- full post-rebase API suite: 500 passed
- focused rebuild/shutdown/health/database suite: 228 passed
- combined #3488/#3489/#3490/#3491 API tree: 557 passed
- Ruff, format, and commit hooks pass

This remains stacked on #3488 because clean bounded shutdown and fast cold API initialization are prerequisites. It contains one additional commit.