### PR TITLE
Preserve API readiness when Gunicorn workers retire

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/apiserver.py
+++ b/counterparty-core/counterpartycore/lib/api/apiserver.py
@@ -697,6 +697,7 @@ class ConnectionPoolMonitor(threading.Thread):
 def run_apiserver(
     args, server_ready_value, stop_event, shared_backend_height, parent_pid, log_stream
 ):
+    api_owner_pid = os.getpid()
     logger.info("Starting API Server process...")
 
     def handle_interrupt_signal(_signum, _frame):
@@ -838,7 +839,10 @@ def run_apiserver(
             memory_profiler.stop_memory_profiler()
 
         logger.info("API Server stopped.")
-        server_ready_value.value = 2
+        # Retiring Gunicorn workers also unwind through this finally block.
+        # Only the API owner can mark the shared server state as stopped.
+        if os.getpid() == api_owner_pid:
+            server_ready_value.value = 2
 
 
 # This thread is used for the following two reasons:

--- a/counterparty-core/counterpartycore/test/units/api/apiserver_lifecycle_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/apiserver_lifecycle_test.py
@@ -1,0 +1,113 @@
+"""Exercise API lifecycle state without starting threads, listeners or databases."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from counterpartycore.lib.api import apiserver, healthz_server
+
+
+@pytest.mark.parametrize("health_enabled", [True, False], ids=["health", "no-health"])
+@pytest.mark.parametrize(
+    "exit_path, expected_state, exit_code",
+    [
+        pytest.param("owner-return", 2, None, id="owner-returns"),
+        pytest.param("owner-exit", 2, 0, id="owner-exits"),
+        pytest.param("worker-exit", 1, 0, id="worker-retires"),
+        pytest.param("startup-error", 2, 1, id="startup-fails"),
+    ],
+)
+def test_run_apiserver_lifecycle_state(
+    monkeypatch, health_enabled, exit_path, expected_state, exit_code
+):
+    ready = SimpleNamespace(value=0)
+    process = SimpleNamespace(pid=100)
+    sampler = None
+
+    # Replace only apiserver's view of the PID; no fork or process-wide OS patch.
+    monkeypatch.setattr(apiserver, "os", SimpleNamespace(getpid=lambda: process.pid))
+    monkeypatch.setattr(apiserver.signal, "signal", Mock())
+    for name in (
+        "logger",
+        "sentry",
+        "initialise_log_and_config",
+        "ConnectionPoolMonitor",
+        "database",
+        "check_database_version",
+        "init_flask_app",
+        "CurrentState",
+        "ParentProcessChecker",
+        "LedgerDBConnectionPool",
+        "StateDBConnectionPool",
+    ):
+        monkeypatch.setattr(apiserver, name, Mock())
+    monkeypatch.setattr(apiserver.apiwatcher, "APIWatcher", Mock())
+    monkeypatch.setattr(apiserver.apiwatcher, "watcher_has_failed", lambda: False)
+    for name, value in {
+        "MEMORY_PROFILE": False,
+        "NO_HEALTHZ_SERVER": not health_enabled,
+        "API_HOST": "127.0.0.1",
+        "HEALTHZ_PORT": 0,
+        "STATE_DATABASE": "unused-state.db",
+    }.items():
+        monkeypatch.setattr(apiserver.config, name, value, raising=False)
+
+    def make_health_server(**kwargs):
+        nonlocal sampler
+        # Use the real sampler and the serving callback supplied by run_apiserver.
+        # API-only mode isolates readiness from backend height and block age.
+        sampler = healthz_server.HealthSampler(
+            last_parsed_provider=lambda: 100,
+            backend_height_provider=lambda: 0,
+            block_time_provider=lambda: None,
+            api_only_provider=lambda: True,
+            serving_provider=kwargs["serving_provider"],
+        )
+        sampler._tick()
+        assert ready.value == 0
+        assert sampler.current_snapshot().ready is False
+        assert sampler.current_snapshot().reason == "starting"
+        return Mock()
+
+    health_factory = Mock(side_effect=make_health_server)
+    monkeypatch.setattr(apiserver.healthz_server, "HealthCheckServer", health_factory)
+
+    def run_wsgi(_ready, _backend_height):
+        assert ready.value == 1
+        if sampler is not None:
+            sampler._tick()
+            assert sampler.current_snapshot().ready is True
+        if exit_path == "worker-exit":
+            # Gunicorn forks inside run(), then a retiring worker raises SystemExit
+            # through the inherited run_apiserver() frame while the owner stays up.
+            process.pid += 1
+        if exit_path in ("owner-exit", "worker-exit"):
+            raise SystemExit(0)
+
+    wsgi_server = Mock()
+    wsgi_server.run.side_effect = run_wsgi
+    wsgi_factory = Mock(return_value=wsgi_server)
+    if exit_path == "startup-error":
+        wsgi_factory.side_effect = OSError("could not bind API socket")
+    monkeypatch.setattr(apiserver.wsgi, "WSGIApplication", wsgi_factory)
+
+    args = {"rebuild_state_db": False, "refresh_state_db": False}
+    call_args = (args, ready, Mock(), SimpleNamespace(value=0), 99, None)
+    if exit_code is None:
+        apiserver.run_apiserver(*call_args)
+    else:
+        with pytest.raises(SystemExit) as exc:
+            apiserver.run_apiserver(*call_args)
+        assert exc.value.code == exit_code
+
+    assert ready.value == expected_state
+    if health_enabled:
+        sampler._tick()
+        assert sampler.current_snapshot().ready is (expected_state == 1)
+        assert sampler.current_snapshot().reason == (None if expected_state == 1 else "starting")
+    else:
+        health_factory.assert_not_called()
+    if exit_path == "startup-error":
+        wsgi_server.run.assert_not_called()
+    else:
+        wsgi_server.run.assert_called_once()

--- a/release-notes/release-notes-v11.4.0.md
+++ b/release-notes/release-notes-v11.4.0.md
@@ -184,6 +184,8 @@ The dedicated health listener now starts before State DB maintenance, which is t
 
 Readiness now requires the API process to have reached the point where it serves requests, in both modes, and reports `503 starting` until then. Liveness is unchanged and stays `200` throughout, so a pod that is still coming up is still not killed.
 
+Routine Gunicorn worker retirement preserves the readiness of an otherwise healthy API instance.
+
 ## Packaged OpenAPI document (#3495, #3505)
 
 The installed wheel now includes `openapi.json`. Previously `/v2/openapi.json` worked from a source checkout but returned `500` from the official container: the handler walked four directories upward from `site-packages`, where the repository-root file does not exist. The API now resolves the packaged resource and retains a source-tree fallback for editable development installs.


### PR DESCRIPTION
In #3509, a Gunicorn worker reaching `max_requests` can make `/healthz/ready` return `503 starting` while the API and replacement workers continue serving requests. Readiness-based routing can then exclude a functioning instance.

Worker exit unwinds through `run_apiserver()`'s outer `finally` and marks the shared API state as **stopped** (`server_ready_value.value = 2`). The readiness check accepts only **ready** (`1`). This fix captures the API process's PID before workers are forked and restricts the stopped-state write to that process.

The regression test exercises `run_apiserver()` with mocked startup services, simulated PIDs and the real health sampler. Its eight cases cover worker retirement, owner shutdown and startup failure, with the health listener enabled and disabled.

Validation:

- On unpatched `c19a9992`, both worker-retirement cases fail and six controls pass. With the fix, all eight pass.
- All **653 API unit tests** pass, including those eight cases. Ruff lint and formatting checks pass.
- Separate isolated Linux tests with real Gunicorn workers confirm readiness through repeated replacements. Shutdown, startup-error, Waitress and Werkzeug controls also pass.

Run the regression test from `counterparty-core/`:

```sh
python -m pytest --noconftest -q counterpartycore/test/units/api/apiserver_lifecycle_test.py
```
