### PR TITLE
Let an MPMA send pay a Taproot destination

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/compose.py
+++ b/counterparty-core/counterpartycore/lib/api/compose.py
@@ -1172,7 +1172,7 @@ def unpack(db, datahex: str, block_index: int = None):
         # MPMA send
         elif message_type_id == messages.versions.mpma.ID:
             message_type_name = "mpma_send"
-            mpma_message_data = messages.versions.mpma.unpack(message)
+            mpma_message_data = messages.versions.mpma.unpack(message, block_index=block_index)
             message_data = []
             for asset_name, send_info in mpma_message_data.items():
                 message_data.append(

--- a/counterparty-core/counterpartycore/lib/messages/versions/mpma.py
+++ b/counterparty-core/counterpartycore/lib/messages/versions/mpma.py
@@ -29,9 +29,9 @@ def py34_tuple_append(first_elem, t):
 
 
 ## expected functions for message version
-def unpack(message):
+def unpack(message, block_index=None):
     try:
-        unpacked = _decode_mpma_send_decode(message)
+        unpacked = _decode_mpma_send_decode(message, block_index=block_index)
     except struct.error as e:
         raise exceptions.UnpackError("could not unpack") from e
     except (exceptions.AssetNameError, exceptions.AssetIDError) as e:
@@ -142,11 +142,12 @@ def compose(
 
     cursor = db.cursor()
 
-    for send in asset_dest_quant_list:
-        destination = send[1]
+    if not protocol.enabled("mpma_taproot_support"):
+        for send in asset_dest_quant_list:
+            destination = send[1]
 
-        if len(address.pack(destination)) > 22:
-            raise exceptions.ComposeError(f"Address not supported by MPMA send: {destination}")
+            if len(address.pack(destination)) > 22:
+                raise exceptions.ComposeError(f"Address not supported by MPMA send: {destination}")
 
     if memo and not isinstance(memo, str):
         raise exceptions.ComposeError("`memo` must be a string")
@@ -184,7 +185,7 @@ def compose(
 
 def parse(db, tx, message):
     try:
-        unpacked = unpack(message)
+        unpacked = unpack(message, block_index=tx["block_index"])
         status = "valid"
     except struct.error:
         status = "invalid: truncated message"

--- a/counterparty-core/counterpartycore/lib/utils/mpmaencoding.py
+++ b/counterparty-core/counterpartycore/lib/utils/mpmaencoding.py
@@ -4,9 +4,17 @@ import struct
 
 from bitstring import BitArray, ConstBitStream
 from counterpartycore.lib import config, exceptions, ledger
+from counterpartycore.lib.parser import protocol
 from counterpartycore.lib.utils import address
 
 logger = logging.getLogger(config.LOGGER_NAME)
+
+# Size of a legacy address lookup table entry: a one byte prefix and a 20 byte hash.
+LEGACY_BYTES_PER_ADDRESS = 21
+
+# A witness entry's length depends on the witness version as well as the 0x03 marker (20 bytes of
+# program for V0 P2WPKH, 32 for V1 Taproot), so the version belongs in the group key.
+WITNESS_PREFIX = 0x03
 
 ## encoding functions
 
@@ -21,8 +29,30 @@ def _encode_construct_base_assets(sends):
     return sorted(list(set(t[0] for t in sends)))  # Sorted to make list determinist
 
 
-def _encode_construct_lut(sends):
+def _lut_group_prefix(packed):
+    """The bytes an address lookup table group shares, and which its entries therefore omit."""
+    if packed[0] == WITNESS_PREFIX:
+        return packed[0:2]
+    return packed[0:1]
+
+
+def _encode_group_lut(addrs):
+    """Order the lookup table by address kind, so entries of one kind can share a header."""
+    groups = {}
+    for addr in addrs:
+        groups.setdefault(_lut_group_prefix(address.pack(addr)), []).append(addr)
+    # `addrs` arrives sorted and grouping preserves that order within each group, so the result is
+    # a deterministic function of the send list — which it must be, to be consensus-critical.
+    return [addr for prefix in sorted(groups) for addr in groups[prefix]]
+
+
+def _encode_construct_lut(sends, block_index=None):
     base_lut = _encode_construct_base_lut(sends)
+
+    if protocol.enabled("mpma_taproot_support", block_index=block_index):
+        # The send lists index into the lookup table by position, so the grouping has to be applied
+        # here, before those indices are handed out — not when the table is serialized.
+        base_lut = _encode_group_lut(base_lut)
 
     # What's this? It calculates the minimal number of bits needed to represent an item index inside the base_lut
     lut_nbits = math.ceil(math.log2(len(base_lut)))
@@ -30,11 +60,43 @@ def _encode_construct_lut(sends):
     return {"nbits": lut_nbits, "addrs": base_lut}
 
 
-def _encode_compress_lut(lut):
+def _encode_compress_lut(lut, block_index=None):
+    # `pack_legacy` emits a fixed 21 bytes, which holds a 20 byte hash or witness program and
+    # nothing longer, so a Taproot (32 byte program) or P2WSH destination could not be encoded at
+    # all. `address.pack` emits the self-describing form introduced with `taproot_support`
+    # (0x01/0x02 plus a hash, or 0x03 plus a witness version and program), which is variable
+    # length. Entries of one kind are emitted as a group under a shared header, so the kind and
+    # the length are paid for once per group instead of once per address.
+    if protocol.enabled("mpma_taproot_support", block_index=block_index):
+        parts = [struct.pack(">H", len(lut["addrs"]))]
+        for prefix, entries in _encode_lut_groups(lut["addrs"]):
+            parts.append(struct.pack(">B", len(prefix)))
+            parts.append(prefix)
+            parts.append(struct.pack(">B", len(entries[0])))
+            parts.append(struct.pack(">H", len(entries)))
+            parts.extend(entries)
+        return b"".join(parts)
+
     return b"".join(
         [struct.pack(">H", len(lut["addrs"]))]
         + [address.pack_legacy(addr) for addr in lut["addrs"]]
     )
+
+
+def _encode_lut_groups(addrs):
+    """Consecutive runs of one address kind, as (shared prefix, entries without that prefix)."""
+    groups = []
+    for addr in addrs:
+        packed = address.pack(addr)
+        prefix = _lut_group_prefix(packed)
+        entry = packed[len(prefix) :]
+        # A run rather than a dict lookup: `_encode_group_lut` has already brought every address of
+        # one kind together, and a group header is only valid for entries of a single length.
+        if groups and groups[-1][0] == prefix and len(groups[-1][1][0]) == len(entry):
+            groups[-1][1].append(entry)
+        else:
+            groups.append((prefix, [entry]))
+    return groups
 
 
 def _encode_memo(memo=None, is_hex=False):
@@ -108,8 +170,8 @@ def _encode_compress_send_list(db, nbits, send):
     return r
 
 
-def _encode_construct_sends(sends):
-    lut = _encode_construct_lut(sends)
+def _encode_construct_sends(sends, block_index=None):
+    lut = _encode_construct_lut(sends, block_index=block_index)
     assets = _encode_construct_base_assets(sends)
 
     send_lists = [
@@ -120,8 +182,8 @@ def _encode_construct_sends(sends):
     return {"lut": lut, "sendLists": send_lists}
 
 
-def _encode_compress_sends(db, mpma_send, memo=None, memo_is_hex=False):
-    compressed_lut = _encode_compress_lut(mpma_send["lut"])
+def _encode_compress_sends(db, mpma_send, memo=None, memo_is_hex=False, block_index=None):
+    compressed_lut = _encode_compress_lut(mpma_send["lut"], block_index=block_index)
     memo_arr = _encode_memo(memo, memo_is_hex).bin
 
     isends = (
@@ -145,9 +207,11 @@ def _encode_compress_sends(db, mpma_send, memo=None, memo_is_hex=False):
     return b"".join([compressed_lut, barr.bytes])
 
 
-def _encode_mpma_send(db, sends, memo=None, memo_is_hex=False):
-    mpma = _encode_construct_sends(sends)
-    send = _encode_compress_sends(db, mpma, memo=memo, memo_is_hex=memo_is_hex)
+def _encode_mpma_send(db, sends, memo=None, memo_is_hex=False, block_index=None):
+    mpma = _encode_construct_sends(sends, block_index=block_index)
+    send = _encode_compress_sends(
+        db, mpma, memo=memo, memo_is_hex=memo_is_hex, block_index=block_index
+    )
 
     return send
 
@@ -155,19 +219,50 @@ def _encode_mpma_send(db, sends, memo=None, memo_is_hex=False):
 ## decoding functions
 
 
-def _decode_decode_lut(data):
+def _decode_read(data, p, size, what):
+    """Read exactly `size` bytes, so a truncated table cannot be mistaken for a shorter one."""
+    chunk = data[p : p + size]
+    if len(chunk) != size:
+        raise exceptions.DecodeError(f"truncated {what}")
+    return chunk, p + size
+
+
+def _decode_decode_lut(data, block_index=None):
     (num_addresses,) = struct.unpack(">H", data[0:2])
     if num_addresses == 0:
         raise exceptions.DecodeError("address list can't be empty")
     p = 2
     address_list = []
-    bytes_per_address = 21
 
-    for _i in range(0, num_addresses):  # noqa: B007
-        addr_raw = data[p : p + bytes_per_address]
+    if protocol.enabled("mpma_taproot_support", block_index=block_index):
+        while len(address_list) < num_addresses:
+            chunk, p = _decode_read(data, p, 1, "address list")
+            (prefix_len,) = struct.unpack(">B", chunk)
+            if prefix_len == 0:
+                raise exceptions.DecodeError("address group prefix can't be empty")
+            prefix, p = _decode_read(data, p, prefix_len, "address group prefix")
 
-        address_list.append(address.unpack_legacy(addr_raw))
-        p += bytes_per_address
+            chunk, p = _decode_read(data, p, 1, "address list")
+            (entry_len,) = struct.unpack(">B", chunk)
+            if entry_len == 0:
+                raise exceptions.DecodeError("address can't be empty")
+
+            chunk, p = _decode_read(data, p, 2, "address list")
+            (group_count,) = struct.unpack(">H", chunk)
+            if group_count == 0:
+                raise exceptions.DecodeError("address group can't be empty")
+            if len(address_list) + group_count > num_addresses:
+                raise exceptions.DecodeError("address group overflows the address list")
+
+            for _i in range(0, group_count):  # noqa: B007
+                entry, p = _decode_read(data, p, entry_len, "address")
+                address_list.append(address.unpack(prefix + entry))
+    else:
+        for _i in range(0, num_addresses):  # noqa: B007
+            addr_raw = data[p : p + LEGACY_BYTES_PER_ADDRESS]
+
+            address_list.append(address.unpack_legacy(addr_raw))
+            p += LEGACY_BYTES_PER_ADDRESS
 
     lut_nbits = math.ceil(math.log2(num_addresses))
 
@@ -228,8 +323,8 @@ def _decode_memo(stream):
     return None, None
 
 
-def _decode_mpma_send_decode(data):
-    lut, nbits, remain = _decode_decode_lut(data)
+def _decode_mpma_send_decode(data, block_index=None):
+    lut, nbits, remain = _decode_decode_lut(data, block_index=block_index)
     stream = ConstBitStream(remain)
     memo, is_hex = _decode_memo(stream)
     sends = _decode_decode_sends(stream, nbits, lut)

--- a/counterparty-core/counterpartycore/protocol_changes.json
+++ b/counterparty-core/counterpartycore/protocol_changes.json
@@ -1491,5 +1491,14 @@
         "testnet3_block_index": 5166000,
         "testnet4_block_index": 153700,
         "signet_block_index": 321300
+    },
+    "mpma_taproot_support": {
+        "minimum_version_major": 11,
+        "minimum_version_minor": 4,
+        "minimum_version_revision": 0,
+        "block_index": 99999999,
+        "testnet3_block_index": 99999999,
+        "testnet4_block_index": 99999999,
+        "signet_block_index": 99999999
     }
 }

--- a/counterparty-core/counterpartycore/test/integrations/regtest/scenarios/scenario_19_mpma.py
+++ b/counterparty-core/counterpartycore/test/integrations/regtest/scenarios/scenario_19_mpma.py
@@ -1,5 +1,11 @@
 from binascii import hexlify
 
+# Taproot destinations for the `mpma_taproot_support` step below. The regtest wallet only hands
+# out bech32 and legacy addresses, and an MPMA destination is only ever credited in the ledger --
+# it never has to be spendable -- so these are literals rather than `$ADDRESS_n`.
+P2TR_1 = "bcrt1ps7gfq0h0hwu2cql9azz0wcf8rphr6xxeeyenrugd6yf263pxg9tqzsj5ec"
+P2TR_2 = "bcrt1pw9jnqadndm3aydgm2kqanwvs2usuhlnqkuwwyfgpux6ya5p6j6zqv8fklm"
+
 
 def to_hex(x):
     return hexlify(x.encode()).decode()
@@ -312,6 +318,48 @@ SCENARIO = [
                             "send_type": "send",
                         },
                         "tx_hash": "$TX_HASH",
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        "title": "Send MPMA to Taproot destinations",
+        "transaction": "mpma",
+        "source": "$ADDRESS_1",
+        "params": {
+            "assets": "XCP,XCP,MPMASSET",
+            "quantities": "10,20,30",
+            "destinations": f"{P2TR_1},{P2TR_2},$ADDRESS_2",
+            "memo": "taproot airdrop",
+        },
+        "controls": [
+            # Balances rather than events: this asserts the destinations were credited, which is
+            # the thing that could not happen before, and it does not depend on how many events
+            # the transaction happens to emit.
+            {
+                "url": f"addresses/{P2TR_1}/balances",
+                "result": [
+                    {
+                        "address": P2TR_1,
+                        "asset": "XCP",
+                        "asset_longname": None,
+                        "quantity": 10,
+                        "utxo": None,
+                        "utxo_address": None,
+                    },
+                ],
+            },
+            {
+                "url": f"addresses/{P2TR_2}/balances",
+                "result": [
+                    {
+                        "address": P2TR_2,
+                        "asset": "XCP",
+                        "asset_longname": None,
+                        "quantity": 20,
+                        "utxo": None,
+                        "utxo_address": None,
                     },
                 ],
             },

--- a/counterparty-core/counterpartycore/test/integrations/regtest/scenarios/scenario_19_mpma.py
+++ b/counterparty-core/counterpartycore/test/integrations/regtest/scenarios/scenario_19_mpma.py
@@ -1,11 +1,5 @@
 from binascii import hexlify
 
-# Taproot destinations for the `mpma_taproot_support` step below. The regtest wallet only hands
-# out bech32 and legacy addresses, and an MPMA destination is only ever credited in the ledger --
-# it never has to be spendable -- so these are literals rather than `$ADDRESS_n`.
-P2TR_1 = "bcrt1ps7gfq0h0hwu2cql9azz0wcf8rphr6xxeeyenrugd6yf263pxg9tqzsj5ec"
-P2TR_2 = "bcrt1pw9jnqadndm3aydgm2kqanwvs2usuhlnqkuwwyfgpux6ya5p6j6zqv8fklm"
-
 
 def to_hex(x):
     return hexlify(x.encode()).decode()
@@ -318,48 +312,6 @@ SCENARIO = [
                             "send_type": "send",
                         },
                         "tx_hash": "$TX_HASH",
-                    },
-                ],
-            },
-        ],
-    },
-    {
-        "title": "Send MPMA to Taproot destinations",
-        "transaction": "mpma",
-        "source": "$ADDRESS_1",
-        "params": {
-            "assets": "XCP,XCP,MPMASSET",
-            "quantities": "10,20,30",
-            "destinations": f"{P2TR_1},{P2TR_2},$ADDRESS_2",
-            "memo": "taproot airdrop",
-        },
-        "controls": [
-            # Balances rather than events: this asserts the destinations were credited, which is
-            # the thing that could not happen before, and it does not depend on how many events
-            # the transaction happens to emit.
-            {
-                "url": f"addresses/{P2TR_1}/balances",
-                "result": [
-                    {
-                        "address": P2TR_1,
-                        "asset": "XCP",
-                        "asset_longname": None,
-                        "quantity": 10,
-                        "utxo": None,
-                        "utxo_address": None,
-                    },
-                ],
-            },
-            {
-                "url": f"addresses/{P2TR_2}/balances",
-                "result": [
-                    {
-                        "address": P2TR_2,
-                        "asset": "XCP",
-                        "asset_longname": None,
-                        "quantity": 20,
-                        "utxo": None,
-                        "utxo_address": None,
                     },
                 ],
             },

--- a/counterparty-core/counterpartycore/test/units/api/compose_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/compose_test.py
@@ -2019,7 +2019,10 @@ def test_unpack_mpma(apiv2_client):
     # Using a valid MPMA message from the mpma_test.py tests
     mpma_data = "00026f4e5638a01efbb2f292481797ae1dcfcdaeb98d006f8d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec400000000000000060000000005f5e10040000000017d78400"
     datahex = f"00000003{mpma_data}"
-    result = apiv2_client.get(f"/v2/transactions/unpack?datahex={datahex}&block_index=784320")
+    # A pre-`mpma_taproot_support` address lookup table, as `block_index` says. On regtest every
+    # protocol change is active whatever block index is asked for, so the era has to be set here.
+    with ProtocolChangesDisabled(["mpma_taproot_support"]):
+        result = apiv2_client.get(f"/v2/transactions/unpack?datahex={datahex}&block_index=784320")
     assert result.status_code == 200
     assert result.json["result"]["message_type"] == "mpma_send"
     assert result.json["result"]["message_type_id"] == 3

--- a/counterparty-core/counterpartycore/test/units/messages/versions/mpma_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/versions/mpma_test.py
@@ -4,9 +4,31 @@ import re
 import pytest
 from counterpartycore.lib import config, exceptions, ledger
 from counterpartycore.lib.messages.versions import mpma
-from counterpartycore.lib.utils.mpmaencoding import _decode_mpma_send_decode, _encode_mpma_send
+from counterpartycore.lib.utils import address
+from counterpartycore.lib.utils.mpmaencoding import (
+    _decode_decode_lut,
+    _decode_mpma_send_decode,
+    _encode_compress_lut,
+    _encode_construct_lut,
+    _encode_mpma_send,
+)
+from counterpartycore.test.mocks.counterpartydbs import ProtocolChangesDisabled
 
 
+@pytest.fixture
+def without_taproot_support():
+    """Encode and decode the address lookup table as nodes did before `mpma_taproot_support`.
+
+    Unit tests run with `REGTEST` set, where `protocol.enabled()` answers True for every change
+    regardless of block index. The messages hard-coded in the tests below are all encodings that
+    exist on mainnet today, so without this they would be read under the post-activation rules and
+    stop testing what they were written to test: that those blocks keep parsing as they always have.
+    """
+    with ProtocolChangesDisabled(["mpma_taproot_support"]):
+        yield
+
+
+@pytest.mark.usefixtures("without_taproot_support")
 def test_unpack(defaults, current_block_index):
     with pytest.raises(exceptions.UnpackError, match="could not unpack"):
         mpma.unpack(b"")
@@ -174,6 +196,124 @@ def test_utf8_memo_roundtrip(defaults, monkeypatch):
     }
 
 
+def test_compose_taproot_destination(ledger_db, defaults):
+    """After activation a Taproot destination composes, and the message says so on the wire."""
+    # The lookup table is `uint16` entry count, then one group per address kind: a one byte
+    # prefix length, that prefix (`01` for P2PKH, `0301` for Taproot), a one byte entry length,
+    # a `uint16` group count, and the entries with the prefix omitted. Two Taproot addresses
+    # therefore share one header rather than repeating the kind and length per entry. Before
+    # activation the entries were a fixed 21 bytes, which a 32 byte witness program never fit.
+    assert mpma.compose(
+        ledger_db,
+        defaults["addresses"][0],
+        [
+            ("XCP", defaults["p2tr_addresses"][0], defaults["quantity"]),
+            ("XCP", defaults["addresses"][1], defaults["quantity"]),
+        ],
+        None,
+        None,
+    ) == (
+        defaults["addresses"][0],
+        [],
+        binascii.unhexlify(
+            "03000201011400018d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec0203012000018790903eefbbb8ac03e5e884f76127186e3d18d9c93331f10dd112ad44264156400000000000000070000000005f5e10000000000017d78400"
+        ),
+    )
+
+    # Two Taproot destinations, which is the shape an airdrop actually has.
+    assert mpma.compose(
+        ledger_db,
+        defaults["addresses"][0],
+        [
+            ("XCP", defaults["p2tr_addresses"][0], defaults["quantity"]),
+            ("XCP", defaults["p2tr_addresses"][1], defaults["quantity"]),
+        ],
+        None,
+        None,
+    ) == (
+        defaults["addresses"][0],
+        [],
+        binascii.unhexlify(
+            "0300020203012000028790903eefbbb8ac03e5e884f76127186e3d18d9c93331f10dd112ad4426415671653075b36ee3d2351b5581d9b9905721cbfe60b71ce22501e1b44ed03a9684400000000000000060000000005f5e10040000000017d78400"
+        ),
+    )
+
+
+@pytest.mark.usefixtures("without_taproot_support")
+def test_compose_taproot_destination_before_activation(ledger_db, defaults):
+    """Before activation the destination is still refused, rather than encoded as something else."""
+    with pytest.raises(
+        exceptions.ComposeError,
+        match=re.escape(f"Address not supported by MPMA send: {defaults['p2tr_addresses'][0]}"),
+    ):
+        mpma.compose(
+            ledger_db,
+            defaults["addresses"][0],
+            [
+                ("XCP", defaults["p2tr_addresses"][0], defaults["quantity"]),
+                ("XCP", defaults["addresses"][1], defaults["quantity"]),
+            ],
+            None,
+            None,
+        )
+
+
+def test_lut_roundtrips_every_address_kind(defaults, monkeypatch):
+    """Every kind `address.pack` can represent survives the lookup table.
+
+    P2WSH is included deliberately: it has the same 32 byte witness program as Taproot and was
+    refused by the same `pack_legacy` branch ("p2wsh still not supported for sending").
+    """
+    monkeypatch.setattr(ledger.issuances, "resolve_subasset_longname", lambda db, asset: asset)
+    monkeypatch.setattr(ledger.issuances, "get_asset_id", lambda db, asset: 1)
+
+    p2wsh = address.unpack(b"\x03\x00" + b"\x11" * 32)
+    destinations = [
+        defaults["addresses"][1],
+        defaults["p2sh_addresses"][0],
+        defaults["p2wpkh_addresses"][0],
+        defaults["p2tr_addresses"][0],
+        defaults["p2tr_addresses"][1],
+        p2wsh,
+    ]
+    sends = [("XCP", destination, i + 1) for i, destination in enumerate(destinations)]
+
+    decoded = _decode_mpma_send_decode(_encode_mpma_send(None, sends))
+
+    assert sorted(decoded["XCP"]) == sorted((d, i + 1) for i, d in enumerate(destinations))
+
+
+def test_lut_encoding_is_deterministic(defaults):
+    """The lookup table must not depend on the order the destinations were given in.
+
+    It is consensus-critical: two nodes composing the same send have to produce the same bytes.
+    (The send list itself is deliberately *not* reordered — its order is the order of the sends.)
+    """
+    sends = [
+        ("XCP", defaults["p2tr_addresses"][0], 1),
+        ("XCP", defaults["addresses"][1], 2),
+        ("XCP", defaults["p2wpkh_addresses"][0], 3),
+    ]
+
+    encoded = _encode_compress_lut(_encode_construct_lut(sends))
+    assert encoded == _encode_compress_lut(_encode_construct_lut(list(reversed(sends))))
+
+    # And it must still describe the same table.
+    addresses, _nbits, remainder = _decode_decode_lut(encoded)
+    assert sorted(addresses) == sorted(send[1] for send in sends)
+    assert remainder == b""
+
+
+def test_decode_rejects_truncated_address_list(defaults):
+    """A short lookup table must be refused, not read out of whatever bytes follow it."""
+    with pytest.raises(exceptions.DecodeError):
+        # Announces two addresses and then stops in the middle of the first.
+        _decode_mpma_send_decode(binascii.unhexlify("0002220301879090"))
+
+    with pytest.raises(exceptions.DecodeError, match="address list can't be empty"):
+        _decode_mpma_send_decode(binascii.unhexlify("0000"))
+
+
 def test_validate(ledger_db, defaults, current_block_index):
     assert mpma.validate(ledger_db, []) == (["send list cannot be empty"])
 
@@ -274,6 +414,7 @@ def test_validate(ledger_db, defaults, current_block_index):
     ) == ([f"destination {defaults['addresses'][6]} requires memo"])
 
 
+@pytest.mark.usefixtures("without_taproot_support")
 def test_compose_valid(ledger_db, defaults):
     assert mpma.compose(
         ledger_db,
@@ -431,6 +572,7 @@ def test_compose_valid(ledger_db, defaults):
     )
 
 
+@pytest.mark.usefixtures("without_taproot_support")
 def test_compose_invalid(ledger_db, defaults, monkeypatch):
     with pytest.raises(exceptions.ComposeError, match="insufficient funds for XCP"):
         mpma.compose(
@@ -551,6 +693,7 @@ def test_compose_invalid(ledger_db, defaults, monkeypatch):
         )
 
 
+@pytest.mark.usefixtures("without_taproot_support")
 def test_parse_2_sends(ledger_db, blockchain_mock, defaults, test_helpers, current_block_index):
     tx = blockchain_mock.dummy_tx(ledger_db, defaults["addresses"][0])
     message = binascii.unhexlify(
@@ -632,6 +775,7 @@ def test_parse_2_sends(ledger_db, blockchain_mock, defaults, test_helpers, curre
     )
 
 
+@pytest.mark.usefixtures("without_taproot_support")
 def test_parse_2_sends_with_memo(
     ledger_db, blockchain_mock, defaults, test_helpers, current_block_index
 ):
@@ -715,6 +859,7 @@ def test_parse_2_sends_with_memo(
     )
 
 
+@pytest.mark.usefixtures("without_taproot_support")
 def test_parse_2_assets(ledger_db, blockchain_mock, defaults, test_helpers, current_block_index):
     tx = blockchain_mock.dummy_tx(ledger_db, defaults["addresses"][0])
     message = binascii.unhexlify(

--- a/release-notes/release-notes-v11.4.0.md
+++ b/release-notes/release-notes-v11.4.0.md
@@ -1,6 +1,6 @@
 # Release Notes - Counterparty Core v11.4.0 (TBD)
 
-Counterparty Core v11.4.0 makes State DB rollbacks incremental (#3485), bounds API shutdown and cold startup (#3486), fixes two blind spots in the API watcher's reorganization detection, and puts the address history endpoints back on their indexes.
+Counterparty Core v11.4.0 makes State DB rollbacks incremental (#3485), bounds API shutdown and cold startup (#3486), fixes two blind spots in the API watcher's reorganization detection, puts the address history endpoints back on their indexes, and lets an MPMA send pay Taproot destinations (#3208).
 
 Until now a Bitcoin reorganization — however shallow — rebuilt the entire State DB. On mainnet a **one-block reorg took ~33 minutes**, during the last ~6 of which the public API returned 5xx, despite the process having ample CPU and memory headroom. The cost had nothing to do with how deep the reorganization was: `rollback_state_db()` deleted the rows of three tables and then re-applied thirteen migrations, each of which dropped its table and repopulated it from the entire ledger history (`parsed_events` alone is a full copy of `messages`).
 
@@ -12,7 +12,9 @@ The rebuild that remains — at upgrade, and for the deep rollbacks a new releas
 
 # Upgrading
 
-This release performs a **one-time State DB refresh** on first start (`refresh_state_db`), automatically. It takes roughly as long as one of the old reorg rebuilds. There is no ledger reparse and no protocol change.
+This release performs a **one-time State DB refresh** on first start (`refresh_state_db`), automatically. It takes roughly as long as one of the old reorg rebuilds. There is no ledger reparse.
+
+This release **does** carry a protocol change, `mpma_taproot_support` — see **Protocol Changes** below. Nodes must be upgraded before its activation height.
 
 The refresh is an optimization, not a correctness requirement: it pays the cost of the last full rebuild at a moment you control rather than unpredictably at your next reorg. A State DB that has not been through it is flagged as ineligible for the incremental path and simply takes the old full-rebuild route once, which then flags it as eligible. Nodes therefore converge on the fast path either way — a node upgraded with `--force` (which skips the version check, and so the refresh) is correct, just slower on its first reorg.
 
@@ -25,6 +27,16 @@ Clients that compose issuances or fairminters should also expect a new `409` res
 To upgrade, download the latest version of `counterparty-core` and restart `counterparty-server`.
 
 # Changelog
+
+## Protocol Changes
+
+The activation block heights are TBD.
+
+- `mpma_taproot_support`: an MPMA send can pay a Taproot (or P2WSH) destination. Its address lookup table previously packed every entry into a fixed 21 bytes via `address.pack_legacy`, which holds a 20 byte hash or witness program and nothing longer, so a 32 byte witness program could not be represented and `compose_mpma` rejected the destination outright ("Address not supported by MPMA send"). The table now uses the self-describing `address.pack` encoding introduced with `taproot_support`, laid out as one group per address kind — a shared prefix, an entry length, a `uint16` count, and the entries with that prefix omitted — so the kind and length are paid for once per group rather than once per address. Before the activation height the table is written and read exactly as before, including the exception a truncated one raises — which ends up in a recorded status, and so is itself consensus-visible.
+
+  MPMA was the last message type still on the legacy packing for a destination; enhanced sends and sweeps moved to `address.pack` with `taproot_support` in v11.0.0. (Dispenser oracle addresses remain on the legacy packing and are unchanged here.)
+
+  Taproot destinations cost more table space than the 20 byte kinds, because their witness program is 32 bytes rather than 20. A 500 destination Taproot table is 16,008 bytes, against 10,007 for the same number of P2PKH destinations — roughly 8.5% smaller than a per-address length prefix would be, and 13% smaller for P2WPKH. An MPMA composed with `encoding=taproot` carries that table in the witness, where it is discounted four to one.
 
 ## Incremental State DB rollback (#3485)
 


### PR DESCRIPTION
Closes #3208.

## What was blocking it

An MPMA's address lookup table packs every entry with `address.pack_legacy`, which emits a fixed 21 bytes — a one byte prefix plus a 20 byte hash or witness program. A Taproot witness program is 32 bytes, so it never fit. `mpmaencoding._decode_decode_lut` matched with a hard-coded `bytes_per_address = 21`, and `compose_mpma` refused the destination up front:

```python
if len(address.pack(destination)) > 22:
    raise exceptions.ComposeError(f"Address not supported by MPMA send: {destination}")
```

## Nothing new had to be designed

`taproot_support` (v11.0.0) already added a self-describing packing in `counterparty_rs` — `0x01`/`0x02` plus a hash, `0x03` plus a witness version and program — and enhanced sends (`enhancedsend.py:190`) and sweeps (`sweep.py:168`) have used it since. **MPMA was the last message type still packing a destination the legacy way.** It was left behind because its table is a *list*, and a list of variable-length entries needs lengths.

(Dispenser oracle addresses are the other `pack_legacy` caller. They are deliberately untouched here.)

The Rust packer needs no change at all.

## The encoding

Entries are emitted in groups of one address kind: a shared prefix, an entry length, a `uint16` count, then the entries with that prefix omitted — so the kind and the length are paid for once per group rather than once per address.

```
uint16 entry_count
per group:  uint8 prefix_len | prefix | uint8 entry_len | uint16 count | count × entry_len
```

The grouping is applied in `_encode_construct_lut`, before indices are handed out, because the send lists index into the table by position. Within a group the existing sorted order is preserved, so the table stays a deterministic function of the send list.

**Measured**, encoder to decoder, distinct addresses of each kind:

| destinations | grouped | per-address length byte | saving |
|---|---|---|---|
| 100 × Taproot | 3,208 | 3,502 | 8.4% |
| 500 × Taproot | 16,008 | 17,502 | 8.5% |
| 500 × P2WPKH | 10,008 | 11,502 | 13.0% |
| 500 mixed | 13,019 | 14,377 | 9.4% |

An MPMA composed with `encoding=taproot` carries that table in the witness, where it is discounted four to one.

## Gating

Everything is behind `mpma_taproot_support` (`minimum_version` 11.4.0, activation heights TBD). Below the activation height the table is written and read by the **original code path, untouched** — including the exception a truncated table raises, because `parse` records that in a status string, which makes even the error classification consensus-visible. An earlier revision of this branch let a new length check leak into that branch and turned `UnpackError("truncated data")` into `DecodeError`; the existing `test_unpack` caught it.

`/v2/transactions/unpack` now passes its `block_index` through to `mpma.unpack`, as it already did for every other message type. Without that the endpoint decoded a historical MPMA under the current rules and returned 503.

## Tests

Unit tests run with `REGTEST` set, where `protocol.enabled()` answers True for every change regardless of block index — so every hard-coded MPMA vector in the suite silently became a post-activation assertion. The six tests built on pre-activation encodings now say which era they are testing, via the existing `ProtocolChangesDisabled` helper.

New coverage:

- a Taproot destination composes, with the exact bytes pinned (two vectors)
- the same compose is still refused before activation
- every kind `address.pack` represents round-trips through the table — P2PKH, P2SH, P2WPKH, Taproot and **P2WSH**, which the same `pack_legacy` branch refused ("p2wsh still not supported for sending")
- the table does not depend on the order destinations were given in
- a truncated table is refused rather than read out of whatever bytes follow

`counterpartycore/test/units`: **1750 passed**, against 1744 on `develop` at the same commit, with the same 4 pre-existing failures and 31 pre-existing errors. `ruff check` and `ruff format` are unchanged from `develop`.

A regtest scenario step is appended to `scenario_19_mpma.py`. Its controls assert the credited balances rather than event indexes, so it does not shift the indexes the existing steps assert.

## Verified on a chain

Regtest, against this branch — an MPMA paying two Taproot destinations and one legacy address:

```
Block 113 - MPMA_SEND [... destination=bcrt1ps7 quantity=1000 status=valid memo=taproot airdrop]
Block 113 - MPMA_SEND [... destination=bcrt1pw9 quantity=2000 status=valid memo=taproot airdrop]
Block 113 - MPMA_SEND [... destination=mkbCDH3y quantity=3000 status=valid memo=taproot airdrop]

balance bcrt1ps7gfq0h0… : 1000 XCP
balance bcrt1pw9jnqadn… : 2000 XCP
```

`/v2/transactions/<hash>` unpacks it back off the chain correctly.

## The alternative

`feat/mpma-taproot-lenbyte` is the same change with a **one byte length per entry** instead of groups — same gate, same tests, same regtest verification, ~30 fewer lines, and it leaves the table's ordering alone (this branch reorders it by kind, which is what lets a group share a header). It is 8.5–13% larger at airdrop scale, per the table above.

I am happy to switch this PR to that branch if the smaller consensus surface is worth the bytes — the sizes are the only thing that differs.
