### PR TITLE
Fix gpg-agent and temp dir leak in bootstrap signature verification

### DIFF
--- a/counterparty-core/counterpartycore/lib/cli/bootstrap.py
+++ b/counterparty-core/counterpartycore/lib/cli/bootstrap.py
@@ -2,6 +2,7 @@ import getpass
 import glob
 import io
 import os
+import shutil
 import sqlite3
 import subprocess  # nosec B404
 import sys
@@ -69,7 +70,20 @@ def verify_signature(public_key_data, signature_path, snapshot_path):
         with open(signature_path, "rb") as s:
             verified = gpg.verify_file(s, snapshot_path, close_file=False)
     finally:
-        pass
+        # Each gnupg.GPG(gnupghome=...) call spawns a persistent gpg-agent
+        # daemon for that homedir; kill it before removing the directory so
+        # repeated bootstrap runs don't leak agents and temp dirs. Removing
+        # the directory out from under a running agent races with socket /
+        # lockfile creation, so the kill must come first. check=False because
+        # the agent may legitimately not have started (e.g. import_keys
+        # raised); ignore_errors guards against gpg transiently recreating a
+        # file during shutdown.
+        subprocess.run(  # noqa: S603
+            ["gpgconf", "--homedir", temp_dir, "--kill", "gpg-agent"],  # noqa: S607  # nosec B603, B607
+            check=False,
+            capture_output=True,
+        )
+        shutil.rmtree(temp_dir, ignore_errors=True)
 
     return verified
 

--- a/release-notes/release-notes-v11.4.0.md
+++ b/release-notes/release-notes-v11.4.0.md
@@ -111,3 +111,7 @@ The differential tests above surfaced three ways in which a State DB maintained 
 ## Security
 
 - Bumped `h2` to 0.4.19 in both Rust lockfiles for **RUSTSEC-2026-0258** ("h2 unbounded empty DATA frames"). `counterparty-rs` carried 0.4.8 and `counterparty-client` 0.4.15; the advisory requires >= 0.4.16.
+
+## Bugfixes
+
+- **Fix a resource leak in snapshot signature verification** (`bootstrap` / `prepare-bootstrap`). Every call to `verify_signature()` leaked one `gpg-agent` daemon and one temporary GnuPG home directory, because the cleanup added in f53a7443 was accidentally disabled in 301c37ac ("Fix bootstrap with custom url") — commented out as apparent leftover debugging. The agent is now terminated with `gpgconf --homedir <dir> --kill gpg-agent` before the directory is removed, which avoids the socket/lockfile race that removing a live agent's home directory would otherwise hit. Only the agent spawned by the call itself is terminated; other GnuPG daemons on the machine are unaffected.


### PR DESCRIPTION
## Fix gpg-agent and temp dir leak in bootstrap signature verification

### Summary

`verify_signature()` in `counterpartycore/lib/cli/bootstrap.py` leaks one `gpg-agent` daemon process and one temporary GnuPG home directory on every call. This restores the cleanup that was accidentally removed in 301c37ac, and makes it race-safe by terminating the agent before removing its home directory.

### The problem

Each call to `verify_signature()` creates a throwaway GnuPG home via `tempfile.mkdtemp()` and passes it to `gnupg.GPG(gnupghome=...)`. GnuPG spawns a persistent `gpg-agent --homedir <dir> --daemon` for that home, which outlives the verification. Since the cleanup code was disabled, every call leaves behind:

- an orphaned `gpg-agent` process (reparented to init, runs indefinitely), and
- its temporary keyring directory under `$TMPDIR`.

The function is called once per snapshot per signing key tried, on both the `bootstrap` path (`check_signature`, in a `multiprocessing.Process` child) and the `prepare-bootstrap` path (`verify_prepared_signature`). The unit test suite exercises it as well, so CI and repeated local runs accumulate orphaned agents and temp dirs without bound. On a machine used for bootstrap performance testing, 16 orphaned agents and 25 stale temp dirs were observed.

### How it happened

`verify_signature()` was introduced in f53a7443 (May 2024) with correct cleanup:

```python
finally:
    shutil.rmtree(temp_dir)
```

Commit 301c37ac (Jan 2025, "Fix bootstrap with custom url") — an otherwise unrelated change to version-string parsing — commented out the cleanup and removed the `shutil` import:

```python
finally:
    pass
    # shutil.rmtree(temp_dir)
```

This appears to be leftover debugging committed by accident; nothing in that commit's purpose relates to GPG cleanup.

### The fix

Restore the cleanup, but terminate the agent **before** removing the directory:

```python
finally:
    subprocess.run(
        ["gpgconf", "--homedir", temp_dir, "--kill", "gpg-agent"],
        check=False,
        capture_output=True,
    )
    shutil.rmtree(temp_dir, ignore_errors=True)
```

Removing the directory out from under a running agent races with socket/lockfile creation and fails intermittently — which is likely what prompted the original cleanup to be disabled. `gpgconf --homedir <dir> --kill gpg-agent` is the documented way to stop the agent for a specific home directory.

- `check=False`: the agent may legitimately never have started (e.g. if `import_keys` raised).
- `ignore_errors=True`: guards against GnuPG transiently recreating a file during shutdown, particularly under parallel `verify_and_decompress` workers.

The kill is strictly scoped to the temp homedir created by the call — other `gpg-agent` instances on the machine (e.g. the user's `~/.gnupg` agent used by git, mail clients, etc.) are unaffected.

### Testing

- All 10 tests in `counterpartycore/test/units/cli/bootstrap_test.py` pass, including `test_verify_signature` (valid signature verifies, invalid signature rejected).
- Direct verification: ran `verify_signature()` twice and confirmed **zero** new `gpg-agent` processes and **zero** leftover temp directories afterwards (previously: one of each per call). Pre-existing agents on the machine were untouched.