### PR TITLE
Package the OpenAPI document with Core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
     pip3 install /wheels/*.whl
 
 # Build Python components
+COPY ./openapi.json /counterparty-core/openapi.json
 COPY ./counterparty-core /counterparty-core/counterparty-core
 WORKDIR /counterparty-core/counterparty-core
 RUN pip3 install .

--- a/counterparty-core/counterpartycore/lib/api/apiserver.py
+++ b/counterparty-core/counterpartycore/lib/api/apiserver.py
@@ -7,6 +7,7 @@ import sys
 import threading
 import time
 from collections import namedtuple
+from importlib import resources
 from multiprocessing import Process, Value
 
 import flask
@@ -46,8 +47,19 @@ logger = logging.getLogger(config.LOGGER_NAME)
 auth = HTTPBasicAuth()
 
 
-CURR_DIR = os.path.dirname(os.path.realpath(__file__))
-OPENAPI_FILEPATH = os.path.join(CURR_DIR, "..", "..", "..", "..", "openapi.json")
+def get_openapi_filepath():
+    packaged_spec = resources.files("counterpartycore").joinpath("openapi.json")
+    if packaged_spec.is_file():
+        return os.fspath(packaged_spec)
+
+    # Editable/source-tree fallback. Built wheels force-include the same root
+    # document at counterpartycore/openapi.json, so installed servers do not
+    # depend on the repository layout.
+    source_spec = resources.files("counterpartycore").joinpath("..", "..", "openapi.json")
+    return os.fspath(source_spec)
+
+
+OPENAPI_FILEPATH = get_openapi_filepath()
 
 
 @auth.verify_password

--- a/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
@@ -137,6 +137,16 @@ def test_openapi_file_is_available_to_the_running_package():
     assert apiserver.OPENAPI_FILEPATH.endswith("openapi.json")
 
 
+def test_openapi_prefers_the_packaged_resource(monkeypatch, tmp_path):
+    package_root = tmp_path / "counterpartycore"
+    package_root.mkdir()
+    packaged_spec = package_root / "openapi.json"
+    packaged_spec.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(apiserver.resources, "files", lambda _package: package_root)
+
+    assert apiserver.get_openapi_filepath() == os.fspath(packaged_spec)
+
+
 def _sort_arg(route):
     return next((arg for arg in ROUTES[route]["args"] if arg["name"] == "sort"), None)
 

--- a/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
@@ -132,6 +132,11 @@ def test_apiserver_openapi_spec(apiv2_client):
     )
 
 
+def test_openapi_file_is_available_to_the_running_package():
+    assert os.path.isfile(apiserver.OPENAPI_FILEPATH)
+    assert apiserver.OPENAPI_FILEPATH.endswith("openapi.json")
+
+
 def _sort_arg(route):
     return next((arg for arg in ROUTES[route]["args"] if arg["name"] == "sort"), None)
 

--- a/counterparty-core/pyproject.toml
+++ b/counterparty-core/pyproject.toml
@@ -45,6 +45,9 @@ path = "counterpartycore/lib/config.py"
 [tool.hatch.build.targets.wheel]
 include = ["counterpartycore"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"../openapi.json" = "counterpartycore/openapi.json"
+
 [tool.hatch.envs.default]
 pre-install-commands = [
   "pip install -e ../counterparty-rs",

--- a/release-notes/release-notes-v11.4.0.md
+++ b/release-notes/release-notes-v11.4.0.md
@@ -91,6 +91,14 @@ The API watcher thread is what advances the State DB, and nothing restarts it. A
 
 Such a failure is now logged at `CRITICAL` with its traceback, and `/healthz/ready` returns `503` with `reason: "watcher_stopped"` from that moment. Previously the only symptom was the lag signal drifting past the ready threshold minutes later — and on an `--api-only` node, which does not compare itself to the backend tip, never at all. Liveness deliberately stays `200`: the process is internally alive, and the remedy is to shed traffic and page an operator, not to have Kubernetes kill a pod mid-request.
 
+## Packaged OpenAPI document (#3495)
+
+The installed wheel now includes `openapi.json`. Previously `/v2/openapi.json`
+worked from a source checkout but returned `500` from the official container:
+the handler walked four directories upward from `site-packages`, where the
+repository-root file does not exist. The API now resolves the packaged resource
+and retains a source-tree fallback for editable development installs.
+
 ## Address history endpoints
 
 `/v2/addresses/<address>/credits`, `/debits`, `/sends` and `/sends/<asset>` match an address against two or four columns, each of which already has its own index. Neither plan SQLite has for the resulting `OR` predicate followed by `ORDER BY rowid DESC LIMIT` is bounded by the page size. A reverse full-table scan — the right plan only for an address whose newest row sits near the tip — reads millions of unrelated rows before reaching the first match of an address whose history is short or old. The alternative, a multi-index `OR`, does use every index but then has to sort the address's *entire* history to honour the ordering, so a busy address pays for all of it to return one page.


### PR DESCRIPTION
Fixes #3495.

## Summary
- force-include the committed root `openapi.json` in the Python wheel as `counterpartycore/openapi.json`
- copy the root document into the Docker builder before installing the Python package
- resolve the installed resource with `importlib.resources`
- retain a source-tree fallback for editable development installs
- test both source-tree and packaged-resource resolution
- document the container-visible fix in v11.4.0 release notes

## Validation
- `/v2/openapi.json` focused tests: 3 passed
- built `counterparty_core-11.3.0-py3-none-any.whl` successfully
- wheel contains `counterpartycore/openapi.json` (1,854,263 bytes)
- packaged and repository documents have identical SHA-256 hashes
- packaged JSON parses as OpenAPI 3.1.0 with 197 paths
- Ruff 0.9.10 check and format: passed
- `git diff --check`: passed

The first Docker CI run correctly exposed that the parent file was absent from the builder image; the Dockerfile now copies it before `pip install .`. This fixes packaging only and does not alter API schema or consensus behavior.