### PR TITLE
Bound database-close mutex waits during API shutdown

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/apiwatcher.py
+++ b/counterparty-core/counterpartycore/lib/api/apiwatcher.py
@@ -976,16 +976,21 @@ class APIWatcher(threading.Thread):
         # Under the lock: apsw checks the connection is open and then calls
         # sqlite3_interrupt() while holding the GIL, but close() releases it
         # around sqlite3_close_v2(), so an unsynchronised interrupt can reach a
-        # handle that is already being freed. Held only for the duration of the
-        # interrupts, which never block, so the closing thread waits on it for
-        # microseconds and the join() below cannot deadlock against it.
-        with self.db_lock:
+        # handle that is already being freed. The closing thread also holds
+        # this lock during SQLite close, which can wait on disk I/O. Include
+        # lock acquisition in the shutdown budget; never interrupt without it.
+        if not self.db_lock.acquire(timeout=deadline_timeout(deadline, 5)):
+            logger.warning("API Watcher database close exceeded the shutdown deadline.")
+            return
+        try:
             for connection in (self.state_db, self.ledger_db):
                 if connection is not None:
                     try:
                         connection.interrupt()
                     except apsw.Error:
                         pass
+        finally:
+            self.db_lock.release()
         self.join(timeout=deadline_timeout(deadline, 5))
         if self.is_alive():
             logger.warning("API Watcher thread did not stop in time, continuing...")

--- a/counterparty-core/counterpartycore/lib/api/wsgi.py
+++ b/counterparty-core/counterpartycore/lib/api/wsgi.py
@@ -114,16 +114,21 @@ class NodeStatusCheckerThread(threading.Thread):
             # Under the lock: apsw checks the connection is open and then calls
             # sqlite3_interrupt() while holding the GIL, but close() releases it
             # around sqlite3_close_v2(), so an unsynchronised interrupt can reach
-            # a handle that is already being freed. Held only for the duration of
-            # the interrupt, which never blocks, so the closing thread waits on it
-            # for microseconds and the join() below cannot deadlock against it.
-            with self.db_lock:
+            # a handle that is already being freed. SQLite close holds this
+            # same lock and can wait on I/O; acquiring it must respect the
+            # deadline too. A daemon still closing can finish independently.
+            if not self.db_lock.acquire(timeout=helpers.deadline_timeout(deadline, 2)):
+                logger.warning("NodeStatusChecker database close exceeded the shutdown deadline.")
+                return
+            try:
                 try:
                     self.state_db.interrupt()
                 except apsw.Error:
                     # The checker may finish and close its connection between the
                     # is_alive() check and this cross-thread interrupt.
                     pass
+            finally:
+                self.db_lock.release()
             self.join(timeout=helpers.deadline_timeout(deadline, 2))
             if self.is_alive():
                 logger.warning("NodeStatusChecker thread did not stop before its deadline.")

--- a/counterparty-core/counterpartycore/test/units/api/shutdown_lock_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/shutdown_lock_test.py
@@ -1,0 +1,40 @@
+"""A SQLite close holding db_lock must not defeat the API shutdown budget."""
+
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from counterpartycore.lib.api import apiwatcher, wsgi
+
+
+@pytest.mark.parametrize("cls", [apiwatcher.APIWatcher, wsgi.NodeStatusCheckerThread])
+def test_stop_does_not_wait_for_a_slow_database_close(cls):
+    worker = cls.__new__(cls)
+    threading.Thread.__init__(worker)
+    worker.stop_event = threading.Event()
+    worker.db_lock = threading.Lock()
+    worker.state_db = MagicMock()
+    worker.ledger_db = MagicMock()
+    worker.is_alive = MagicMock(return_value=True)
+    worker.join = MagicMock()
+    worker.db_lock.acquire()
+    finished = threading.Event()
+
+    def stop():
+        try:
+            worker.stop(deadline=time.monotonic() + 0.02)
+        finally:
+            finished.set()
+
+    caller = threading.Thread(target=stop)
+    caller.start()
+    try:
+        assert finished.wait(0.5), "stop blocked behind SQLite close despite its deadline"
+        assert worker.stop_event.is_set()
+        worker.state_db.interrupt.assert_not_called()
+        worker.ledger_db.interrupt.assert_not_called()
+    finally:
+        worker.db_lock.release()
+        caller.join(timeout=2)
+    assert not caller.is_alive()

--- a/release-notes/release-notes-v11.4.0.md
+++ b/release-notes/release-notes-v11.4.0.md
@@ -1,5 +1,9 @@
 # Release Notes - Counterparty Core v11.4.0 (2026-09-05)
 
+API shutdown now bounds the wait for the database-close mutex in the watcher
+and node-status threads. A slow SQLite close cannot make that mutex wait bypass
+the caller's shutdown deadline; interrupt remains serialized with close.
+
 Counterparty Core v11.4.0 is a **security release**. It fixes a family of remotely triggerable chain-halt vulnerabilities reported privately as [GHSA-pmfx-7qj5-fx6c](https://github.com/CounterpartyXCP/counterparty-core/security/advisories/GHSA-pmfx-7qj5-fx6c), plus a silent ledger-fork vector in how the source of an inscription reveal transaction is resolved. Each halt vector let an unprivileged attacker stop **every node on the network** at the same block for the price of one or two ordinary transactions, and a halted node restarts onto the same poisoned block and halts again.
 
 **All node operators should upgrade immediately.**


### PR DESCRIPTION
The watcher and node-status shutdown paths acquire `db_lock` without a timeout before their bounded joins. The worker holds the same lock during SQLite close, so a slow close can consume the entire parent shutdown budget before the join is reached.

Bound mutex acquisition by the supplied deadline. If close still owns the lock, log the condition and let the daemon finish independently; never call SQLite interrupt without the lock. This preserves serialization of interrupt and close.

Follow-up to #3486. Production still emitted forced-kill logs on September 7; this fixes a reproducible deadline gap, but the logs do not prove it caused those particular kills.

Validation: a dependency-free harness exercising the exact production stop methods passes both contended-lock cases; Ruff passes. Added parametrized pytest regressions. Full repository pytest execution is pending: a fresh test environment cannot resolve the unreleased counterparty-rs==11.4.0 requirement from the package registry. This PR stays draft until CI and review complete. No production deployment or protocol change is included.
