### PR TITLE
Point bootstrap at the v11.4.0 snapshots

### DIFF
--- a/.github/workflows/pytest_action.yml
+++ b/.github/workflows/pytest_action.yml
@@ -43,6 +43,12 @@ jobs:
         with:
           path: ~/.cache/counterparty-integration-cache/${{ inputs.integration_cache_network }}
           # Cache key version: increment to invalidate incompatible caches
+          # v7: bootstrap snapshots bumped to v11.4.0. Same reason as v6: a restored
+          # cache short-circuits the bootstrap download, so without a new key the
+          # integration tests would keep running against the v11.3.0-derived DBs and
+          # never exercise the new snapshots. The v11.4.0 snapshots have also been
+          # through the one-time `refresh_state_db`, so a v6 cache would take the slow
+          # full-rebuild path on its first reorg instead of the incremental one.
           # v6: bootstrap snapshots bumped to v11.3.0. A restored cache short-circuits
           # the bootstrap download, so without a new key the integration tests would
           # keep running against the v11.2.0-derived DBs and never exercise the new
@@ -59,9 +65,9 @@ jobs:
           # migration 0004 then fails with `no such column: a.asset_index`.
           # v3: compact-hash match tables re-keyed on (tx0_index, tx1_index);
           # the v2 cached DBs carry the old TEXT `id` schema and are incompatible.
-          key: integration-v6-${{ inputs.integration_cache_network }}-${{ github.run_id }}
+          key: integration-v7-${{ inputs.integration_cache_network }}-${{ github.run_id }}
           restore-keys: |
-            integration-v6-${{ inputs.integration_cache_network }}-
+            integration-v7-${{ inputs.integration_cache_network }}-
 
       - name: Set up Python
         uses: actions/setup-python@v3
@@ -129,7 +135,7 @@ jobs:
           path: ~/.cache/counterparty-integration-cache/${{ inputs.integration_cache_network }}
           # Cache key version: increment to invalidate incompatible caches
           # (must match the restore key above).
-          key: integration-v6-${{ inputs.integration_cache_network }}-${{ github.run_id }}
+          key: integration-v7-${{ inputs.integration_cache_network }}-${{ github.run_id }}
 
       - name: Upload coverage
         uses: codecov/codecov-action@v5

--- a/counterparty-core/counterpartycore/lib/config.py
+++ b/counterparty-core/counterpartycore/lib/config.py
@@ -286,12 +286,12 @@ PROTOCOL_CHANGES_URL = "https://counterparty.io/protocol_changes.json"
 
 
 BOOTSTRAP_URL_BASE = "https://storage.googleapis.com/counterparty-bootstrap"
-# Version tag embedded in the bootstrap snapshot file names (e.g. "v11.3.0").
+# Version tag embedded in the bootstrap snapshot file names (e.g. "v11.4.0").
 # Versioned names let several releases coexist in the bucket. This tag tracks the
 # latest *published* snapshot set, which may lag behind VERSION_STRING when a
 # release needs no new snapshots (no database migration) or when they have not
 # been uploaded yet — bump it when new snapshots are published to the bucket.
-BOOTSTRAP_VERSION = "v11.3.0"
+BOOTSTRAP_VERSION = "v11.4.0"
 
 # Ledger / state database base file names per network (as stored in the bucket).
 # testnet3 is intentionally absent: it is deprecated and no snapshots are produced


### PR DESCRIPTION
The v11.4.0 snapshot set is published to `gs://counterparty-bootstrap` (12/12 files, 6.99 GiB), so point the bootstrap at it.

## Changes

**`config.py`** — `BOOTSTRAP_VERSION`: `v11.3.0` → `v11.4.0`.

That constant is the single source of truth: `_bootstrap_urls()` derives the 12 URLs from it, and `bootstrap_test.py` builds its expectations from the same constant. Nothing else hardcodes the version.

**`pytest_action.yml`** — integration cache key `v6` → `v7` (3 occurrences: `key`, `restore-keys`, and the `key` on the save step).

A restored cache short-circuits the bootstrap download, so without a new key the integration tests would keep running against the v11.3.0-derived DBs and never exercise the new snapshots. The v11.4.0 snapshots have also been through the one-time `refresh_state_db`, so a v6 cache would take the slow full-rebuild path on its first reorg instead of the incremental one.

## Verification

| Check | Result |
|---|---|
| `bootstrap_test.py` | 13 passed |
| `ruff format --check` + `ruff check` on `config.py` | clean |
| `pytest_action.yml` YAML parse | OK |
| Derived URLs vs uploaded object names | 12/12 match |
| Remote vs local byte sizes | identical |
| GPG signature of `counterparty.signet.db.v11.4.0.zst` against the shipped `PUBLIC_KEYS` | verifies |
| `https://storage.googleapis.com/counterparty-bootstrap/…v11.4.0.zst` | HTTP 200 (public read inherited, no ACL step needed) |

## Not in this PR

`docker-compose.yml` is still on `v11.3.0`, while `dockercompose_test.py` replaces `image: counterparty/counterparty:v{config.VERSION_STRING}` (i.e. `v11.4.0`) with `v11.0.4`. The replacement is therefore a silent no-op and the upgrade test starts from v11.3.0 rather than v11.0.4. That bump is historically a separate release commit made once the image is on Docker Hub, so it is left out here — but it still needs doing.