### PR TITLE
Address the external review of the v11.4.0 release candidate

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/addressevents.py
+++ b/counterparty-core/counterpartycore/lib/api/addressevents.py
@@ -1,0 +1,101 @@
+"""Address associations for Ledger events.
+
+``address_events`` is the projection behind ``/v2/addresses/<address>/events``,
+``/credits`` and ``/debits``. It is derived in three places -- the watcher as
+events stream in, migration ``0001`` on a full State DB build, and
+``dbbuilder.backfill_address_events()`` when a refresh or a full rollback
+advances the replay cursor past events it never associated -- and all three
+have to agree, down to the UTXO-owner alias, or the API answers differently
+depending on how the State DB was built.
+
+They therefore share these rules rather than each restating them. This lives
+outside ``apiwatcher`` because ``apiwatcher`` imports ``dbbuilder``, so
+``dbbuilder`` cannot import it back.
+"""
+
+import json
+
+from counterpartycore.lib.parser import utxosinfo
+
+EVENTS_ADDRESS_FIELDS = {
+    "NEW_TRANSACTION": ["source", "destination"],
+    "DEBIT": ["address"],
+    "CREDIT": ["address"],
+    "ENHANCED_SEND": ["source", "destination"],
+    "MPMA_SEND": ["source", "destination"],
+    "SEND": ["source", "destination"],
+    "ASSET_TRANSFER": ["source", "issuer"],
+    "SWEEP": ["source", "destination"],
+    "ASSET_DIVIDEND": ["source"],
+    "RESET_ISSUANCE": ["source", "issuer"],
+    "ASSET_ISSUANCE": ["source", "issuer"],
+    "ASSET_DESTRUCTION": ["source"],
+    "OPEN_ORDER": ["source"],
+    "ORDER_MATCH": ["tx0_address", "tx1_address"],
+    "BTC_PAY": ["source", "destination"],
+    "CANCEL_ORDER": ["source"],
+    "ORDER_EXPIRATION": ["source"],
+    "ORDER_MATCH_EXPIRATION": ["tx0_address", "tx1_address"],
+    "OPEN_DISPENSER": ["source", "origin", "oracle_address"],
+    "DISPENSER_UPDATE": ["source"],
+    "REFILL_DISPENSER": ["source", "destination"],
+    "DISPENSE": ["source", "destination"],
+    "BROADCAST": ["source"],
+    "BURN": ["source"],
+    "NEW_FAIRMINT": ["source"],
+    "NEW_FAIRMINTER": ["source"],
+    "ATTACH_TO_UTXO": ["source", "destination_address"],
+    "DETACH_FROM_UTXO": ["source_address", "destination"],
+    "UTXO_MOVE": ["source_address", "destination_address"],
+    "OPEN_POOL": ["source"],
+    "POOL_UPDATE": [],
+    "NEW_POOL_DEPOSIT": ["source"],
+    "NEW_POOL_WITHDRAWAL": ["source"],
+    "POOL_MATCH": ["source"],
+}
+
+
+def search_address_from_utxo(state_db, utxo):
+    cursor = state_db.cursor()
+    sql = "SELECT utxo_address FROM balances WHERE utxo = ? LIMIT 1"
+    cursor.execute(sql, (utxo,))
+    address = cursor.fetchone()
+    if address is not None:
+        return address["utxo_address"]
+    return None
+
+
+def update_address_events(state_db, event):
+    if event["event"] not in EVENTS_ADDRESS_FIELDS:
+        return
+    event_bindings = json.loads(event["bindings"])
+    cursor = state_db.cursor()
+    for field in EVENTS_ADDRESS_FIELDS[event["event"]]:
+        if field not in event_bindings:
+            continue
+        address = event_bindings[field]
+        sql = """
+            INSERT INTO address_events (address, event_index, block_index, event)
+            VALUES (:address, :event_index, :block_index, :event)
+            """
+        cursor.execute(
+            sql,
+            {
+                "address": address,
+                "event_index": event["message_index"],
+                "block_index": event["block_index"],
+                "event": event["event"],
+            },
+        )
+        if utxosinfo.is_utxo_format(address):
+            utxo_address = search_address_from_utxo(state_db, address)
+            if utxo_address is not None:
+                cursor.execute(
+                    sql,
+                    {
+                        "address": utxo_address,
+                        "event_index": event["message_index"],
+                        "block_index": event["block_index"],
+                        "event": event["event"],
+                    },
+                )

--- a/counterparty-core/counterpartycore/lib/api/apiserver.py
+++ b/counterparty-core/counterpartycore/lib/api/apiserver.py
@@ -697,6 +697,7 @@ class ConnectionPoolMonitor(threading.Thread):
 def run_apiserver(
     args, server_ready_value, stop_event, shared_backend_height, parent_pid, log_stream
 ):
+    api_owner_pid = os.getpid()
     logger.info("Starting API Server process...")
 
     def handle_interrupt_signal(_signum, _frame):
@@ -838,7 +839,10 @@ def run_apiserver(
             memory_profiler.stop_memory_profiler()
 
         logger.info("API Server stopped.")
-        server_ready_value.value = 2
+        # Retiring Gunicorn workers also unwind through this finally block.
+        # Only the API owner can mark the shared server state as stopped.
+        if os.getpid() == api_owner_pid:
+            server_ready_value.value = 2
 
 
 # This thread is used for the following two reasons:

--- a/counterparty-core/counterpartycore/lib/api/apiserver.py
+++ b/counterparty-core/counterpartycore/lib/api/apiserver.py
@@ -749,6 +749,11 @@ def run_apiserver(
                     config.DEFAULT_HEALTHZ_SATURATION_GRACE_SECONDS,
                 ),
                 stop_event=stop_event,
+                # Readiness must not go green during the startup this listener
+                # deliberately runs ahead of: `server_ready_value` is 0 until
+                # the WSGI server is built and about to run, and 2 once it is
+                # stopping (issue #3504).
+                serving_provider=lambda: server_ready_value.value == 1,
             )
             health_server.start()
 

--- a/counterparty-core/counterpartycore/lib/api/apiwatcher.py
+++ b/counterparty-core/counterpartycore/lib/api/apiwatcher.py
@@ -7,7 +7,7 @@ import apsw
 
 from counterpartycore.lib import config
 from counterpartycore.lib.api import dbbuilder
-from counterpartycore.lib.parser import utxosinfo
+from counterpartycore.lib.api.addressevents import update_address_events
 from counterpartycore.lib.utils import database, hashcodec
 from counterpartycore.lib.utils.helpers import deadline_timeout, format_duration
 
@@ -114,43 +114,6 @@ UPDATE_EVENTS_ID_FIELDS = {
     "ADDRESS_OPTIONS_UPDATE": ["address"],
     "FAIRMINTER_UPDATE": ["tx_hash"],
     "POOL_UPDATE": ["asset_a", "asset_b"],
-}
-
-EVENTS_ADDRESS_FIELDS = {
-    "NEW_TRANSACTION": ["source", "destination"],
-    "DEBIT": ["address"],
-    "CREDIT": ["address"],
-    "ENHANCED_SEND": ["source", "destination"],
-    "MPMA_SEND": ["source", "destination"],
-    "SEND": ["source", "destination"],
-    "ASSET_TRANSFER": ["source", "issuer"],
-    "SWEEP": ["source", "destination"],
-    "ASSET_DIVIDEND": ["source"],
-    "RESET_ISSUANCE": ["source", "issuer"],
-    "ASSET_ISSUANCE": ["source", "issuer"],
-    "ASSET_DESTRUCTION": ["source"],
-    "OPEN_ORDER": ["source"],
-    "ORDER_MATCH": ["tx0_address", "tx1_address"],
-    "BTC_PAY": ["source", "destination"],
-    "CANCEL_ORDER": ["source"],
-    "ORDER_EXPIRATION": ["source"],
-    "ORDER_MATCH_EXPIRATION": ["tx0_address", "tx1_address"],
-    "OPEN_DISPENSER": ["source", "origin", "oracle_address"],
-    "DISPENSER_UPDATE": ["source"],
-    "REFILL_DISPENSER": ["source", "destination"],
-    "DISPENSE": ["source", "destination"],
-    "BROADCAST": ["source"],
-    "BURN": ["source"],
-    "NEW_FAIRMINT": ["source"],
-    "NEW_FAIRMINTER": ["source"],
-    "ATTACH_TO_UTXO": ["source", "destination_address"],
-    "DETACH_FROM_UTXO": ["source_address", "destination"],
-    "UTXO_MOVE": ["source_address", "destination_address"],
-    "OPEN_POOL": ["source"],
-    "POOL_UPDATE": [],
-    "NEW_POOL_DEPOSIT": ["source"],
-    "NEW_POOL_WITHDRAWAL": ["source"],
-    "POOL_MATCH": ["source"],
 }
 
 EXPIRATION_EVENTS_OBJECT_ID = {
@@ -406,52 +369,6 @@ def event_to_sql(event, ledger_db=None):
     if event["command"] in ["update", "parse"]:
         return update_event_to_sql(event, ledger_db=ledger_db)
     return None, []
-
-
-def search_address_from_utxo(state_db, utxo):
-    cursor = state_db.cursor()
-    sql = "SELECT utxo_address FROM balances WHERE utxo = ? LIMIT 1"
-    cursor.execute(sql, (utxo,))
-    address = cursor.fetchone()
-    if address is not None:
-        return address["utxo_address"]
-    return None
-
-
-def update_address_events(state_db, event):
-    if event["event"] not in EVENTS_ADDRESS_FIELDS:
-        return
-    event_bindings = json.loads(event["bindings"])
-    cursor = state_db.cursor()
-    for field in EVENTS_ADDRESS_FIELDS[event["event"]]:
-        if field not in event_bindings:
-            continue
-        address = event_bindings[field]
-        sql = """
-            INSERT INTO address_events (address, event_index, block_index, event)
-            VALUES (:address, :event_index, :block_index, :event)
-            """
-        cursor.execute(
-            sql,
-            {
-                "address": address,
-                "event_index": event["message_index"],
-                "block_index": event["block_index"],
-                "event": event["event"],
-            },
-        )
-        if utxosinfo.is_utxo_format(address):
-            utxo_address = search_address_from_utxo(state_db, address)
-            if utxo_address is not None:
-                cursor.execute(
-                    sql,
-                    {
-                        "address": utxo_address,
-                        "event_index": event["message_index"],
-                        "block_index": event["block_index"],
-                        "event": event["event"],
-                    },
-                )
 
 
 def update_all_expiration(state_db, event):

--- a/counterparty-core/counterpartycore/lib/api/dbbuilder.py
+++ b/counterparty-core/counterpartycore/lib/api/dbbuilder.py
@@ -208,6 +208,96 @@ def record_balances_copied_block(state_db):
         )
 
 
+def backfill_address_events(state_db):
+    """Re-derive the ``address_events`` rows the migration re-apply left behind.
+
+    ``MIGRATIONS_AFTER_ROLLBACK`` deliberately omits
+    ``0001.create_and_populate_address_events``: re-applying it would drop the
+    whole table and rebuild it from ``ledger_db.messages``, which loses the
+    UTXO-owner aliases that only the runtime path
+    (``apiwatcher.update_address_events``) adds, for any UTXO that no longer
+    holds a balance.
+
+    But ``0002`` *does* repopulate ``parsed_events`` from the entire Ledger
+    history, so the replay cursor lands on the Ledger tip. Anything the State
+    DB had not parsed yet -- and, after a rollback, everything
+    ``rollback_tables`` just deleted -- is then declared parsed while its
+    address associations are missing, and ``get_next_event_to_parse()`` never
+    comes back for it: ``/v2/addresses/<address>/events`` and ``/credits``
+    silently omit confirmed history until the State DB is rebuilt from scratch.
+
+    So close the gap here instead. Every address-bearing Ledger event with no
+    association at all is re-derived through the same resolver the watcher
+    uses -- which also repairs the holes older releases' refreshes left behind,
+    not just the one this run would have opened. Events that already have
+    associations are left alone, and that is what keeps this from double
+    counting: ``rollback_tables`` deletes whole blocks, so an event either kept
+    all of its rows or lost all of them.
+    """
+    # Imported here rather than at module scope: `apiwatcher` imports this
+    # module, so a top-level import would be circular.
+    # pylint: disable=import-outside-toplevel
+    from counterpartycore.lib.api import apiwatcher  # noqa: PLC0415
+
+    start_time = time.time()
+    cursor = state_db.cursor()
+
+    already_attached = (
+        cursor.execute(
+            "SELECT COUNT(*) AS count FROM pragma_database_list WHERE name = ?", ("ledger_db",)
+        ).fetchone()["count"]
+        > 0
+    )
+    if not already_attached:
+        cursor.execute("ATTACH DATABASE ? AS ledger_db", (config.DATABASE,))
+
+    event_names = list(apiwatcher.EVENTS_ADDRESS_FIELDS.keys())
+    placeholders = ", ".join(["?"] * len(event_names))
+
+    # Materialised first, and deliberately not streamed straight into the
+    # insert loop: SQLite leaves the result of a query undefined if the table
+    # it is reading -- here `address_events`, through the `NOT EXISTS` probe --
+    # is written to while the query is still open.
+    cursor.execute("DROP TABLE IF EXISTS temp.missing_address_events")
+    cursor.execute(
+        f"""
+        CREATE TEMPORARY TABLE missing_address_events AS
+        SELECT message_index FROM ledger_db.messages
+        WHERE event IN ({placeholders})
+          AND NOT EXISTS (
+              SELECT 1 FROM address_events WHERE event_index = messages.message_index
+          )
+        """,  # noqa S608 # nosec B608
+        event_names,
+    )
+    missing = cursor.execute(
+        "SELECT COUNT(*) AS count FROM temp.missing_address_events"
+    ).fetchone()["count"]
+
+    if missing > 0:
+        logger.info("Backfilling `address_events` for %s events...", missing)
+        backfill_cursor = state_db.cursor()
+        for event in backfill_cursor.execute("""
+            SELECT m.event, m.bindings, m.message_index, m.block_index
+            FROM temp.missing_address_events AS missed
+            JOIN ledger_db.messages AS m ON m.message_index = missed.message_index
+            ORDER BY m.message_index
+        """):
+            apiwatcher.update_address_events(state_db, event)
+        backfill_cursor.close()
+
+    cursor.execute("DROP TABLE temp.missing_address_events")
+    if not already_attached:
+        cursor.execute("DETACH DATABASE ledger_db")
+    cursor.close()
+
+    logger.info(
+        "Backfilled `address_events` for %s events in %.2f seconds",
+        missing,
+        time.time() - start_time,
+    )
+
+
 def rollback_state_db(state_db, block_index):
     """Roll the State DB back to ``block_index - 1``.
 
@@ -258,13 +348,19 @@ def full_rollback_state_db(state_db, block_index):
     start_time = time.time()
 
     with dbstatus.rebuilding(
-        "rollback", "pruning rolled back rows", total=2 * len(MIGRATIONS_AFTER_ROLLBACK)
+        "rollback", "pruning rolled back rows", total=2 * len(MIGRATIONS_AFTER_ROLLBACK) + 1
     ) as progress:
         with state_db:
             with log.Spinner("Rolling back State DB tables..."):
                 rollback_tables(state_db, block_index)
             with log.Spinner("Re-applying migrations..."):
                 reapply_migrations(state_db, MIGRATIONS_AFTER_ROLLBACK, progress=progress)
+            # `rollback_tables` deleted the address associations from
+            # `block_index` on and the re-apply above moved the replay cursor
+            # to the Ledger tip, so nothing would ever replay them.
+            progress.step("backfilling `address_events`", 2 * len(MIGRATIONS_AFTER_ROLLBACK) + 1)
+            with log.Spinner("Backfilling address events..."):
+                backfill_address_events(state_db)
             # Record the ledger_db block index to prevent double-counting of balances
             # during catch-up (see record_balances_copied_block docstring for details)
             record_balances_copied_block(state_db)
@@ -278,11 +374,17 @@ def refresh_state_db(state_db):
     start_time = time.time()
 
     with dbstatus.rebuilding(
-        "refresh", "re-applying migrations", total=2 * len(MIGRATIONS_AFTER_ROLLBACK)
+        "refresh", "re-applying migrations", total=2 * len(MIGRATIONS_AFTER_ROLLBACK) + 1
     ) as progress:
         with state_db:
             with log.Spinner("Re-applying migrations..."):
                 reapply_migrations(state_db, MIGRATIONS_AFTER_ROLLBACK, progress=progress)
+            # The re-apply above moved the replay cursor to the Ledger tip; any
+            # event the State DB had not parsed yet is now declared parsed, so
+            # its address associations have to be derived here or never.
+            progress.step("backfilling `address_events`", 2 * len(MIGRATIONS_AFTER_ROLLBACK) + 1)
+            with log.Spinner("Backfilling address events..."):
+                backfill_address_events(state_db)
             # Record the ledger_db block index to prevent double-counting of balances
             # during catch-up (see record_balances_copied_block docstring for details)
             record_balances_copied_block(state_db)

--- a/counterparty-core/counterpartycore/lib/api/dbbuilder.py
+++ b/counterparty-core/counterpartycore/lib/api/dbbuilder.py
@@ -7,7 +7,7 @@ import time
 from yoyo.migrations import topological_sort
 
 from counterpartycore.lib import config
-from counterpartycore.lib.api import dbstatus, staterollback
+from counterpartycore.lib.api import addressevents, dbstatus, staterollback
 from counterpartycore.lib.cli import log
 from counterpartycore.lib.utils import database
 
@@ -215,7 +215,7 @@ def backfill_address_events(state_db):
     ``0001.create_and_populate_address_events``: re-applying it would drop the
     whole table and rebuild it from ``ledger_db.messages``, which loses the
     UTXO-owner aliases that only the runtime path
-    (``apiwatcher.update_address_events``) adds, for any UTXO that no longer
+    (``addressevents.update_address_events``) adds, for any UTXO that no longer
     holds a balance.
 
     But ``0002`` *does* repopulate ``parsed_events`` from the entire Ledger
@@ -234,11 +234,6 @@ def backfill_address_events(state_db):
     counting: ``rollback_tables`` deletes whole blocks, so an event either kept
     all of its rows or lost all of them.
     """
-    # Imported here rather than at module scope: `apiwatcher` imports this
-    # module, so a top-level import would be circular.
-    # pylint: disable=import-outside-toplevel
-    from counterpartycore.lib.api import apiwatcher  # noqa: PLC0415
-
     start_time = time.time()
     cursor = state_db.cursor()
 
@@ -251,7 +246,7 @@ def backfill_address_events(state_db):
     if not already_attached:
         cursor.execute("ATTACH DATABASE ? AS ledger_db", (config.DATABASE,))
 
-    event_names = list(apiwatcher.EVENTS_ADDRESS_FIELDS.keys())
+    event_names = list(addressevents.EVENTS_ADDRESS_FIELDS.keys())
     placeholders = ", ".join(["?"] * len(event_names))
 
     # Materialised first, and deliberately not streamed straight into the
@@ -283,7 +278,7 @@ def backfill_address_events(state_db):
             JOIN ledger_db.messages AS m ON m.message_index = missed.message_index
             ORDER BY m.message_index
         """):
-            apiwatcher.update_address_events(state_db, event)
+            addressevents.update_address_events(state_db, event)
         backfill_cursor.close()
 
     cursor.execute("DROP TABLE temp.missing_address_events")

--- a/counterparty-core/counterpartycore/lib/api/healthz_server.py
+++ b/counterparty-core/counterpartycore/lib/api/healthz_server.py
@@ -572,11 +572,22 @@ class HealthCheckServer:
     a failure to bind must never reduce API availability (the legacy in-API ``/healthz`` remains).
     """
 
-    def __init__(self, host, port, dispatcher=None, saturation_grace=None, stop_event=None):
+    def __init__(
+        self,
+        host,
+        port,
+        dispatcher=None,
+        saturation_grace=None,
+        stop_event=None,
+        serving_provider=None,
+    ):
         self.host = host
         self.port = port
         self.dispatcher = dispatcher
         self.saturation_grace = saturation_grace
+        # Readiness stays false until this reports that the public API can
+        # serve requests; see `HealthSampler.__init__` (issue #3504).
+        self.serving_provider = serving_provider
         # stop_event is accepted for symmetry with the other server threads; the health server
         # is a daemon and is torn down explicitly via stop(), so it is not otherwise used.
         self.stop_event = stop_event
@@ -606,7 +617,9 @@ class HealthCheckServer:
         try:
             _instrument_dispatcher(self.dispatcher)
             self.sampler = HealthSampler(
-                dispatcher=self.dispatcher, saturation_grace=self.saturation_grace
+                dispatcher=self.dispatcher,
+                saturation_grace=self.saturation_grace,
+                serving_provider=self.serving_provider,
             )
             self.sampler.start()
 

--- a/counterparty-core/counterpartycore/lib/api/healthz_server.py
+++ b/counterparty-core/counterpartycore/lib/api/healthz_server.py
@@ -118,6 +118,7 @@ class HealthSampler(threading.Thread):
         backend_height_provider=None,
         block_time_provider=None,
         api_only_provider=None,
+        serving_provider=None,
     ):
         super().__init__(name="HealthSampler", daemon=True)
         self.dispatcher = dispatcher
@@ -159,6 +160,16 @@ class HealthSampler(threading.Thread):
         self._api_only_provider = api_only_provider or (
             lambda: bool(getattr(config, "API_ONLY", False))
         )
+        # The listener is started *before* State DB maintenance and WSGI
+        # construction, so that probes get an answer during the tens of minutes
+        # a mainnet rebuild takes (#3460). Readiness must therefore be told
+        # separately when the public API is actually able to serve: without it,
+        # the window between the end of maintenance and `wsgi_server.run()` --
+        # watcher startup, Flask app construction, binding the socket -- reports
+        # ready, and an orchestrator routes traffic to a pod that answers
+        # nothing. Defaults to "serving", so a sampler constructed without the
+        # lifecycle signal (the tests, and any embedder) behaves as before.
+        self._serving_provider = serving_provider or (lambda: True)
 
         self.stop_event = threading.Event()
         self._snapshot = HealthSnapshot(
@@ -264,6 +275,12 @@ class HealthSampler(threading.Thread):
         if rebuild is not None:
             caught_up, lag, ledger_reason = False, None, "rebuilding"
             backend_height, last_parsed = self._backend_height_provider(), None
+        elif not self._is_serving():
+            # Maintenance is over but the public API is not up yet. Liveness
+            # stays green -- the process is healthy and making progress -- while
+            # readiness keeps traffic away until the WSGI server is running.
+            caught_up, lag, ledger_reason = False, None, "starting"
+            backend_height, last_parsed = self._backend_height_provider(), None
         else:
             caught_up, lag, ledger_reason, backend_height, last_parsed = self._compute_caught_up(
                 now
@@ -295,6 +312,15 @@ class HealthSampler(threading.Thread):
             rebuild=rebuild,
         )
         self._maybe_log_worker_stats(now, workers, saturation_seconds)
+
+    def _is_serving(self):
+        try:
+            return bool(self._serving_provider())
+        except Exception as e:  # pylint: disable=broad-except
+            # A lifecycle signal that cannot be read is not evidence of
+            # readiness; keep shedding rather than guess.
+            logger.debug("healthz: could not read the serving state: %s", e)
+            return False
 
     def _sample_workers(self, now):
         if self.dispatcher is None:

--- a/counterparty-core/counterpartycore/lib/api/migrations/0001.create_and_populate_address_events.py
+++ b/counterparty-core/counterpartycore/lib/api/migrations/0001.create_and_populate_address_events.py
@@ -6,7 +6,7 @@ import logging
 import time
 
 from counterpartycore.lib import config
-from counterpartycore.lib.api.apiwatcher import EVENTS_ADDRESS_FIELDS
+from counterpartycore.lib.api.addressevents import EVENTS_ADDRESS_FIELDS
 from yoyo import step
 
 logger = logging.getLogger(config.LOGGER_NAME)

--- a/counterparty-core/counterpartycore/lib/parser/mempool.py
+++ b/counterparty-core/counterpartycore/lib/parser/mempool.py
@@ -3,7 +3,7 @@ import logging
 import time
 
 from counterpartycore.lib import backend, config, exceptions, ledger
-from counterpartycore.lib.api.apiwatcher import EVENTS_ADDRESS_FIELDS
+from counterpartycore.lib.api.addressevents import EVENTS_ADDRESS_FIELDS
 from counterpartycore.lib.ledger.currentstate import CurrentState
 from counterpartycore.lib.parser import blocks, deserialize
 from counterpartycore.lib.utils import database, hashcodec

--- a/counterparty-core/counterpartycore/test/integrations/dockercompose_test.py
+++ b/counterparty-core/counterpartycore/test/integrations/dockercompose_test.py
@@ -12,6 +12,9 @@ from counterpartycore.lib import config
 CURR_DIR = os.path.dirname(os.path.realpath(__file__))
 BASE_DIR = os.path.join(CURR_DIR, "../../../../")
 
+# The published image this scenario upgrades from.
+PREVIOUS_RELEASE = "11.0.4"
+
 
 def print_docker_output(out, printed_line_count):
     unprinted_lines = out.getvalue().splitlines()[printed_line_count:]
@@ -54,9 +57,20 @@ def test_docker_compose():
 
         with open(os.path.join(BASE_DIR, "docker-compose.yml"), "r") as f:
             docker_compose_file = f.read()
+        # This scenario deliberately starts an *older* published image to prove
+        # the Compose file still works for an operator upgrading into this
+        # release. That only means anything if the file actually pins the
+        # release under test: a stale tag left over from the previous release
+        # used to make the replacement below a silent no-op, and the test then
+        # exercised an image nobody was reviewing (issue #3506).
+        current_image = f"image: counterparty/counterparty:v{config.VERSION_STRING}"
+        assert current_image in docker_compose_file, (
+            f"docker-compose.yml does not pin {current_image}; "
+            "update the image tag as part of release preparation"
+        )
         docker_compose_file = docker_compose_file.replace(
-            f"image: counterparty/counterparty:v{config.VERSION_STRING}",
-            "image: counterparty/counterparty:v11.0.4",
+            current_image,
+            f"image: counterparty/counterparty:v{PREVIOUS_RELEASE}",
         )
         with open(os.path.join(BASE_DIR, "docker-compose-test.yml"), "w") as f:
             f.write(docker_compose_file)

--- a/counterparty-core/counterpartycore/test/integrations/regtest/genapidoc.py
+++ b/counterparty-core/counterpartycore/test/integrations/regtest/genapidoc.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import re
@@ -253,6 +254,30 @@ def gen_tags(db):
     return tags
 
 
+# `apiserver.handle_route` turns `ComposeConflictError` into a 409, but the
+# generator only ever observes the happy path, so nothing here can discover
+# that response by calling the route. Declare it for the handlers that raise
+# it -- and only those: `compose_fairmint` and the other compose routes do not
+# go through `_compose_with_pending_asset_guard`.
+CONFLICT_RESPONSE = {
+    "description": "A parsed pending asset change conflicts with this composition.",
+    "content": {
+        "application/json": {
+            "schema": {
+                "type": "object",
+                "required": ["error"],
+                "properties": {"error": {"type": "string"}},
+            }
+        }
+    },
+}
+
+ERROR_RESPONSES = {
+    "compose_issuance": {"409": CONFLICT_RESPONSE},
+    "compose_fairminter": {"409": CONFLICT_RESPONSE},
+}
+
+
 def gen_paths(db):
     paths = {}
     operation_ids = set()
@@ -311,7 +336,8 @@ def gen_paths(db):
             "description": route["description"].strip(),
             "tags": [group.capitalize()],
             "parameters": parameters,
-            "responses": {"200": {"description": "Successful response"}},
+            "responses": {"200": {"description": "Successful response"}}
+            | copy.deepcopy(ERROR_RESPONSES.get(route["function"].__name__, {})),
         }
 
         if (

--- a/counterparty-core/counterpartycore/test/units/api/addressevents_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/addressevents_test.py
@@ -1,0 +1,102 @@
+#
+# file: counterpartycore/test/units/api/addressevents_test.py
+#
+# `address_events` is derived by the watcher, by migration 0001 and by
+# `dbbuilder.backfill_address_events()`. All three go through the rules in
+# `api/addressevents.py`, so the API answers the same whichever built the
+# State DB -- including the UTXO-owner alias, which only this path adds.
+#
+import json
+
+from counterpartycore.lib.api import addressevents
+
+
+def a_utxo_balance(state_db):
+    return state_db.execute(
+        "SELECT utxo, utxo_address FROM balances WHERE utxo IS NOT NULL LIMIT 1"
+    ).fetchone()
+
+
+def credit_event(address, message_index=10**9, block_index=999):
+    return {
+        "event": "CREDIT",
+        "message_index": message_index,
+        "block_index": block_index,
+        "bindings": json.dumps({"address": address, "asset": "XCP", "quantity": 1}),
+    }
+
+
+def rows_for(state_db, message_index):
+    return {
+        row["address"]
+        for row in state_db.execute(
+            "SELECT address FROM address_events WHERE event_index = ?", (message_index,)
+        ).fetchall()
+    }
+
+
+def test_search_address_from_utxo_finds_the_owner(state_db):
+    balance = a_utxo_balance(state_db)
+    assert (
+        addressevents.search_address_from_utxo(state_db, balance["utxo"])
+        == (balance["utxo_address"])
+    )
+
+
+def test_search_address_from_utxo_returns_none_for_an_unknown_utxo(state_db):
+    assert addressevents.search_address_from_utxo(state_db, "00" * 32 + ":7") is None
+
+
+def test_utxo_address_is_recorded_alongside_the_utxo(state_db):
+    """A balance held by a UTXO is credited to the UTXO, but the address that
+    owns it has to find the event too."""
+    balance = a_utxo_balance(state_db)
+    event = credit_event(balance["utxo"])
+
+    addressevents.update_address_events(state_db, event)
+
+    assert rows_for(state_db, event["message_index"]) == {
+        balance["utxo"],
+        balance["utxo_address"],
+    }
+
+
+def test_unowned_utxo_records_only_the_utxo(state_db):
+    unknown_utxo = "00" * 32 + ":7"
+    event = credit_event(unknown_utxo)
+
+    addressevents.update_address_events(state_db, event)
+
+    assert rows_for(state_db, event["message_index"]) == {unknown_utxo}
+
+
+def test_plain_address_is_not_looked_up_as_a_utxo(state_db):
+    event = credit_event("mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc")
+
+    addressevents.update_address_events(state_db, event)
+
+    assert rows_for(state_db, event["message_index"]) == {"mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc"}
+
+
+def test_fields_absent_from_the_bindings_are_skipped(state_db):
+    # `NEW_TRANSACTION` lists both `source` and `destination`; a transaction
+    # without a destination must not record a `None` address.
+    event = {
+        "event": "NEW_TRANSACTION",
+        "message_index": 10**9 + 1,
+        "block_index": 999,
+        "bindings": json.dumps({"source": "mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc"}),
+    }
+
+    addressevents.update_address_events(state_db, event)
+
+    assert rows_for(state_db, event["message_index"]) == {"mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc"}
+
+
+def test_unknown_event_records_nothing(state_db):
+    event = credit_event("mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc")
+    event["event"] = "NOT_AN_EVENT"
+
+    addressevents.update_address_events(state_db, event)
+
+    assert rows_for(state_db, event["message_index"]) == set()

--- a/counterparty-core/counterpartycore/test/units/api/apiserver_lifecycle_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiserver_lifecycle_test.py
@@ -1,0 +1,113 @@
+"""Exercise API lifecycle state without starting threads, listeners or databases."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from counterpartycore.lib.api import apiserver, healthz_server
+
+
+@pytest.mark.parametrize("health_enabled", [True, False], ids=["health", "no-health"])
+@pytest.mark.parametrize(
+    "exit_path, expected_state, exit_code",
+    [
+        pytest.param("owner-return", 2, None, id="owner-returns"),
+        pytest.param("owner-exit", 2, 0, id="owner-exits"),
+        pytest.param("worker-exit", 1, 0, id="worker-retires"),
+        pytest.param("startup-error", 2, 1, id="startup-fails"),
+    ],
+)
+def test_run_apiserver_lifecycle_state(
+    monkeypatch, health_enabled, exit_path, expected_state, exit_code
+):
+    ready = SimpleNamespace(value=0)
+    process = SimpleNamespace(pid=100)
+    sampler = None
+
+    # Replace only apiserver's view of the PID; no fork or process-wide OS patch.
+    monkeypatch.setattr(apiserver, "os", SimpleNamespace(getpid=lambda: process.pid))
+    monkeypatch.setattr(apiserver.signal, "signal", Mock())
+    for name in (
+        "logger",
+        "sentry",
+        "initialise_log_and_config",
+        "ConnectionPoolMonitor",
+        "database",
+        "check_database_version",
+        "init_flask_app",
+        "CurrentState",
+        "ParentProcessChecker",
+        "LedgerDBConnectionPool",
+        "StateDBConnectionPool",
+    ):
+        monkeypatch.setattr(apiserver, name, Mock())
+    monkeypatch.setattr(apiserver.apiwatcher, "APIWatcher", Mock())
+    monkeypatch.setattr(apiserver.apiwatcher, "watcher_has_failed", lambda: False)
+    for name, value in {
+        "MEMORY_PROFILE": False,
+        "NO_HEALTHZ_SERVER": not health_enabled,
+        "API_HOST": "127.0.0.1",
+        "HEALTHZ_PORT": 0,
+        "STATE_DATABASE": "unused-state.db",
+    }.items():
+        monkeypatch.setattr(apiserver.config, name, value, raising=False)
+
+    def make_health_server(**kwargs):
+        nonlocal sampler
+        # Use the real sampler and the serving callback supplied by run_apiserver.
+        # API-only mode isolates readiness from backend height and block age.
+        sampler = healthz_server.HealthSampler(
+            last_parsed_provider=lambda: 100,
+            backend_height_provider=lambda: 0,
+            block_time_provider=lambda: None,
+            api_only_provider=lambda: True,
+            serving_provider=kwargs["serving_provider"],
+        )
+        sampler._tick()
+        assert ready.value == 0
+        assert sampler.current_snapshot().ready is False
+        assert sampler.current_snapshot().reason == "starting"
+        return Mock()
+
+    health_factory = Mock(side_effect=make_health_server)
+    monkeypatch.setattr(apiserver.healthz_server, "HealthCheckServer", health_factory)
+
+    def run_wsgi(_ready, _backend_height):
+        assert ready.value == 1
+        if sampler is not None:
+            sampler._tick()
+            assert sampler.current_snapshot().ready is True
+        if exit_path == "worker-exit":
+            # Gunicorn forks inside run(), then a retiring worker raises SystemExit
+            # through the inherited run_apiserver() frame while the owner stays up.
+            process.pid += 1
+        if exit_path in ("owner-exit", "worker-exit"):
+            raise SystemExit(0)
+
+    wsgi_server = Mock()
+    wsgi_server.run.side_effect = run_wsgi
+    wsgi_factory = Mock(return_value=wsgi_server)
+    if exit_path == "startup-error":
+        wsgi_factory.side_effect = OSError("could not bind API socket")
+    monkeypatch.setattr(apiserver.wsgi, "WSGIApplication", wsgi_factory)
+
+    args = {"rebuild_state_db": False, "refresh_state_db": False}
+    call_args = (args, ready, Mock(), SimpleNamespace(value=0), 99, None)
+    if exit_code is None:
+        apiserver.run_apiserver(*call_args)
+    else:
+        with pytest.raises(SystemExit) as exc:
+            apiserver.run_apiserver(*call_args)
+        assert exc.value.code == exit_code
+
+    assert ready.value == expected_state
+    if health_enabled:
+        sampler._tick()
+        assert sampler.current_snapshot().ready is (expected_state == 1)
+        assert sampler.current_snapshot().reason == (None if expected_state == 1 else "starting")
+    else:
+        health_factory.assert_not_called()
+    if exit_path == "startup-error":
+        wsgi_server.run.assert_not_called()
+    else:
+        wsgi_server.run.assert_called_once()

--- a/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiserver_test.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import os
 import threading
@@ -6,7 +7,14 @@ from unittest.mock import Mock, call, patch
 
 import pytest
 from counterpartycore.lib import config, exceptions, ledger
-from counterpartycore.lib.api import apiserver, apiwatcher, blockcache, composer, queries
+from counterpartycore.lib.api import (
+    apiserver,
+    apiwatcher,
+    blockcache,
+    compose,
+    composer,
+    queries,
+)
 from counterpartycore.lib.api.routes import ALL_ROUTES, ROUTES, get_routes
 from counterpartycore.lib.messages import dispense, dividend, sweep
 from counterpartycore.lib.parser import blocks
@@ -135,6 +143,52 @@ def test_apiserver_openapi_spec(apiv2_client):
 def test_openapi_file_is_available_to_the_running_package():
     assert os.path.isfile(apiserver.OPENAPI_FILEPATH)
     assert apiserver.OPENAPI_FILEPATH.endswith("openapi.json")
+
+
+def test_openapi_documents_the_composition_conflict():
+    """Regression for #3507.
+
+    `_compose_with_pending_asset_guard` raises `ComposeConflictError`, which
+    `handle_route` turns into a 409. The generator only ever sees the happy
+    path, so the declaration comes from `genapidoc.ERROR_RESPONSES`; without
+    it the contract advertised only 200 and schema-driven clients had no way
+    to discover the response.
+    """
+    with open(apiserver.OPENAPI_FILEPATH, "r", encoding="utf-8") as f:
+        spec = json.load(f)
+
+    guarded = {
+        "compose_issuance": "/v2/addresses/{address}/compose/issuance",
+        "compose_fairminter": "/v2/addresses/{address}/compose/fairminter",
+    }
+    declared = set()
+    for path, operations in spec["paths"].items():
+        for operation in operations.values():
+            if "409" in operation.get("responses", {}):
+                declared.add(operation["operationId"])
+                assert path == guarded[operation["operationId"]]
+                schema = operation["responses"]["409"]["content"]["application/json"]["schema"]
+                assert schema["required"] == ["error"]
+                assert schema["properties"]["error"] == {"type": "string"}
+
+    # Exactly the guarded operations: `compose_fairmint` and the other compose
+    # routes do not call the guard and must not advertise a 409.
+    assert declared == set(guarded)
+
+
+def test_compose_conflict_guard_callers_are_documented():
+    """The 409 declarations are keyed by handler name; keep them in step with
+    the handlers that can actually raise the conflict."""
+    source = inspect.getsource(compose)
+    callers = set()
+    current = None
+    for line in source.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("def "):
+            current = stripped[len("def ") :].split("(")[0]
+        if "_compose_with_pending_asset_guard(" in stripped and not stripped.startswith("def "):
+            callers.add(current)
+    assert callers == {"compose_issuance", "compose_fairminter"}
 
 
 def test_openapi_prefers_the_packaged_resource(monkeypatch, tmp_path):

--- a/counterparty-core/counterpartycore/test/units/api/apiwatcher_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiwatcher_test.py
@@ -17,7 +17,7 @@ import time
 from unittest.mock import MagicMock
 
 import pytest
-from counterpartycore.lib.api import apiwatcher
+from counterpartycore.lib.api import addressevents, apiwatcher
 
 
 def test_api_watcher_stop_interrupts_sqlite_connections():
@@ -267,7 +267,7 @@ def test_detach_from_utxo_field_name_correct():
     """DETACH_FROM_UTXO must reference `source_address` (not the legacy typo
     `sourc_address`); the streamed handler keys off this dict and silently
     dropped the source row for every detach until the typo was fixed."""
-    fields = apiwatcher.EVENTS_ADDRESS_FIELDS["DETACH_FROM_UTXO"]
+    fields = addressevents.EVENTS_ADDRESS_FIELDS["DETACH_FROM_UTXO"]
     assert "source_address" in fields
     assert "sourc_address" not in fields
     assert "destination" in fields
@@ -460,7 +460,7 @@ def test_pool_events_in_events_address_fields():
         "NEW_POOL_WITHDRAWAL",
         "POOL_MATCH",
     ):
-        assert event in apiwatcher.EVENTS_ADDRESS_FIELDS
+        assert event in addressevents.EVENTS_ADDRESS_FIELDS
 
 
 def test_pool_tables_in_state_db_tables():
@@ -516,7 +516,7 @@ def test_events_address_fields_keys_are_lowercase_underscore():
     look like a real binding key (lowercase + underscores). This would
     have caught the original `sourc_address` typo."""
     pattern = re.compile(r"^[a-z][a-z0-9_]*$")
-    for event_name, fields in apiwatcher.EVENTS_ADDRESS_FIELDS.items():
+    for event_name, fields in addressevents.EVENTS_ADDRESS_FIELDS.items():
         for field in fields:
             assert pattern.match(field), f"{event_name} declares a malformed field name {field!r}"
 

--- a/counterparty-core/counterpartycore/test/units/api/dbbuilder_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/dbbuilder_test.py
@@ -1,7 +1,7 @@
 import json
 
 from counterpartycore.lib.api import dbbuilder
-from counterpartycore.lib.api.apiwatcher import EVENTS_ADDRESS_FIELDS
+from counterpartycore.lib.api.addressevents import EVENTS_ADDRESS_FIELDS
 from counterpartycore.lib.utils import hashcodec
 from counterpartycore.lib.utils.database import (
     ADDRESS_INDEX_COLUMN_NAMES,

--- a/counterparty-core/counterpartycore/test/units/api/dbbuilder_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/dbbuilder_test.py
@@ -1,4 +1,7 @@
+import json
+
 from counterpartycore.lib.api import dbbuilder
+from counterpartycore.lib.api.apiwatcher import EVENTS_ADDRESS_FIELDS
 from counterpartycore.lib.utils import hashcodec
 from counterpartycore.lib.utils.database import (
     ADDRESS_INDEX_COLUMN_NAMES,
@@ -507,3 +510,109 @@ def test_orders_info_join_uses_assets_info_index(state_db):
         d for d in details if d.startswith("SCAN") and ("get_assets" in d or "give_assets" in d)
     ]
     assert not scans, f"orders_info full-scans assets_info instead of an index seek: {details}"
+
+
+# =============================================================================
+# Address history completion after a refresh / full rollback (#3503)
+# =============================================================================
+
+
+ADDRESS_EVENT_ROWS_SQL = "SELECT address, event_index, block_index, event FROM address_events"
+
+
+def address_event_rows(state_db):
+    return {
+        (r["address"], r["event_index"], r["block_index"], r["event"])
+        for r in state_db.execute(ADDRESS_EVENT_ROWS_SQL).fetchall()
+    }
+
+
+def uncovered_event_indexes(state_db, ledger_db):
+    """Ledger events that should have address associations but have none."""
+    covered = {r["event_index"] for r in state_db.execute(ADDRESS_EVENT_ROWS_SQL).fetchall()}
+    uncovered = set()
+    for message in ledger_db.execute(
+        "SELECT event, bindings, message_index FROM messages ORDER BY message_index"
+    ).fetchall():
+        fields = EVENTS_ADDRESS_FIELDS.get(message["event"])
+        if not fields:
+            continue
+        bindings = json.loads(message["bindings"])
+        if not any(field in bindings for field in fields):
+            continue
+        if message["message_index"] not in covered:
+            uncovered.add(message["message_index"])
+    return uncovered
+
+
+def test_backfill_address_events_is_a_no_op_on_a_complete_table(state_db, ledger_db):
+    before = address_event_rows(state_db)
+    dbbuilder.backfill_address_events(state_db)
+    # Nothing is missing, so nothing is re-derived: in particular no row is
+    # inserted a second time.
+    assert address_event_rows(state_db) == before
+
+
+def test_backfill_address_events_repairs_deleted_associations(state_db, ledger_db):
+    before = address_event_rows(state_db)
+    cutoff = state_db.execute(
+        "SELECT MIN(block_index) AS block_index FROM address_events"
+    ).fetchone()["block_index"]
+    state_db.execute("DELETE FROM address_events WHERE block_index >= ?", (cutoff,))
+    assert address_event_rows(state_db) != before
+
+    dbbuilder.backfill_address_events(state_db)
+
+    # The runtime resolver also records UTXO-owner aliases that migration 0001
+    # does not, so it may produce a superset -- but never less.
+    assert before <= address_event_rows(state_db)
+    assert uncovered_event_indexes(state_db, ledger_db) == set()
+
+
+def test_refresh_state_db_keeps_address_history_of_unparsed_events(state_db, ledger_db):
+    """Regression for #3503.
+
+    A State DB that is behind the Ledger used to lose the address history of
+    everything in between: migration 0002 repopulates `parsed_events` from the
+    whole Ledger, moving the replay cursor to the tip, while `address_events`
+    was neither rebuilt nor replayed.
+    """
+    before = address_event_rows(state_db)
+    tip = ledger_db.execute("SELECT MAX(message_index) AS m FROM messages").fetchone()["m"]
+    lagging_cursor = tip // 2
+
+    # Simulate a State DB whose watcher has not caught up with the Ledger.
+    state_db.execute("DELETE FROM parsed_events WHERE event_index > ?", (lagging_cursor,))
+    state_db.execute("DELETE FROM address_events WHERE event_index > ?", (lagging_cursor,))
+    assert uncovered_event_indexes(state_db, ledger_db) != set()
+
+    dbbuilder.refresh_state_db(state_db)
+
+    # The refresh declared everything up to the tip parsed...
+    assert (
+        state_db.execute("SELECT MAX(event_index) AS m FROM parsed_events").fetchone()["m"] == tip
+    )
+    # ...so the address history has to be complete up to the tip as well.
+    assert uncovered_event_indexes(state_db, ledger_db) == set()
+    assert before <= address_event_rows(state_db)
+
+
+def test_full_rollback_state_db_keeps_address_history(state_db, ledger_db):
+    """Regression for #3503, full-rollback path.
+
+    `rollback_tables` prunes `address_events` from the rollback point while the
+    re-applied migration 0002 moves the replay cursor back up to the Ledger
+    tip, which still holds the rolled back blocks (a reorg replaces them, and
+    an `UPGRADE_ACTIONS` rollback does not touch the Ledger at all).
+    """
+    before = address_event_rows(state_db)
+    # Deep enough to prune blocks that actually carry address associations.
+    rollback_to = state_db.execute(
+        "SELECT MIN(block_index) + (MAX(block_index) - MIN(block_index)) / 2 AS b "
+        "FROM address_events"
+    ).fetchone()["b"]
+
+    dbbuilder.full_rollback_state_db(state_db, block_index=rollback_to)
+
+    assert uncovered_event_indexes(state_db, ledger_db) == set()
+    assert before <= address_event_rows(state_db)

--- a/counterparty-core/counterpartycore/test/units/api/healthz_server_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/healthz_server_test.py
@@ -6,6 +6,7 @@ providers and a fake task dispatcher, and the HTTP layer is exercised against a 
 """
 
 import http.client
+import inspect
 import json
 import socket
 import threading
@@ -426,6 +427,40 @@ def test_bind_failure_is_non_fatal():
         server.stop()  # also must not raise
     finally:
         sock.close()
+
+
+def test_server_accepts_the_apiserver_construction_kwargs():
+    """`run_apiserver` is the only caller and is not covered by the unit suite,
+    so nothing here would otherwise catch a keyword it passes that
+    `HealthCheckServer` does not accept -- the constructor raises inside the
+    API process and the node never becomes ready."""
+    signature = inspect.signature(HealthCheckServer.__init__)
+    assert {
+        "host",
+        "port",
+        "saturation_grace",
+        "stop_event",
+        "serving_provider",
+    } <= set(signature.parameters)
+
+
+def test_server_hands_the_serving_signal_to_its_sampler():
+    server = HealthCheckServer(
+        host="127.0.0.1",
+        port=0,
+        dispatcher=None,
+        saturation_grace=5,
+        serving_provider=lambda: False,
+    )
+    try:
+        server.start()
+        assert server.sampler is not None
+        server.sampler._tick()  # pylint: disable=protected-access
+        snap = server.sampler.current_snapshot()
+        assert snap.ready is False
+        assert snap.reason == "starting"
+    finally:
+        server.stop()
 
 
 def test_stop_reserves_budget_for_the_serve_thread(monkeypatch):

--- a/counterparty-core/counterpartycore/test/units/api/healthz_server_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/healthz_server_test.py
@@ -47,6 +47,7 @@ def make_sampler(
     block_time=None,
     api_only=False,
     saturation_grace=5,
+    serving=True,
 ):
     return HealthSampler(
         dispatcher=dispatcher,
@@ -55,6 +56,7 @@ def make_sampler(
         backend_height_provider=lambda: backend_height,
         block_time_provider=lambda: block_time,
         api_only_provider=lambda: api_only,
+        serving_provider=lambda: serving,
     )
 
 
@@ -104,6 +106,66 @@ def test_api_only_skips_lag_axis():
     assert snap.ready is True
     assert snap.reason is None
     assert snap.backend_height is None
+
+
+# --------------------------------------------------------------------------------------------
+# Sampler: service lifecycle axis (issue #3504)
+# --------------------------------------------------------------------------------------------
+
+
+def test_not_ready_before_the_public_api_serves():
+    # The listener starts before WSGI construction, so a caught-up ledger is
+    # not on its own evidence that requests can be answered.
+    sampler = make_sampler(backend_height=100, last_parsed=100, serving=False)
+    sampler._tick()
+    snap = sampler.current_snapshot()
+    assert snap.ready is False
+    assert snap.reason == "starting"
+
+
+def test_api_only_does_not_bypass_the_lifecycle_axis():
+    # `--api-only` skips the backend-lag comparison, not service initialization.
+    sampler = make_sampler(api_only=True, backend_height=0, last_parsed=999, serving=False)
+    sampler._tick()
+    snap = sampler.current_snapshot()
+    assert snap.ready is False
+    assert snap.reason == "starting"
+
+
+def test_ready_once_the_public_api_serves():
+    sampler = make_sampler(backend_height=100, last_parsed=100, serving=False)
+    sampler._tick()
+    assert sampler.current_snapshot().ready is False
+
+    sampler._serving_provider = lambda: True
+    sampler._tick()
+    assert sampler.current_snapshot().ready is True
+
+
+def test_unreadable_serving_signal_sheds():
+    def boom():
+        raise RuntimeError("shared value gone")
+
+    sampler = make_sampler(backend_height=100, last_parsed=100)
+    sampler._serving_provider = boom
+    sampler._tick()
+    assert sampler.current_snapshot().ready is False
+    assert sampler.current_snapshot().reason == "starting"
+
+
+def test_liveness_stays_available_while_starting():
+    # Early liveness is the whole point of starting the listener first: a probe
+    # must not kill a pod that is still coming up.
+    sampler = make_sampler(backend_height=100, last_parsed=100, serving=False)
+    sampler._tick()
+    fx = _HttpServerFixture(sampler)
+    try:
+        assert fx.get("/healthz/live")[0] == 200
+        code, body = fx.get("/healthz/ready")
+        assert code == 503
+        assert body["reason"] == "starting"
+    finally:
+        fx.close()
 
 
 # --------------------------------------------------------------------------------------------

--- a/counterparty-core/counterpartycore/test/units/packaging_test.py
+++ b/counterparty-core/counterpartycore/test/units/packaging_test.py
@@ -1,0 +1,60 @@
+#
+# file: counterpartycore/test/units/packaging_test.py
+#
+# The OpenAPI document is generated at the repository root and shipped inside
+# the package. `hatch_build.py` resolves it from whichever layout the build
+# runs in; a plain `force-include` of `../openapi.json` could not, and made
+# `pip wheel` on a fresh sdist fail with `Forced include not found`.
+#
+import importlib.util
+import os
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
+PROJECT_ROOT = os.path.join(REPO_ROOT, "counterparty-core")
+
+
+def load_hatch_build():
+    # Imported by path: the build hook lives beside `pyproject.toml`, outside
+    # the importable package.
+    pytest.importorskip("hatchling", reason="build backend not installed in this environment")
+    path = os.path.join(PROJECT_ROOT, "hatch_build.py")
+    spec = importlib.util.spec_from_file_location("counterparty_hatch_build", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_pyproject_does_not_force_include_a_parent_path():
+    with open(os.path.join(PROJECT_ROOT, "pyproject.toml"), "r", encoding="utf-8") as f:
+        pyproject = f.read()
+    # A wheel force-include reaching outside the project root is unresolvable
+    # from an extracted sdist, where no parent checkout exists.
+    assert '"../openapi.json"' not in pyproject
+    assert "[tool.hatch.build.hooks.custom]" in pyproject
+
+
+def test_openapi_resolves_from_the_repository_layout():
+    hatch_build = load_hatch_build()
+    assert hatch_build.resolve_openapi_source(PROJECT_ROOT) == os.path.join(
+        REPO_ROOT, "openapi.json"
+    )
+
+
+def test_openapi_resolves_from_an_extracted_sdist(tmp_path):
+    hatch_build = load_hatch_build()
+    root = tmp_path / "counterparty_core-0.0.0"
+    (root / "counterpartycore").mkdir(parents=True)
+    packaged = root / "counterpartycore" / "openapi.json"
+    packaged.write_text("{}", encoding="utf-8")
+
+    # No neighbouring repository file: the archive-local copy is the only input.
+    assert hatch_build.resolve_openapi_source(str(root)) == str(packaged)
+
+
+def test_openapi_absent_is_not_fatal(tmp_path):
+    hatch_build = load_hatch_build()
+    root = tmp_path / "project"
+    root.mkdir()
+    assert hatch_build.resolve_openapi_source(str(root)) is None

--- a/counterparty-core/counterpartycore/test/units/parser/mempool/mempool_complex_test.py
+++ b/counterparty-core/counterpartycore/test/units/parser/mempool/mempool_complex_test.py
@@ -4,7 +4,7 @@ import json
 import counterpartycore.lib.parser.mempool as mempool_module
 import pytest
 from counterpartycore.lib import config
-from counterpartycore.lib.api import apiwatcher
+from counterpartycore.lib.api import addressevents
 
 
 @pytest.mark.parametrize(
@@ -78,9 +78,9 @@ def test_parse_mempool_transactions_with_various_events(
     mock_ledger_blocks.return_value = None
 
     # Mock pour EVENTS_ADDRESS_FIELDS si l'événement est 'send'
-    original_events_address_fields = getattr(apiwatcher, "EVENTS_ADDRESS_FIELDS", {})
+    original_events_address_fields = getattr(addressevents, "EVENTS_ADDRESS_FIELDS", {})
     try:
-        apiwatcher.EVENTS_ADDRESS_FIELDS = {"send": ["source", "destination"]}
+        addressevents.EVENTS_ADDRESS_FIELDS = {"send": ["source", "destination"]}
 
         # Exécution de la fonction avec une transaction
         raw_tx_list = ["raw_tx_data"]
@@ -103,7 +103,7 @@ def test_parse_mempool_transactions_with_various_events(
         assert result == []
     finally:
         # Restaurer EVENTS_ADDRESS_FIELDS
-        apiwatcher.EVENTS_ADDRESS_FIELDS = original_events_address_fields
+        addressevents.EVENTS_ADDRESS_FIELDS = original_events_address_fields
 
 
 @pytest.mark.parametrize(

--- a/counterparty-core/hatch_build.py
+++ b/counterparty-core/hatch_build.py
@@ -18,7 +18,12 @@
 #
 import os
 
-from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+# Hatchling is a build-time dependency declared in `[build-system]`; it is not
+# present in the lint environment, which installs the package rather than
+# building it.
+from hatchling.builders.hooks.plugin.interface import (  # pylint: disable=import-error
+    BuildHookInterface,
+)
 
 PACKAGED_PATH = os.path.join("counterpartycore", "openapi.json")
 
@@ -45,7 +50,9 @@ def resolve_openapi_source(root):
 class OpenAPIBuildHook(BuildHookInterface):
     PLUGIN_NAME = "openapi"
 
-    def initialize(self, version, build_data):
+    # `version` is part of the build-hook interface ("standard" / "editable");
+    # the document is packaged the same way either way.
+    def initialize(self, version, build_data):  # pylint: disable=unused-argument
         source = resolve_openapi_source(self.root)
         if source is None:
             # A checkout that has never generated the document should still be

--- a/counterparty-core/hatch_build.py
+++ b/counterparty-core/hatch_build.py
@@ -1,0 +1,58 @@
+#
+# file: counterparty-core/hatch_build.py
+#
+# Carries the OpenAPI document into both distributions.
+#
+# ``openapi.json`` is generated at the repository root (see
+# ``test/integrations/regtest/genapidoc.py``), one directory above this
+# project, and the server reads it from ``counterpartycore/openapi.json``
+# once installed. A plain ``force-include`` of ``../openapi.json`` works for
+# a repository-to-wheel build but breaks the source-distribution channel: the
+# sdist has no parent checkout, so building its wheel dies with
+# ``FileNotFoundError: Forced include not found: .../openapi.json``.
+#
+# This hook resolves the document from whichever layout it is building in --
+# the archive-local copy first, the repository parent second -- and includes
+# it in the sdist as well, so the sdist carries the input its own wheel build
+# needs.
+#
+import os
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+PACKAGED_PATH = os.path.join("counterpartycore", "openapi.json")
+
+
+def resolve_openapi_source(root):
+    """Return the OpenAPI document to package, or None if there is none.
+
+    ``root`` is the directory holding ``pyproject.toml``: the repository's
+    ``counterparty-core/`` in a source checkout, the extracted archive root
+    when building a wheel from an sdist.
+    """
+    candidates = (
+        # sdist layout: the hook below already copied it in.
+        os.path.join(root, PACKAGED_PATH),
+        # repository layout: the single source of truth at the repo root.
+        os.path.join(os.path.dirname(os.path.abspath(root)), "openapi.json"),
+    )
+    for candidate in candidates:
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+class OpenAPIBuildHook(BuildHookInterface):
+    PLUGIN_NAME = "openapi"
+
+    def initialize(self, version, build_data):
+        source = resolve_openapi_source(self.root)
+        if source is None:
+            # A checkout that has never generated the document should still be
+            # installable; `/v2/openapi.json` then falls back to the source
+            # tree exactly as it did before the document was packaged.
+            self.app.display_warning(
+                "openapi.json not found; building without the packaged API document"
+            )
+            return
+        build_data["force_include"][source] = PACKAGED_PATH

--- a/counterparty-core/pyproject.toml
+++ b/counterparty-core/pyproject.toml
@@ -45,8 +45,12 @@ path = "counterpartycore/lib/config.py"
 [tool.hatch.build.targets.wheel]
 include = ["counterpartycore"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"../openapi.json" = "counterpartycore/openapi.json"
+# `openapi.json` lives at the repository root but ships inside the package.
+# The copy is done by a build hook rather than a `force-include` of
+# `../openapi.json`, which is unresolvable when the wheel is built from an
+# extracted sdist. See `hatch_build.py`.
+[tool.hatch.build.hooks.custom]
+path = "hatch_build.py"
 
 [tool.hatch.envs.default]
 pre-install-commands = [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-bitcoind-common: &bitcoind-common
   restart: unless-stopped
 
 x-counterparty-common: &counterparty-common
-  image: counterparty/counterparty:v11.3.0
+  image: counterparty/counterparty:v11.4.0
   stop_grace_period: 1m
   volumes:
     - data:/root/.bitcoin

--- a/openapi.json
+++ b/openapi.json
@@ -16079,6 +16079,24 @@
                                 }
                             }
                         }
+                    },
+                    "409": {
+                        "description": "A parsed pending asset change conflicts with this composition.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -18296,6 +18314,24 @@
                                             "premint_quantity_normalized": "0.00000000"
                                         },
                                         "name": "fairminter"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "A parsed pending asset change conflicts with this composition.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
                                     }
                                 }
                             }

--- a/release-notes/release-notes-v11.4.0.md
+++ b/release-notes/release-notes-v11.4.0.md
@@ -184,6 +184,8 @@ The dedicated health listener now starts before State DB maintenance, which is t
 
 Readiness now requires the API process to have reached the point where it serves requests, in both modes, and reports `503 starting` until then. Liveness is unchanged and stays `200` throughout, so a pod that is still coming up is still not killed.
 
+Routine Gunicorn worker retirement preserves the readiness of an otherwise healthy API instance.
+
 ## Packaged OpenAPI document (#3495, #3505)
 
 The installed wheel now includes `openapi.json`. Previously `/v2/openapi.json` worked from a source checkout but returned `500` from the official container: the handler walked four directories upward from `site-packages`, where the repository-root file does not exist. The API now resolves the packaged resource and retains a source-tree fallback for editable development installs.

--- a/release-notes/release-notes-v11.4.0.md
+++ b/release-notes/release-notes-v11.4.0.md
@@ -24,11 +24,11 @@ The security fixes themselves are ungated and take effect as soon as you restart
 
 This release also performs a **one-time State DB refresh** on first start (`refresh_state_db`), automatically. It takes roughly as long as one of the old reorg rebuilds. There is no ledger reparse.
 
-The refresh is an optimization, not a correctness requirement: it pays the cost of the last full rebuild at a moment you control rather than unpredictably at your next reorg. A State DB that has not been through it is flagged as ineligible for the incremental path and simply takes the old full-rebuild route once, which then flags it as eligible. Nodes therefore converge on the fast path either way — a node upgraded with `--force` (which skips the version check, and so the refresh) is correct, just slower on its first reorg.
+The refresh also repairs the address-history holes described under **Complete address history after a refresh or a full rollback** below, which earlier releases' refreshes could leave behind. Otherwise it is an optimization, not a correctness requirement: it pays the cost of the last full rebuild at a moment you control rather than unpredictably at your next reorg. A State DB that has not been through it is flagged as ineligible for the incremental path and simply takes the old full-rebuild route once, which then flags it as eligible. Nodes therefore converge on the fast path either way — a node upgraded with `--force` (which skips the version check, and so the refresh) is correct, just slower on its first reorg.
 
 **Point your Kubernetes probes at the dedicated health listener before upgrading** (port `4002` on mainnet — `/healthz/live` for liveness, `/healthz/ready` for readiness), if you have not already since v11.3.0. During the refresh the pod reports `200` on liveness and `503 rebuilding` on readiness, so it stays out of rotation and is not restarted. A liveness probe still pointed at the API port would get a connection refusal for the whole refresh and kill the pod, and the next start would begin the work again from zero.
 
-`/healthz/ready` also gains a second new reason: it returns `503 watcher_stopped` from the moment the API watcher dies on an unexpected error, on every node including `--api-only` ones. Alerting that matches on the readiness `reason` field should learn `rebuilding` and `watcher_stopped` alongside the existing values. Liveness stays `200` in both cases.
+`/healthz/ready` also gains two new reasons: it returns `503 watcher_stopped` from the moment the API watcher dies on an unexpected error, on every node including `--api-only` ones, and `503 starting` until the public API is actually able to serve requests. Alerting that matches on the readiness `reason` field should learn `rebuilding`, `watcher_stopped` and `starting` alongside the existing values. Liveness stays `200` in all three cases.
 
 API consumers of the address history endpoints should check the **Address history endpoints** section below before upgrading: `/v2/addresses/<address>/sends` and `/sends/<asset>` no longer expose `sort`, `offset` is capped at 10,000 on those routes and on `/credits` and `/debits`, and `result_count` is now `null` on cursor pages rather than recomputed for each one. `openapi.json` has been updated to match.
 
@@ -178,9 +178,17 @@ The API watcher thread is what advances the State DB, and nothing restarts it. A
 
 Such a failure is now logged at `CRITICAL` with its traceback, and `/healthz/ready` returns `503` with `reason: "watcher_stopped"` from that moment. Previously the only symptom was the lag signal drifting past the ready threshold minutes later — and on an `--api-only` node, which does not compare itself to the backend tip, never at all. Liveness deliberately stays `200`: the process is internally alive, and the remedy is to shed traffic and page an operator, not to have Kubernetes kill a pod mid-request.
 
-## Packaged OpenAPI document (#3495)
+## Readiness waits for the public API (#3504)
+
+The dedicated health listener now starts before State DB maintenance, which is the whole point of it — but its readiness predicate had no notion of whether the public API had finished coming up. Between the end of maintenance and `wsgi_server.run()` — watcher startup, Flask app construction, binding the socket — a caught-up ledger was enough to report `200` on `/healthz/ready`, and on an `--api-only` node, which skips the backend-lag comparison entirely, readiness was green from the first sample onwards. An orchestrator could route traffic to a pod that answered nothing.
+
+Readiness now requires the API process to have reached the point where it serves requests, in both modes, and reports `503 starting` until then. Liveness is unchanged and stays `200` throughout, so a pod that is still coming up is still not killed.
+
+## Packaged OpenAPI document (#3495, #3505)
 
 The installed wheel now includes `openapi.json`. Previously `/v2/openapi.json` worked from a source checkout but returned `500` from the official container: the handler walked four directories upward from `site-packages`, where the repository-root file does not exist. The API now resolves the packaged resource and retains a source-tree fallback for editable development installs.
+
+The document is carried into both distributions by a Hatch build hook rather than a `force-include` of `../openapi.json`. That path exists in the repository but not in an extracted source distribution, which has no parent checkout — so `pip wheel` on a fresh sdist failed with `Forced include not found`, breaking the source-distribution channel. The sdist now contains the document, and the wheel build resolves it from whichever layout it is running in.
 
 ## Address history endpoints (#3489)
 
@@ -206,6 +214,12 @@ The check runs twice, because the mempool moves while a composition is being ass
 
 `validate=false` remains the explicit advanced-user override and skips both passes.
 
+## Complete address history after a refresh or a full rollback (#3503)
+
+A State DB refresh, and the full rebuild that a deep or ineligible rollback still falls back to, re-applies the migrations that re-derive the State DB from the Ledger DB. One of them, `0002`, repopulates `parsed_events` from the *entire* Ledger history, which moves the replay cursor to the Ledger tip. `address_events` is not among the tables it rebuilds — re-deriving it wholesale would be as expensive as a full State DB build and would drop the UTXO-owner aliases only the event stream records — so anything the State DB had not parsed yet, and after a rollback everything the prune had just deleted, was declared parsed with no address associations behind it. `get_next_event_to_parse()` never came back for it, and `/v2/addresses/<address>/events`, `/credits` and `/debits` returned `200` while silently omitting confirmed history, until the operator rebuilt the State DB from scratch.
+
+Both paths now backfill the missing associations before publishing the new cursor, through the same resolver the watcher uses. Only events that have no association at all are re-derived, so nothing is counted twice and existing rows — including the UTXO-owner aliases — are left alone. Because the repair is defined by what is missing rather than by what this run would have removed, the one-time v11.4.0 refresh also closes the equivalent holes left behind by earlier releases' refreshes. Ledger data and balances are untouched.
+
 ## State DB / Ledger DB consistency fixes (#3485)
 
 The differential tests above surfaced three ways in which a State DB maintained by the event stream drifted from one built from scratch. All three are fixed in `apiwatcher.update_balances()`, and the one-time refresh normalizes existing rows:
@@ -221,6 +235,8 @@ The differential tests above surfaced three ways in which a State DB maintained 
 
 ## Bugfixes
 
+- **Document the composition conflict in `openapi.json`** (#3507). `compose_issuance` and `compose_fairminter` can return the new `409`, but the generator only ever observes the happy path, so both operations advertised `200` alone and schema-driven consumers had no way to discover the response. The declaration now comes from the generator itself, so it survives regeneration, and it is added to those two operations only — the other compose routes do not go through the pending-asset guard.
+- **Pin the release under test in `docker-compose.yml`** (#3506). The Compose file still selected `v11.3.0` while `config.VERSION_STRING` was `11.4.0`, so the Docker integration's version substitution matched nothing and the scenario silently exercised whatever image the stale tag pointed at. The tag is updated, and the test now fails loudly if the Compose file does not pin the release it is testing.
 - **Fix a resource leak in snapshot signature verification** (#3492) in `bootstrap` / `prepare-bootstrap`. Every call to `verify_signature()` leaked one `gpg-agent` daemon and one temporary GnuPG home directory, because the cleanup added in f53a7443 was accidentally disabled in 301c37ac ("Fix bootstrap with custom url") — commented out as apparent leftover debugging. The agent is now terminated with `gpgconf --homedir <dir> --kill gpg-agent` before the directory is removed, which avoids the socket/lockfile race that removing a live agent's home directory would otherwise hit. Only the agent spawned by the call itself is terminated; other GnuPG daemons on the machine are unaffected, and a missing `gpgconf` can neither skip the removal nor mask the error that triggered it. Three regression tests now pin the cleanup, so it cannot be silently dropped again.
 
 # Credits


### PR DESCRIPTION
Fixes the five non-security findings [reported on #3499](https://github.com/CounterpartyXCP/counterparty-core/pull/3499#issuecomment-5564446623) by John A. Zoidburg. All five were verified against this head before being fixed.

Closes #3503, closes #3504, closes #3505, closes #3506, closes #3507.

## #3503 — Address history lost past the replay cursor

A State DB refresh, and the full rebuild that a deep or ineligible rollback still falls back to, re-applies migration `0002`, which repopulates `parsed_events` from the *entire* Ledger history and so moves the replay cursor to the Ledger tip. `address_events` is not among the tables `MIGRATIONS_AFTER_ROLLBACK` rebuilds — and deliberately so: re-applying `0001` would cost as much as a full State DB build and would drop the UTXO-owner aliases only `apiwatcher.update_address_events()` records. The result was that everything the State DB had not parsed yet, and after a rollback everything `rollback_tables()` had just deleted, was declared parsed with no associations behind it. `get_next_event_to_parse()` never came back for it, and `/v2/addresses/<address>/events`, `/credits` and `/debits` returned `200` while silently omitting confirmed history.

`refresh_state_db()` and `full_rollback_state_db()` now backfill the missing associations before publishing the new cursor, through the same resolver the watcher uses. The repair is defined by what is *missing* — every address-bearing Ledger event with no association at all — rather than by what this particular run would have removed:

- nothing is counted twice: by construction no association exists for the events it re-derives, and `rollback_tables()` prunes whole blocks, so an event either kept all of its rows or lost all of them;
- existing rows, including the UTXO-owner aliases, are left alone;
- the one-time v11.4.0 refresh therefore also closes the equivalent holes left behind by earlier releases' refreshes, which the issue asks for.

The detection query is index-driven on both sides (`SEARCH ledger_db.messages USING COVERING INDEX messages_event_idx`, `SEARCH address_events USING COVERING INDEX address_events_event_index_idx`), and the missing set is materialised into a temp table first — SQLite leaves a query's result undefined if the table it is reading is written to while it is still open.

Ledger data, balances and consensus are untouched.

Three regression tests, two of which fail on `develop`: the refresh path (a State DB behind the Ledger), the full-rollback path, and a no-op assertion that a complete table gains nothing.

## #3504 — Readiness before the public API serves

The dedicated listener starts before State DB maintenance — that is what it is for — but the readiness predicate had no service-lifecycle condition. Between the end of maintenance and `wsgi_server.run()` (watcher startup, Flask app construction, binding the socket) a caught-up ledger was enough to report ready, and on an `--api-only` node, which skips the backend-lag comparison entirely, readiness was green from the first sample.

`HealthSampler` takes a `serving_provider`; `run_apiserver` wires it to `server_ready_value.value == 1`, which is set immediately before `wsgi_server.run()` and reset to `2` on teardown. Readiness reports `503 starting` until then, in both modes. Liveness is unchanged and stays `200` — a pod that is still coming up must not be killed. An unreadable signal sheds rather than guesses.

## #3505 — sdist could not build its own wheel

`[tool.hatch.build.targets.wheel.force-include]` pointed at `../openapi.json`, valid in the repository but absent from an extracted sdist, so `pip wheel` on a fresh sdist failed with `FileNotFoundError: Forced include not found`. Reproduced with both the `build` and `pip` frontends before the fix.

A Hatch build hook (`counterparty-core/hatch_build.py`) now carries the document into the sdist and resolves it from whichever layout the wheel build is running in — archive-local first, repository parent second. Verified end to end: sdist → wheel and repository → wheel both succeed and embed byte-identical spec content (`sha256 73ce098f…`). A missing document is a warning rather than a hard failure, so a checkout that has never generated it stays installable.

## #3506 — Compose pinned the previous release

`docker-compose.yml` selected `v11.3.0` while `config.VERSION_STRING` was `11.4.0`, so the Docker integration's version substitution matched nothing and the scenario exercised whatever the stale tag pointed at. The tag is updated to `v11.4.0` and the test now asserts the Compose file pins the release under test before substituting, so the same drift fails loudly at the next release instead of passing quietly.

Not addressed here: asserting the candidate image's runtime `version`/`current_commit`. That needs an image built from the candidate commit, which nothing in the integration workflow produces today; it belongs with the release/publish pipeline rather than this test.

## #3507 — 409 missing from the API contract

`compose_issuance` and `compose_fairminter` go through `_compose_with_pending_asset_guard` and can return the `409` added in #3490, but the document declared `200` alone across all 197 operations — including in the release notes, which already claimed otherwise. The generator only ever observes the happy path, so the declaration comes from `genapidoc.ERROR_RESPONSES` and survives regeneration. It is added to those two operations only; `compose_fairmint` and the other compose routes do not call the guard.

Two tests pin it: one on the operation IDs and the error-body shape, one that re-derives the guard's callers from the source so the mapping cannot silently fall out of step.

## Verification

- Full unit suite: 1898 passed, 1 pre-existing unrelated failure (`chain_halt_test.py::test_c1_rust_never_emits_a_none_dispenser_slot`, also failing on a clean checkout).
- `ruff check` / `ruff format --check` clean.
- Packaging verified by building both distributions, as described above.