### PR TITLE
Let an MPMA send pay a Taproot destination

### DIFF
--- a/counterparty-core/counterpartycore/lib/api/compose.py
+++ b/counterparty-core/counterpartycore/lib/api/compose.py
@@ -1172,7 +1172,7 @@ def unpack(db, datahex: str, block_index: int = None):
         # MPMA send
         elif message_type_id == messages.versions.mpma.ID:
             message_type_name = "mpma_send"
-            mpma_message_data = messages.versions.mpma.unpack(message)
+            mpma_message_data = messages.versions.mpma.unpack(message, block_index=block_index)
             message_data = []
             for asset_name, send_info in mpma_message_data.items():
                 message_data.append(

--- a/counterparty-core/counterpartycore/lib/messages/versions/mpma.py
+++ b/counterparty-core/counterpartycore/lib/messages/versions/mpma.py
@@ -29,9 +29,9 @@ def py34_tuple_append(first_elem, t):
 
 
 ## expected functions for message version
-def unpack(message):
+def unpack(message, block_index=None):
     try:
-        unpacked = _decode_mpma_send_decode(message)
+        unpacked = _decode_mpma_send_decode(message, block_index=block_index)
     except struct.error as e:
         raise exceptions.UnpackError("could not unpack") from e
     except (exceptions.AssetNameError, exceptions.AssetIDError) as e:
@@ -142,11 +142,12 @@ def compose(
 
     cursor = db.cursor()
 
-    for send in asset_dest_quant_list:
-        destination = send[1]
+    if not protocol.enabled("mpma_taproot_support"):
+        for send in asset_dest_quant_list:
+            destination = send[1]
 
-        if len(address.pack(destination)) > 22:
-            raise exceptions.ComposeError(f"Address not supported by MPMA send: {destination}")
+            if len(address.pack(destination)) > 22:
+                raise exceptions.ComposeError(f"Address not supported by MPMA send: {destination}")
 
     if memo and not isinstance(memo, str):
         raise exceptions.ComposeError("`memo` must be a string")
@@ -184,7 +185,7 @@ def compose(
 
 def parse(db, tx, message):
     try:
-        unpacked = unpack(message)
+        unpacked = unpack(message, block_index=tx["block_index"])
         status = "valid"
     except struct.error:
         status = "invalid: truncated message"

--- a/counterparty-core/counterpartycore/lib/utils/mpmaencoding.py
+++ b/counterparty-core/counterpartycore/lib/utils/mpmaencoding.py
@@ -4,9 +4,13 @@ import struct
 
 from bitstring import BitArray, ConstBitStream
 from counterpartycore.lib import config, exceptions, ledger
+from counterpartycore.lib.parser import protocol
 from counterpartycore.lib.utils import address
 
 logger = logging.getLogger(config.LOGGER_NAME)
+
+# Size of a legacy address lookup table entry: a one byte prefix and a 20 byte hash.
+LEGACY_BYTES_PER_ADDRESS = 21
 
 ## encoding functions
 
@@ -30,7 +34,20 @@ def _encode_construct_lut(sends):
     return {"nbits": lut_nbits, "addrs": base_lut}
 
 
-def _encode_compress_lut(lut):
+def _encode_compress_lut(lut, block_index=None):
+    # `pack_legacy` emits a fixed 21 bytes, which holds a 20 byte hash or witness program and
+    # nothing longer, so a Taproot (32 byte program) or P2WSH destination could not be encoded at
+    # all. `address.pack` emits the self-describing form introduced with `taproot_support`
+    # (0x01/0x02 plus a hash, or 0x03 plus a witness version and program), which is variable
+    # length, so each entry is prefixed with its own length.
+    if protocol.enabled("mpma_taproot_support", block_index=block_index):
+        entries = []
+        for addr in lut["addrs"]:
+            packed = address.pack(addr)
+            entries.append(struct.pack(">B", len(packed)))
+            entries.append(packed)
+        return b"".join([struct.pack(">H", len(lut["addrs"]))] + entries)
+
     return b"".join(
         [struct.pack(">H", len(lut["addrs"]))]
         + [address.pack_legacy(addr) for addr in lut["addrs"]]
@@ -120,8 +137,8 @@ def _encode_construct_sends(sends):
     return {"lut": lut, "sendLists": send_lists}
 
 
-def _encode_compress_sends(db, mpma_send, memo=None, memo_is_hex=False):
-    compressed_lut = _encode_compress_lut(mpma_send["lut"])
+def _encode_compress_sends(db, mpma_send, memo=None, memo_is_hex=False, block_index=None):
+    compressed_lut = _encode_compress_lut(mpma_send["lut"], block_index=block_index)
     memo_arr = _encode_memo(memo, memo_is_hex).bin
 
     isends = (
@@ -145,9 +162,11 @@ def _encode_compress_sends(db, mpma_send, memo=None, memo_is_hex=False):
     return b"".join([compressed_lut, barr.bytes])
 
 
-def _encode_mpma_send(db, sends, memo=None, memo_is_hex=False):
+def _encode_mpma_send(db, sends, memo=None, memo_is_hex=False, block_index=None):
     mpma = _encode_construct_sends(sends)
-    send = _encode_compress_sends(db, mpma, memo=memo, memo_is_hex=memo_is_hex)
+    send = _encode_compress_sends(
+        db, mpma, memo=memo, memo_is_hex=memo_is_hex, block_index=block_index
+    )
 
     return send
 
@@ -155,19 +174,37 @@ def _encode_mpma_send(db, sends, memo=None, memo_is_hex=False):
 ## decoding functions
 
 
-def _decode_decode_lut(data):
+def _decode_decode_lut(data, block_index=None):
     (num_addresses,) = struct.unpack(">H", data[0:2])
     if num_addresses == 0:
         raise exceptions.DecodeError("address list can't be empty")
     p = 2
     address_list = []
-    bytes_per_address = 21
 
-    for _i in range(0, num_addresses):  # noqa: B007
-        addr_raw = data[p : p + bytes_per_address]
+    if protocol.enabled("mpma_taproot_support", block_index=block_index):
+        for _i in range(0, num_addresses):  # noqa: B007
+            # Each entry carries its own length; see `_encode_compress_lut`.
+            (bytes_per_address,) = struct.unpack(">B", data[p : p + 1])
+            p += 1
+            if bytes_per_address == 0:
+                raise exceptions.DecodeError("address can't be empty")
 
-        address_list.append(address.unpack_legacy(addr_raw))
-        p += bytes_per_address
+            addr_raw = data[p : p + bytes_per_address]
+            # A truncated list would otherwise unpack whatever bytes remain as if they were a
+            # whole address, so the length is checked rather than trusted.
+            if len(addr_raw) != bytes_per_address:
+                raise exceptions.DecodeError("truncated address list")
+
+            address_list.append(address.unpack(addr_raw))
+            p += bytes_per_address
+    else:
+        # Left exactly as it was: this branch decides how blocks already on chain are read, and
+        # even the exception it raises for a truncated message ends up in a recorded status.
+        for _i in range(0, num_addresses):  # noqa: B007
+            addr_raw = data[p : p + LEGACY_BYTES_PER_ADDRESS]
+
+            address_list.append(address.unpack_legacy(addr_raw))
+            p += LEGACY_BYTES_PER_ADDRESS
 
     lut_nbits = math.ceil(math.log2(num_addresses))
 
@@ -228,8 +265,8 @@ def _decode_memo(stream):
     return None, None
 
 
-def _decode_mpma_send_decode(data):
-    lut, nbits, remain = _decode_decode_lut(data)
+def _decode_mpma_send_decode(data, block_index=None):
+    lut, nbits, remain = _decode_decode_lut(data, block_index=block_index)
     stream = ConstBitStream(remain)
     memo, is_hex = _decode_memo(stream)
     sends = _decode_decode_sends(stream, nbits, lut)

--- a/counterparty-core/counterpartycore/protocol_changes.json
+++ b/counterparty-core/counterpartycore/protocol_changes.json
@@ -1491,5 +1491,14 @@
         "testnet3_block_index": 5166000,
         "testnet4_block_index": 153700,
         "signet_block_index": 321300
+    },
+    "mpma_taproot_support": {
+        "minimum_version_major": 11,
+        "minimum_version_minor": 4,
+        "minimum_version_revision": 0,
+        "block_index": 99999999,
+        "testnet3_block_index": 99999999,
+        "testnet4_block_index": 99999999,
+        "signet_block_index": 99999999
     }
 }

--- a/counterparty-core/counterpartycore/test/integrations/regtest/scenarios/scenario_19_mpma.py
+++ b/counterparty-core/counterpartycore/test/integrations/regtest/scenarios/scenario_19_mpma.py
@@ -1,5 +1,11 @@
 from binascii import hexlify
 
+# Taproot destinations for the `mpma_taproot_support` step below. The regtest wallet only hands
+# out bech32 and legacy addresses, and an MPMA destination is only ever credited in the ledger --
+# it never has to be spendable -- so these are literals rather than `$ADDRESS_n`.
+P2TR_1 = "bcrt1ps7gfq0h0hwu2cql9azz0wcf8rphr6xxeeyenrugd6yf263pxg9tqzsj5ec"
+P2TR_2 = "bcrt1pw9jnqadndm3aydgm2kqanwvs2usuhlnqkuwwyfgpux6ya5p6j6zqv8fklm"
+
 
 def to_hex(x):
     return hexlify(x.encode()).decode()
@@ -312,6 +318,48 @@ SCENARIO = [
                             "send_type": "send",
                         },
                         "tx_hash": "$TX_HASH",
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        "title": "Send MPMA to Taproot destinations",
+        "transaction": "mpma",
+        "source": "$ADDRESS_1",
+        "params": {
+            "assets": "XCP,XCP,MPMASSET",
+            "quantities": "10,20,30",
+            "destinations": f"{P2TR_1},{P2TR_2},$ADDRESS_2",
+            "memo": "taproot airdrop",
+        },
+        "controls": [
+            # Balances rather than events: this asserts the destinations were credited, which is
+            # the thing that could not happen before, and it does not depend on how many events
+            # the transaction happens to emit.
+            {
+                "url": f"addresses/{P2TR_1}/balances",
+                "result": [
+                    {
+                        "address": P2TR_1,
+                        "asset": "XCP",
+                        "asset_longname": None,
+                        "quantity": 10,
+                        "utxo": None,
+                        "utxo_address": None,
+                    },
+                ],
+            },
+            {
+                "url": f"addresses/{P2TR_2}/balances",
+                "result": [
+                    {
+                        "address": P2TR_2,
+                        "asset": "XCP",
+                        "asset_longname": None,
+                        "quantity": 20,
+                        "utxo": None,
+                        "utxo_address": None,
                     },
                 ],
             },

--- a/counterparty-core/counterpartycore/test/integrations/regtest/scenarios/scenario_19_mpma.py
+++ b/counterparty-core/counterpartycore/test/integrations/regtest/scenarios/scenario_19_mpma.py
@@ -1,11 +1,5 @@
 from binascii import hexlify
 
-# Taproot destinations for the `mpma_taproot_support` step below. The regtest wallet only hands
-# out bech32 and legacy addresses, and an MPMA destination is only ever credited in the ledger --
-# it never has to be spendable -- so these are literals rather than `$ADDRESS_n`.
-P2TR_1 = "bcrt1ps7gfq0h0hwu2cql9azz0wcf8rphr6xxeeyenrugd6yf263pxg9tqzsj5ec"
-P2TR_2 = "bcrt1pw9jnqadndm3aydgm2kqanwvs2usuhlnqkuwwyfgpux6ya5p6j6zqv8fklm"
-
 
 def to_hex(x):
     return hexlify(x.encode()).decode()
@@ -318,48 +312,6 @@ SCENARIO = [
                             "send_type": "send",
                         },
                         "tx_hash": "$TX_HASH",
-                    },
-                ],
-            },
-        ],
-    },
-    {
-        "title": "Send MPMA to Taproot destinations",
-        "transaction": "mpma",
-        "source": "$ADDRESS_1",
-        "params": {
-            "assets": "XCP,XCP,MPMASSET",
-            "quantities": "10,20,30",
-            "destinations": f"{P2TR_1},{P2TR_2},$ADDRESS_2",
-            "memo": "taproot airdrop",
-        },
-        "controls": [
-            # Balances rather than events: this asserts the destinations were credited, which is
-            # the thing that could not happen before, and it does not depend on how many events
-            # the transaction happens to emit.
-            {
-                "url": f"addresses/{P2TR_1}/balances",
-                "result": [
-                    {
-                        "address": P2TR_1,
-                        "asset": "XCP",
-                        "asset_longname": None,
-                        "quantity": 10,
-                        "utxo": None,
-                        "utxo_address": None,
-                    },
-                ],
-            },
-            {
-                "url": f"addresses/{P2TR_2}/balances",
-                "result": [
-                    {
-                        "address": P2TR_2,
-                        "asset": "XCP",
-                        "asset_longname": None,
-                        "quantity": 20,
-                        "utxo": None,
-                        "utxo_address": None,
                     },
                 ],
             },

--- a/counterparty-core/counterpartycore/test/units/api/compose_test.py
+++ b/counterparty-core/counterpartycore/test/units/api/compose_test.py
@@ -2019,7 +2019,10 @@ def test_unpack_mpma(apiv2_client):
     # Using a valid MPMA message from the mpma_test.py tests
     mpma_data = "00026f4e5638a01efbb2f292481797ae1dcfcdaeb98d006f8d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec400000000000000060000000005f5e10040000000017d78400"
     datahex = f"00000003{mpma_data}"
-    result = apiv2_client.get(f"/v2/transactions/unpack?datahex={datahex}&block_index=784320")
+    # A pre-`mpma_taproot_support` address lookup table, as `block_index` says. On regtest every
+    # protocol change is active whatever block index is asked for, so the era has to be set here.
+    with ProtocolChangesDisabled(["mpma_taproot_support"]):
+        result = apiv2_client.get(f"/v2/transactions/unpack?datahex={datahex}&block_index=784320")
     assert result.status_code == 200
     assert result.json["result"]["message_type"] == "mpma_send"
     assert result.json["result"]["message_type_id"] == 3

--- a/counterparty-core/counterpartycore/test/units/messages/versions/mpma_test.py
+++ b/counterparty-core/counterpartycore/test/units/messages/versions/mpma_test.py
@@ -4,9 +4,31 @@ import re
 import pytest
 from counterpartycore.lib import config, exceptions, ledger
 from counterpartycore.lib.messages.versions import mpma
-from counterpartycore.lib.utils.mpmaencoding import _decode_mpma_send_decode, _encode_mpma_send
+from counterpartycore.lib.utils import address
+from counterpartycore.lib.utils.mpmaencoding import (
+    _decode_decode_lut,
+    _decode_mpma_send_decode,
+    _encode_compress_lut,
+    _encode_construct_lut,
+    _encode_mpma_send,
+)
+from counterpartycore.test.mocks.counterpartydbs import ProtocolChangesDisabled
 
 
+@pytest.fixture
+def without_taproot_support():
+    """Encode and decode the address lookup table as nodes did before `mpma_taproot_support`.
+
+    Unit tests run with `REGTEST` set, where `protocol.enabled()` answers True for every change
+    regardless of block index. The messages hard-coded in the tests below are all encodings that
+    exist on mainnet today, so without this they would be read under the post-activation rules and
+    stop testing what they were written to test: that those blocks keep parsing as they always have.
+    """
+    with ProtocolChangesDisabled(["mpma_taproot_support"]):
+        yield
+
+
+@pytest.mark.usefixtures("without_taproot_support")
 def test_unpack(defaults, current_block_index):
     with pytest.raises(exceptions.UnpackError, match="could not unpack"):
         mpma.unpack(b"")
@@ -174,6 +196,123 @@ def test_utf8_memo_roundtrip(defaults, monkeypatch):
     }
 
 
+def test_compose_taproot_destination(ledger_db, defaults):
+    """After activation a Taproot destination composes, and the message says so on the wire."""
+    # The lookup table is `uint16` entry count, then each address as a one byte length and that
+    # many bytes of `address.pack` output: `22` (34) for the Taproot entry, `15` (21) for the
+    # P2PKH one. Before activation the entries were a fixed 21 bytes with no length, which is why
+    # a 32 byte witness program could not be carried at all.
+    assert mpma.compose(
+        ledger_db,
+        defaults["addresses"][0],
+        [
+            ("XCP", defaults["p2tr_addresses"][0], defaults["quantity"]),
+            ("XCP", defaults["addresses"][1], defaults["quantity"]),
+        ],
+        None,
+        None,
+    ) == (
+        defaults["addresses"][0],
+        [],
+        binascii.unhexlify(
+            "0300022203018790903eefbbb8ac03e5e884f76127186e3d18d9c93331f10dd112ad4426415615018d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec400000000000000060000000005f5e10040000000017d78400"
+        ),
+    )
+
+    # Two Taproot destinations, which is the shape an airdrop actually has.
+    assert mpma.compose(
+        ledger_db,
+        defaults["addresses"][0],
+        [
+            ("XCP", defaults["p2tr_addresses"][0], defaults["quantity"]),
+            ("XCP", defaults["p2tr_addresses"][1], defaults["quantity"]),
+        ],
+        None,
+        None,
+    ) == (
+        defaults["addresses"][0],
+        [],
+        binascii.unhexlify(
+            "0300022203018790903eefbbb8ac03e5e884f76127186e3d18d9c93331f10dd112ad4426415622030171653075b36ee3d2351b5581d9b9905721cbfe60b71ce22501e1b44ed03a9684400000000000000060000000005f5e10040000000017d78400"
+        ),
+    )
+
+
+@pytest.mark.usefixtures("without_taproot_support")
+def test_compose_taproot_destination_before_activation(ledger_db, defaults):
+    """Before activation the destination is still refused, rather than encoded as something else."""
+    with pytest.raises(
+        exceptions.ComposeError,
+        match=re.escape(f"Address not supported by MPMA send: {defaults['p2tr_addresses'][0]}"),
+    ):
+        mpma.compose(
+            ledger_db,
+            defaults["addresses"][0],
+            [
+                ("XCP", defaults["p2tr_addresses"][0], defaults["quantity"]),
+                ("XCP", defaults["addresses"][1], defaults["quantity"]),
+            ],
+            None,
+            None,
+        )
+
+
+def test_lut_roundtrips_every_address_kind(defaults, monkeypatch):
+    """Every kind `address.pack` can represent survives the lookup table.
+
+    P2WSH is included deliberately: it has the same 32 byte witness program as Taproot and was
+    refused by the same `pack_legacy` branch ("p2wsh still not supported for sending").
+    """
+    monkeypatch.setattr(ledger.issuances, "resolve_subasset_longname", lambda db, asset: asset)
+    monkeypatch.setattr(ledger.issuances, "get_asset_id", lambda db, asset: 1)
+
+    p2wsh = address.unpack(b"\x03\x00" + b"\x11" * 32)
+    destinations = [
+        defaults["addresses"][1],
+        defaults["p2sh_addresses"][0],
+        defaults["p2wpkh_addresses"][0],
+        defaults["p2tr_addresses"][0],
+        defaults["p2tr_addresses"][1],
+        p2wsh,
+    ]
+    sends = [("XCP", destination, i + 1) for i, destination in enumerate(destinations)]
+
+    decoded = _decode_mpma_send_decode(_encode_mpma_send(None, sends))
+
+    assert sorted(decoded["XCP"]) == sorted((d, i + 1) for i, d in enumerate(destinations))
+
+
+def test_lut_encoding_is_deterministic(defaults):
+    """The lookup table must not depend on the order the destinations were given in.
+
+    It is consensus-critical: two nodes composing the same send have to produce the same bytes.
+    (The send list itself is deliberately *not* reordered — its order is the order of the sends.)
+    """
+    sends = [
+        ("XCP", defaults["p2tr_addresses"][0], 1),
+        ("XCP", defaults["addresses"][1], 2),
+        ("XCP", defaults["p2wpkh_addresses"][0], 3),
+    ]
+
+    encoded = _encode_compress_lut(_encode_construct_lut(sends))
+    assert encoded == _encode_compress_lut(_encode_construct_lut(list(reversed(sends))))
+
+    # And it must still describe the same table.
+    addresses, _nbits, remainder = _decode_decode_lut(encoded)
+    assert sorted(addresses) == sorted(send[1] for send in sends)
+    assert remainder == b""
+
+
+def test_decode_rejects_truncated_address_list(defaults):
+    """A short lookup table must be refused, not read out of whatever bytes follow it."""
+    with pytest.raises(exceptions.DecodeError):
+        # Announces two addresses and then stops in the middle of the first.
+        _decode_mpma_send_decode(binascii.unhexlify("0002220301879090"))
+
+    with pytest.raises(exceptions.DecodeError, match="address list can't be empty"):
+        _decode_mpma_send_decode(binascii.unhexlify("0000"))
+
+
 def test_validate(ledger_db, defaults, current_block_index):
     assert mpma.validate(ledger_db, []) == (["send list cannot be empty"])
 
@@ -274,6 +413,7 @@ def test_validate(ledger_db, defaults, current_block_index):
     ) == ([f"destination {defaults['addresses'][6]} requires memo"])
 
 
+@pytest.mark.usefixtures("without_taproot_support")
 def test_compose_valid(ledger_db, defaults):
     assert mpma.compose(
         ledger_db,
@@ -431,6 +571,7 @@ def test_compose_valid(ledger_db, defaults):
     )
 
 
+@pytest.mark.usefixtures("without_taproot_support")
 def test_compose_invalid(ledger_db, defaults, monkeypatch):
     with pytest.raises(exceptions.ComposeError, match="insufficient funds for XCP"):
         mpma.compose(
@@ -551,6 +692,7 @@ def test_compose_invalid(ledger_db, defaults, monkeypatch):
         )
 
 
+@pytest.mark.usefixtures("without_taproot_support")
 def test_parse_2_sends(ledger_db, blockchain_mock, defaults, test_helpers, current_block_index):
     tx = blockchain_mock.dummy_tx(ledger_db, defaults["addresses"][0])
     message = binascii.unhexlify(
@@ -632,6 +774,7 @@ def test_parse_2_sends(ledger_db, blockchain_mock, defaults, test_helpers, curre
     )
 
 
+@pytest.mark.usefixtures("without_taproot_support")
 def test_parse_2_sends_with_memo(
     ledger_db, blockchain_mock, defaults, test_helpers, current_block_index
 ):
@@ -715,6 +858,7 @@ def test_parse_2_sends_with_memo(
     )
 
 
+@pytest.mark.usefixtures("without_taproot_support")
 def test_parse_2_assets(ledger_db, blockchain_mock, defaults, test_helpers, current_block_index):
     tx = blockchain_mock.dummy_tx(ledger_db, defaults["addresses"][0])
     message = binascii.unhexlify(

--- a/release-notes/release-notes-v11.4.0.md
+++ b/release-notes/release-notes-v11.4.0.md
@@ -1,6 +1,6 @@
 # Release Notes - Counterparty Core v11.4.0 (TBD)
 
-Counterparty Core v11.4.0 makes State DB rollbacks incremental (#3485), bounds API shutdown and cold startup (#3486), fixes two blind spots in the API watcher's reorganization detection, and puts the address history endpoints back on their indexes.
+Counterparty Core v11.4.0 makes State DB rollbacks incremental (#3485), bounds API shutdown and cold startup (#3486), fixes two blind spots in the API watcher's reorganization detection, puts the address history endpoints back on their indexes, and lets an MPMA send pay Taproot destinations (#3208).
 
 Until now a Bitcoin reorganization — however shallow — rebuilt the entire State DB. On mainnet a **one-block reorg took ~33 minutes**, during the last ~6 of which the public API returned 5xx, despite the process having ample CPU and memory headroom. The cost had nothing to do with how deep the reorganization was: `rollback_state_db()` deleted the rows of three tables and then re-applied thirteen migrations, each of which dropped its table and repopulated it from the entire ledger history (`parsed_events` alone is a full copy of `messages`).
 
@@ -12,7 +12,9 @@ The rebuild that remains — at upgrade, and for the deep rollbacks a new releas
 
 # Upgrading
 
-This release performs a **one-time State DB refresh** on first start (`refresh_state_db`), automatically. It takes roughly as long as one of the old reorg rebuilds. There is no ledger reparse and no protocol change.
+This release performs a **one-time State DB refresh** on first start (`refresh_state_db`), automatically. It takes roughly as long as one of the old reorg rebuilds. There is no ledger reparse.
+
+This release **does** carry a protocol change, `mpma_taproot_support` — see **Protocol Changes** below. Nodes must be upgraded before its activation height.
 
 The refresh is an optimization, not a correctness requirement: it pays the cost of the last full rebuild at a moment you control rather than unpredictably at your next reorg. A State DB that has not been through it is flagged as ineligible for the incremental path and simply takes the old full-rebuild route once, which then flags it as eligible. Nodes therefore converge on the fast path either way — a node upgraded with `--force` (which skips the version check, and so the refresh) is correct, just slower on its first reorg.
 
@@ -25,6 +27,16 @@ Clients that compose issuances or fairminters should also expect a new `409` res
 To upgrade, download the latest version of `counterparty-core` and restart `counterparty-server`.
 
 # Changelog
+
+## Protocol Changes
+
+The activation block heights are TBD.
+
+- `mpma_taproot_support`: an MPMA send can pay a Taproot (or P2WSH) destination. Its address lookup table previously packed every entry into a fixed 21 bytes via `address.pack_legacy`, which holds a 20 byte hash or witness program and nothing longer, so a 32 byte witness program could not be represented and `compose_mpma` rejected the destination outright ("Address not supported by MPMA send"). The table now uses the self-describing `address.pack` encoding introduced with `taproot_support`, laid out as a one byte length followed by that many bytes of `address.pack` output (21 for P2PKH and P2SH, 22 for P2WPKH, 34 for Taproot). Before the activation height the table is written and read exactly as before, including the exception a truncated one raises — which ends up in a recorded status, and so is itself consensus-visible.
+
+  MPMA was the last message type still on the legacy packing for a destination; enhanced sends and sweeps moved to `address.pack` with `taproot_support` in v11.0.0. (Dispenser oracle addresses remain on the legacy packing and are unchanged here.)
+
+  Taproot destinations cost more table space than the 20 byte kinds, because their witness program is 32 bytes rather than 20. A 500 destination Taproot table is 17,502 bytes, against 11,002 for the same number of P2PKH destinations. An MPMA composed with `encoding=taproot` carries that table in the witness, where it is discounted four to one.
 
 ## Incremental State DB rollback (#3485)
 


### PR DESCRIPTION
Closes #3208. Supersedes #3514, which carried a grouped table encoding — see **Why not the grouped table** below.

## Summary

An MPMA send can now pay a Taproot (or P2WSH) destination, gated behind a new `mpma_taproot_support` protocol change that activates with the other v11.4.0 changes.

The address lookup table packed every entry with `address.pack_legacy`, which emits a fixed 21 bytes — a one byte prefix plus a 20 byte hash or witness program. A Taproot witness program is 32 bytes, so it never fit; `_decode_decode_lut` matched with a hard-coded `bytes_per_address = 21`, and `compose_mpma` refused the destination up front with `Address not supported by MPMA send`.

Nothing new had to be designed. `taproot_support` (v11.0.0) already added a self-describing packing in `counterparty_rs` — `0x01`/`0x02` plus a hash, `0x03` plus a witness version and program — and enhanced sends (`enhancedsend.py:190`) and sweeps (`sweep.py:168`) have used it since. MPMA was the last message type still packing a destination the legacy way, left behind only because its table is a *list*, and a list of variable-length entries needs lengths. Each entry now carries a one byte length ahead of its packed address:

```
uint16 entry_count | (uint8 len | len bytes of counterparty_rs pack_address)*
```

The Rust side is untouched. Dispenser oracle addresses are the other `pack_legacy` caller and are deliberately left alone.

## Activation

| Network | Height |
| --- | ---: |
| Mainnet | 970,000 |
| Testnet3 | 5,166,000 |
| Testnet4 | 155,500 |
| Signet | 325,500 |

Same heights and minimum version (11.4.0) as `reject_non_finite_broadcast` and `reject_negative_fee_fraction`.

## Consensus safety

Below the activation height the table is written and read by the **original code path, textually identical to `develop`** — including the exception a truncated table raises. That matters more than it looks: `parse` records the exception in a status string, so even the error classification is consensus-visible for blocks already mined. An earlier revision let a new length check leak into that branch and turned `UnpackError("truncated data")` into `DecodeError`; the existing `test_unpack` caught it.

Pre-activation `messages_hash` is therefore unaffected on re-index. A before/after re-index of a mainnet snapshot comparing `messages_hash` per block below the activation height should show no difference; it has not been run against mainnet yet and belongs on the pre-activation checklist.

After activation the table is canonical: addresses are packed and unpacked with the Rust helpers directly. `address.unpack` falls back to the legacy decoding, which would accept other byte layouts of the same address (and arbitrary bytes as a base58 payload) behind a length byte; the new decoder refuses anything the Rust unpacker rejects with `DecodeError("invalid address: ...")`.

Two height boundaries are handled explicitly:

- **Mempool.** The mempool is parsed in a fake block at `MEMPOOL_BLOCK_INDEX` (9999999), above every activation height. `parse` decodes a pending transaction under the rules of the next block instead, so MPMA sends in the mempool are not read with the new table before activation.
- **Compose.** `compose` encodes under the next block's rules, so a send composed just below the activation height is not written with the legacy table and then parsed with the new one.

`/v2/transactions/unpack` now passes its `block_index` through to `mpma.unpack`, as it already did for every other message type. Without that the endpoint decoded a historical MPMA under the current rules and returned 503.

## Changes

- `mpmaencoding.py`: length-prefixed Rust-packed entries when `mpma_taproot_support` is active, strict Rust unpacking on decode; the legacy branch is unchanged. `block_index` threaded through the encode and decode paths.
- `mpma.py`: `unpack` takes `block_index`; `parse` passes the transaction's block index, or the next block's for a mempool transaction; `compose` encodes for the next block and applies the `> 22` guard only before activation.
- `api/compose.py`: `unpack` endpoint passes `block_index` to `mpma.unpack`.
- `protocol_changes.json`: `mpma_taproot_support`, minimum version 11.4.0, activation heights above.
- `release-notes-v11.4.0.md`: listed with the other protocol changes activating at 970,000.

## Tests

Unit tests run with `REGTEST` set, where `protocol.enabled()` answers True for every change regardless of block index — so every hard-coded MPMA vector in the suite silently became a post-activation assertion. The six tests built on pre-activation encodings now say which era they test, via the existing `ProtocolChangesDisabled` helper.

New coverage in `mpma_test.py`:

| test | what it pins |
|---|---|
| `test_compose_taproot_destination` | exact wire bytes for a Taproot + P2PKH table and an all-Taproot table |
| `test_compose_taproot_destination_before_activation` | the destination is still refused before activation, not encoded as something else |
| `test_lut_roundtrips_every_address_kind` | P2PKH, P2SH, P2WPKH, Taproot and **P2WSH** through the table — P2WSH was refused by the same `pack_legacy` branch |
| `test_lut_encoding_is_deterministic` | the table does not depend on the order destinations were given in |
| `test_decode_rejects_truncated_address_list` | a short table is refused rather than read out of whatever bytes follow |
| `test_decode_rejects_non_canonical_address` | a legacy-packed entry or arbitrary bytes behind a length byte are refused |
| `test_compose_encodes_for_next_block` | compose encodes under the next block's rules |
| `test_parse_mempool_decodes_for_next_block` | a mempool transaction is decoded under the next block's rules, not `MEMPOOL_BLOCK_INDEX` |

## Validation

| check | result |
|---|---|
| `counterpartycore/test/units` | 1750 passed — `develop` at the same commit: 1744, with the same 4 pre-existing failures and 31 errors |
| `mpma_test.py`, `compose_test.py`, `protocol_test.py`, `send_test.py`, `fuzz_parse_test.py`, `deserialize_test.py`, `blocks_test.py` (after the activation-height commit) | all passed |
| `test_fuzz_mpma_parse` (gate on, new decoder) | 5 seeds × 100 examples, no uncaught exception |
| `ruff check` / `ruff format` | clean |
| regtest chain (bitcoind + this branch in Docker) | MPMA paying two Taproot destinations and one legacy address: all three `MPMA_SEND` events `valid`, balances credited (1000 / 2000 / 3000 XCP), `/v2/transactions/<hash>` unpacks it back off the chain |

No regtest scenario step is included. `$EVENT_INDEX_n` in a scenario control resolves to the *n-th event of the current block*, so appending a transaction to the shared scenario chain moves positional expectations in scenarios that run after it (#3514 hit this in `scenario_20_fairminter`). A step is worth adding by someone who can re-derive that ordering.

## Why not the grouped table

#3514 grouped entries by address kind under a shared header — 8.5–13% smaller at 500+ destinations. Measured against this encoding, on a message sent once per airdrop, it was not worth what it cost:

- it **reorders the table** by kind, so the index every destination gets depends on a second ordering rule the encoder and decoder must share forever;
- the encoding is **not canonical** — the same set of addresses has many valid byte layouts;
- the decoder has **five failure branches instead of two**, each a distinct consensus-visible status;
- and it had a latent design flaw: P2WPKH and P2WSH share a witness-v0 prefix but differ in length, so a table mixing them fragmented into a header per run (50 + 50 → 49 groups) and lost the whole saving.

This encoding has exactly one byte layout per table, leaves the existing ordering alone, and is ~10 lines for a second implementation to port. The grouped branch remains at `feat/mpma-taproot-grouped` if the bytes ever matter; it could be layered on later behind its own gate.

## Pre-activation checklist

- [x] Set real activation heights in `protocol_changes.json` and the release notes
- [ ] Re-index a mainnet snapshot before/after; compare `messages_hash` per block below the activation height
- [ ] Add a regtest scenario step with the fixture ordering re-derived
- [ ] Wallets that decode MPMA (the XCP extension mirrors this table in `unpack/messages/mpma.ts`) ship the length-prefixed decoder gated on the same heights before block 970,000
